### PR TITLE
fix(macros): generate environment macros when using large installation tweaks

### DIFF
--- a/doc/release_notes/engine18.rst
+++ b/doc/release_notes/engine18.rst
@@ -6,6 +6,13 @@ Centreon Engine 1.8.1
 Bug fixes
 *********
 
+Generate environment macros when using large installation tweaks
+================================================================
+
+Environment macros were not generated when using large installation
+tweaks, in contradiction with the documentation. Only summary macros
+are not generated now.
+
 =====================
 Centreon Engine 1.8.0
 =====================

--- a/src/commands/raw.cc
+++ b/src/commands/raw.cc
@@ -1,5 +1,5 @@
 /*
-** Copyright 2011-2014 Merethis
+** Copyright 2011-2015,2017 Centreon
 **
 ** This file is part of Centreon Engine.
 **
@@ -553,9 +553,9 @@ void raw::_build_macrosx_environment(
     // Need to grab macros?
     if (!macros.x[i]) {
       // Skip summary macro in lage instalation tweaks.
-      if ((i < MACRO_TOTALHOSTSUP
-           || i > MACRO_TOTALSERVICEPROBLEMSUNHANDLED)
-          && !config->use_large_installation_tweaks()) {
+      if ((i < MACRO_TOTALHOSTSUP)
+          || (i > MACRO_TOTALSERVICEPROBLEMSUNHANDLED)
+          || !config->use_large_installation_tweaks()) {
         grab_macrox_value_r(
           &macros,
           i,


### PR DESCRIPTION
Unlike was the documentation told, environment macros were not properly generated and remained empty. This is now fixed and only summary macros are not generated when using large installation tweaks (as per documentation).