### PR TITLE
fix(applier): std::string cannot be initialized from nullptr

### DIFF
--- a/src/configuration/applier/host.cc
+++ b/src/configuration/applier/host.cc
@@ -448,7 +448,7 @@ void applier::host::remove_object(
       obj.host_name(),
       "",
       (time_t)0,
-      nullptr);
+      "");
 
     // Remove events related to this host.
     applier::scheduler::instance().remove_host(obj);

--- a/src/configuration/applier/service.cc
+++ b/src/configuration/applier/service.cc
@@ -506,7 +506,7 @@ void applier::service::remove_object(
       host_name,
       service_description,
       (time_t)0,
-      NULL);
+      "");
 
     // Remove events related to this service.
     applier::scheduler::instance().remove_service(obj);


### PR DESCRIPTION
This patch is not suffisent but already solves ourselves from an exception during a reload.