### PR TITLE
mistake at line 18, there was wrote engine.cfg

### DIFF
--- a/doc/exploit/running.rst
+++ b/doc/exploit/running.rst
@@ -15,7 +15,7 @@ errors.
 In order to verify your configuration, run Centreon Engine with the
 **-v** command line option like so::
 
-  $ /usr/sbin/centengine -v /etc/centreon-engine/engine.cfg
+  $ /usr/sbin/centengine -v /etc/centreon-engine/centengine.cfg
 
 If you've forgotten to enter some critical data or misconfigured things,
 Centreon Engine will spit out a warning or error message that should


### PR DESCRIPTION
It's not engine.cfg but centengine.cfg, moreover engine.cfg doesn't exist for me and i've got the last version of centreon in iso on a Virtualbix VM