### PR TITLE
fix(external_commands): Segfault fixed in host lookup.

### DIFF
--- a/modules/external_commands/src/commands.cc
+++ b/modules/external_commands/src/commands.cc
@@ -570,12 +570,13 @@ int process_passive_service_check(
     real_host_name = host_name;
   else {
     for (host_map::iterator
-           it(host::hosts.begin()),
+           itt(host::hosts.begin()),
            end(host::hosts.end());
-         it != end;
-         ++it) {
-      if (it->second->get_address() == host_name) {
-        real_host_name = it->first.c_str();
+         itt != end;
+         ++itt) {
+      if (itt->second->get_address() == host_name) {
+        real_host_name = itt->first.c_str();
+        it = itt;
         break ;
       }
     }
@@ -710,12 +711,13 @@ int process_passive_host_check(
     real_host_name = host_name;
   else {
     for (host_map::iterator
-           it(host::hosts.begin()),
+           itt(host::hosts.begin()),
            end(host::hosts.end());
-         it != end;
-         ++it) {
-      if (it->second->get_address() == host_name) {
-        real_host_name = it->first.c_str();
+         itt != end;
+         ++itt) {
+      if (itt->second->get_address() == host_name) {
+        real_host_name = itt->first.c_str();
+        it = itt;
         break;
       }
     }

--- a/modules/external_commands/src/commands.cc
+++ b/modules/external_commands/src/commands.cc
@@ -574,10 +574,10 @@ int process_passive_service_check(
            end(host::hosts.end());
          itt != end;
          ++itt) {
-      if (itt->second->get_address() == host_name) {
+      if (itt->second && itt->second->get_address() == host_name) {
         real_host_name = itt->first.c_str();
         it = itt;
-        break ;
+        break;
       }
     }
   }
@@ -715,7 +715,7 @@ int process_passive_host_check(
            end(host::hosts.end());
          itt != end;
          ++itt) {
-      if (itt->second->get_address() == host_name) {
+      if (itt->second && itt->second->get_address() == host_name) {
         real_host_name = itt->first.c_str();
         it = itt;
         break;

--- a/tests/external_commands/host.cc
+++ b/tests/external_commands/host.cc
@@ -82,6 +82,31 @@ TEST_F(HostExternalCommand, AddHostDowntime) {
   ASSERT_NE(out.find("HOST ALERT"), std::string::npos);
 }
 
+TEST_F(HostExternalCommand, AddHostDowntimeByIpAddress) {
+  configuration::applier::host hst_aply;
+  configuration::host hst;
+
+  ASSERT_TRUE(hst.parse("host_name", "test_srv"));
+  ASSERT_TRUE(hst.parse("address", "127.0.0.1"));
+  ASSERT_TRUE(hst.parse("_HOST_ID", "1"));
+  ASSERT_NO_THROW(hst_aply.add_object(hst));
+
+  set_time(20000);
+  time_t now = time(nullptr);
+
+  std::string cmd{"127.0.0.1;1;|"};
+
+  testing::internal::CaptureStdout();
+  cmd_process_host_check_result(
+    CMD_PROCESS_HOST_CHECK_RESULT, now, const_cast<char *>(cmd.c_str()));
+  checks::checker::instance().reap();
+
+  std::string const& out{testing::internal::GetCapturedStdout()};
+
+  ASSERT_NE(out.find("PASSIVE HOST CHECK"), std::string::npos);
+  ASSERT_NE(out.find("HOST ALERT"), std::string::npos);
+}
+
 TEST_F(HostExternalCommand, AddHostComment) {
   configuration::applier::host hst_aply;
   configuration::host hst;


### PR DESCRIPTION
When a host was specified in an external command from its ip,
the lookup could lead to a crash.