### PR TITLE
fix(downtime): Notification problem between two downtimes fixed.

### DIFF
--- a/doc/release_notes/engine19.04.rst
+++ b/doc/release_notes/engine19.04.rst
@@ -1,9 +1,16 @@
-=====================
-Centreon Engine 19.04
-=====================
+=======================
+Centreon Engine 19.04.2
+=======================
 
-Change version number according to new
-`Centreon Lifecycle Products Policy <https://documentation.centreon.com/docs/centreon/en/latest/life_cycle.html>`_
+*********
+Bug fixes
+*********
+
+Fixed downtimes and notifications
+=================================
+
+A device in downtime on contiguous fixed downtimes should not notify, even
+between those two downtimes.
 
 =======================
 Centreon Engine 19.04.1
@@ -19,3 +26,10 @@ Hosts and contacts custom macros are not inserted into centreon_storage db
 The custom macros added to the hosts and contacts objects are not inserted
 into centreon_storage database. That's why it is not possible to filter by
 criticity in "Monitoring > Status Details > Hosts" page.
+
+=====================
+Centreon Engine 19.04
+=====================
+
+Change version number according to new
+`Centreon Lifecycle Products Policy <https://documentation.centreon.com/docs/centreon/en/latest/life_cycle.html>`_

--- a/src/objects/downtime.cc
+++ b/src/objects/downtime.cc
@@ -735,7 +735,7 @@ int handle_scheduled_downtime(scheduled_downtime*  temp_downtime) {
       event_time
         = (time_t)((unsigned long)time(NULL) + temp_downtime->duration);
     else
-      event_time = temp_downtime->end_time;
+      event_time = temp_downtime->end_time + 1;
     new_downtime_id = new unsigned long;
     *new_downtime_id = temp_downtime->downtime_id;
     schedule_new_event(


### PR DESCRIPTION
Fix concerning to fixed downtimes one just after the other.
When the first one is stopped and just before the second to start, it was possible to receive notifications of devices in downtime.