### PR TITLE
Add header changes to permit compile in clang/freebsd

### DIFF
--- a/src/broker.cc
+++ b/src/broker.cc
@@ -19,6 +19,7 @@
 ** <http://www.gnu.org/licenses/>.
 */
 
+#include <mutex>
 #include <memory>
 #include <unistd.h>
 #include "com/centreon/engine/broker.hh"

--- a/src/daterange.cc
+++ b/src/daterange.cc
@@ -17,6 +17,7 @@
 ** <http://www.gnu.org/licenses/>.
 */
 
+#include <array>
 #include <iomanip>
 #include "com/centreon/engine/common.hh"
 #include "com/centreon/engine/daterange.hh"

--- a/src/dependency.cc
+++ b/src/dependency.cc
@@ -17,6 +17,7 @@
 ** <http://www.gnu.org/licenses/>.
 */
 
+#include <array>
 #include "com/centreon/engine/dependency.hh"
 #include "com/centreon/engine/error.hh"
 #include "com/centreon/engine/logging/logger.hh"

--- a/src/hostdependency.cc
+++ b/src/hostdependency.cc
@@ -17,6 +17,7 @@
 ** <http://www.gnu.org/licenses/>.
 */
 
+#include <array>
 #include "com/centreon/engine/hostdependency.hh"
 #include "com/centreon/engine/broker.hh"
 #include "com/centreon/engine/configuration/applier/state.hh"

--- a/src/retention/host.cc
+++ b/src/retention/host.cc
@@ -17,6 +17,7 @@
 ** <http://www.gnu.org/licenses/>.
 */
 
+#include <array>
 #include "com/centreon/engine/common.hh"
 #include "com/centreon/engine/retention/host.hh"
 #include "com/centreon/engine/string.hh"

--- a/src/retention/object.cc
+++ b/src/retention/object.cc
@@ -17,7 +17,7 @@
 ** <http://www.gnu.org/licenses/>.
 */
 
-
+#include <array>
 #include "com/centreon/engine/retention/comment.hh"
 #include "com/centreon/engine/retention/contact.hh"
 #include "com/centreon/engine/retention/downtime.hh"

--- a/src/retention/parser.cc
+++ b/src/retention/parser.cc
@@ -17,6 +17,7 @@
 ** <http://www.gnu.org/licenses/>.
 */
 
+#include <array>
 #include <fstream>
 #include "com/centreon/engine/error.hh"
 #include "com/centreon/engine/retention/parser.hh"

--- a/src/retention/service.cc
+++ b/src/retention/service.cc
@@ -17,6 +17,7 @@
 ** <http://www.gnu.org/licenses/>.
 */
 
+#include <array>
 #include "com/centreon/engine/common.hh"
 #include "com/centreon/engine/retention/service.hh"
 #include "com/centreon/engine/string.hh"

--- a/src/retention/state.cc
+++ b/src/retention/state.cc
@@ -17,6 +17,7 @@
 ** <http://www.gnu.org/licenses/>.
 */
 
+#include <array>
 #include "com/centreon/engine/retention/state.hh"
 
 using namespace com::centreon::engine::retention;

--- a/src/timerange.cc
+++ b/src/timerange.cc
@@ -17,6 +17,7 @@
 ** <http://www.gnu.org/licenses/>.
 */
 
+#include <array>
 #include <iomanip>
 #include "com/centreon/engine/daterange.hh"
 #include "com/centreon/engine/error.hh"


### PR DESCRIPTION
To compile the code in a FreeBSD environment, creating a system compatible and clang compatible port, I needed to add these headers to some code.

with these changes, I have the engine successfully compiled on FreeBSD 12 and with clang

The output is:
```
# file centengine
centengine: ELF 64-bit LSB executable, x86-64, version 1 (FreeBSD), dynamically linked, interpreter /libexec/ld-elf.so.1, for FreeBSD 12.0 (1200086), FreeBSD-style,
with debug_info, not stripped

# clang --version
FreeBSD clang version 6.0.1 (tags/RELEASE_601/final 335540) (based on LLVM 6.0.1)
Target: x86_64-unknown-freebsd12.0
Thread model: posix
InstalledDir: /usr/bin
```

The lab with FreeBSD ports functional:
https://github.com/freebsd-centreon/ports/tree/master/centreon-engine