### PR TITLE
fix(notifier): Double notification could fail

### DIFF
--- a/doc/release_notes/engine19.10.rst
+++ b/doc/release_notes/engine19.10.rst
@@ -12,6 +12,12 @@ Notifications and contiguous fixed downtimes
 Between two contiguous downtimes, it was possible to receive notifications
 of devices that were in critical state whereas they had to be in downtime.
 
+Second notification with state change
+=====================================
+
+When a notification has been sent for a warning state. If the device changes to
+a critical state, no notification was sent. This is fixed in this version.
+
 =======================
 Centreon Engine 19.10.7
 =======================

--- a/src/notifier.cc
+++ b/src/notifier.cc
@@ -36,28 +36,20 @@ using namespace com::centreon::engine;
 using namespace com::centreon::engine::logging;
 using namespace com::centreon::engine::configuration::applier;
 
-std::array<std::string, 9> const notifier::tab_notification_str{{
-    "NORMAL",
-    "RECOVERY",
-    "ACKNOWLEDGEMENT",
-    "FLAPPINGSTART",
-    "FLAPPINGSTOP",
-    "FLAPPINGDISABLED",
-    "DOWNTIMESTART",
-    "DOWNTIMEEND",
-    "DOWNTIMECANCELLED",
-}};
+std::array<std::string, 9> const notifier::tab_notification_str{
+    {"NORMAL",        "RECOVERY",     "ACKNOWLEDGEMENT",
+     "FLAPPINGSTART", "FLAPPINGSTOP", "FLAPPINGDISABLED",
+     "DOWNTIMESTART", "DOWNTIMEEND",  "DOWNTIMECANCELLED", }};
 
 std::array<std::string, 2> const notifier::tab_state_type{{"SOFT", "HARD"}};
 
-std::array<notifier::is_viable, 6> const notifier::_is_notification_viable{{
-    &notifier::_is_notification_viable_normal,
-    &notifier::_is_notification_viable_recovery,
-    &notifier::_is_notification_viable_acknowledgement,
-    &notifier::_is_notification_viable_flapping,
-    &notifier::_is_notification_viable_downtime,
-    &notifier::_is_notification_viable_custom,
-}};
+std::array<notifier::is_viable, 6> const notifier::_is_notification_viable{
+    {&notifier::_is_notification_viable_normal,
+     &notifier::_is_notification_viable_recovery,
+     &notifier::_is_notification_viable_acknowledgement,
+     &notifier::_is_notification_viable_flapping,
+     &notifier::_is_notification_viable_downtime,
+     &notifier::_is_notification_viable_custom, }};
 
 uint64_t notifier::_next_notification_id{1L};
 
@@ -93,28 +85,15 @@ notifier::notifier(notifier::notifier_type notifier_type,
                    std::string const& timezone,
                    bool retain_status_information,
                    bool retain_nonstatus_information)
-    : checkable{display_name,
-                check_command,
-                checks_enabled,
-                accept_passive_checks,
-                check_interval,
-                retry_interval,
-                max_attempts,
-                check_period,
-                event_handler,
-                event_handler_enabled,
-                notes,
-                notes_url,
-                action_url,
-                icon_image,
-                icon_image_alt,
-                flap_detection_enabled,
-                low_flap_threshold,
-                high_flap_threshold,
-                check_freshness,
-                freshness_threshold,
-                obsess_over,
-                timezone},
+    : checkable{
+          display_name,           check_command,       checks_enabled,
+          accept_passive_checks,  check_interval,      retry_interval,
+          max_attempts,           check_period,        event_handler,
+          event_handler_enabled,  notes,               notes_url,
+          action_url,             icon_image,          icon_image_alt,
+          flap_detection_enabled, low_flap_threshold,  high_flap_threshold,
+          check_freshness,        freshness_threshold, obsess_over,
+          timezone},
       _notifier_type{notifier_type},
       _stalk_type{stalk},
       _flap_type{0},
@@ -200,9 +179,9 @@ void notifier::set_notification_number(int num) {
   update_status(false);
 }
 
-bool notifier::_is_notification_viable_normal(
-    reason_type type __attribute__((unused)),
-    notification_option options) {
+bool notifier::_is_notification_viable_normal(reason_type type
+                                              __attribute__((unused)),
+                                              notification_option options) {
   logger(dbg_functions, basic) << "notifier::is_notification_viable_normal()";
 
   /* On volatile services notifications are always sent */
@@ -313,14 +292,10 @@ bool notifier::_is_notification_viable_normal(
      * and we notify as soon as we can */
     if (get_last_hard_state_change() <= _last_notification) {
 
-      uint32_t notification_interval;
-
-      if (!_notification[cat_normal]) {
-        notification_interval = _notification_interval;
-      }
-      else {
-        notification_interval = _notification[cat_normal]->get_notification_interval();
-      }
+      uint32_t notification_interval =
+          !_notification[cat_normal]
+              ? _notification_interval
+              : _notification[cat_normal]->get_notification_interval();
 
       if (notification_interval == 0) {
         logger(dbg_notifications, more)
@@ -329,10 +304,10 @@ bool notifier::_is_notification_viable_normal(
             << " so, since the notification interval is 0, it won't be sent"
             << " anymore";
         return false;
-      }
-      else if (notification_interval > 0) {
-        if (_last_notification + notification_interval * config->interval_length()
-            > now) {
+      } else if (notification_interval > 0) {
+        if (_last_notification +
+                notification_interval * config->interval_length() >
+            now) {
           logger(dbg_notifications, more)
               << "This notifier problem has been sent at " << _last_notification
               << " so it won't be sent until "
@@ -345,9 +320,10 @@ bool notifier::_is_notification_viable_normal(
   return true;
 }
 
-bool notifier::_is_notification_viable_recovery(
-    reason_type type __attribute__((unused)),
-    notification_option options __attribute__((unused))) {
+bool notifier::_is_notification_viable_recovery(reason_type type
+                                                __attribute__((unused)),
+                                                notification_option options
+                                                __attribute__((unused))) {
   logger(dbg_functions, basic) << "notifier::is_notification_viable_recovery()";
   bool retval{true};
   bool send_later{false};
@@ -365,8 +341,7 @@ bool notifier::_is_notification_viable_recovery(
         << "Notifications are temporarily disabled for "
            "this notifier, so we won't send one out.";
     retval = false;
-  }
-  else {
+  } else {
     timeperiod* tp{get_notification_timeperiod()};
     timezone_locker lock{get_timezone()};
     std::time_t now;
@@ -392,24 +367,23 @@ bool notifier::_is_notification_viable_recovery(
           << "This notifier is flapping, so we won't send notifications.";
       retval = false;
       send_later = true;
-    }
-    else if (get_state_type() != hard) {
+    } else if (get_state_type() != hard) {
       logger(dbg_notifications, more)
           << "This notifier is in soft state, so we won't send notifications.";
       retval = false;
       send_later = true;
     }
     /* Recovery is sent on state OK or UP */
-    else if (get_current_state_int() != 0 || !(get_notify_on(up) || get_notify_on(ok))) {
+    else if (get_current_state_int() != 0 ||
+             !(get_notify_on(up) || get_notify_on(ok))) {
       logger(dbg_notifications, more)
           << "This notifier state is not UP/OK are is not configured to send a "
              "recovery notification";
       retval = false;
       send_later = true;
-    }
-    else if (get_last_hard_state_change() +
-            _recovery_notification_delay * config->interval_length() >
-        now) {
+    } else if (get_last_hard_state_change() +
+                   _recovery_notification_delay * config->interval_length() >
+               now) {
       logger(dbg_notifications, more)
           << "This notifier is configured with a recovery notification delay. "
           << "It won't send any recovery notification until timestamp "
@@ -417,17 +391,15 @@ bool notifier::_is_notification_viable_recovery(
           << (get_last_hard_state_change() + _recovery_notification_delay);
       retval = false;
       send_later = true;
-    }
-    else if (_notification_number == 0) {
-      logger(dbg_notifications, more)
-          << "No notification has been sent to announce a problem. So no recovery"
-          << " notification will be sent";
+    } else if (_notification_number == 0) {
+      logger(dbg_notifications, more) << "No notification has been sent to "
+                                         "announce a problem. So no recovery"
+                                      << " notification will be sent";
       retval = false;
-    }
-    else if (!_notification[cat_normal]) {
-      logger(dbg_notifications, more)
-          << "We should not send a notification since no normal notification has"
-             " been sent before";
+    } else if (!_notification[cat_normal]) {
+      logger(dbg_notifications, more) << "We should not send a notification "
+                                         "since no normal notification has"
+                                         " been sent before";
       retval = false;
     }
   }
@@ -478,9 +450,8 @@ bool notifier::_is_notification_viable_acknowledgement(
   return true;
 }
 
-bool notifier::_is_notification_viable_flapping(
-    reason_type type,
-    notification_option options) {
+bool notifier::_is_notification_viable_flapping(reason_type type,
+                                                notification_option options) {
   logger(dbg_functions, basic) << "notifier::is_notification_viable_flapping()";
   /* forced notifications bust through everything */
   if (options & notification_option_forced) {
@@ -515,9 +486,9 @@ bool notifier::_is_notification_viable_flapping(
     f = flappingdisabled;
 
   if (!get_notify_on(f)) {
-    logger(dbg_notifications, more)
-        << "We shouldn't notify about " << tab_notification_str[type]
-        << " events for this notifier.";
+    logger(dbg_notifications, more) << "We shouldn't notify about "
+                                    << tab_notification_str[type]
+                                    << " events for this notifier.";
     return false;
   }
 
@@ -543,9 +514,9 @@ bool notifier::_is_notification_viable_flapping(
   /* Don't send a notification if the same has already been sent previously. */
   if (_notification[cat_flapping] &&
       _notification[cat_flapping]->get_reason() == type) {
-    logger(dbg_notifications, more)
-        << "We shouldn't notify about a " << tab_notification_str[type]
-        << " event: already sent.";
+    logger(dbg_notifications, more) << "We shouldn't notify about a "
+                                    << tab_notification_str[type]
+                                    << " event: already sent.";
     return false;
   }
 
@@ -558,9 +529,9 @@ bool notifier::_is_notification_viable_flapping(
   return true;
 }
 
-bool notifier::_is_notification_viable_downtime(
-    reason_type type __attribute__((unused)),
-    notification_option options) {
+bool notifier::_is_notification_viable_downtime(reason_type type
+                                                __attribute__((unused)),
+                                                notification_option options) {
   logger(dbg_functions, basic) << "notifier::is_notification_viable_downtime()";
 
   /* forced notifications bust through everything */
@@ -610,9 +581,9 @@ bool notifier::_is_notification_viable_downtime(
   return true;
 }
 
-bool notifier::_is_notification_viable_custom(
-    reason_type type __attribute__((unused)),
-    notification_option options) {
+bool notifier::_is_notification_viable_custom(reason_type type
+                                              __attribute__((unused)),
+                                              notification_option options) {
   logger(dbg_functions, basic) << "notifier::is_notification_viable_custom()";
   /* forced notifications bust through everything */
   if (options & notification_option_forced) {
@@ -655,17 +626,16 @@ std::unordered_set<contact*> notifier::get_contacts_to_notify(
   uint32_t notif_interv{_notification_interval};
 
   /* Let's start looking at escalations */
-  for (std::list<escalation*>::const_iterator
-           it{_escalations.begin()},
+  for (std::list<escalation*>::const_iterator it{_escalations.begin()},
        end{_escalations.end()};
-       it != end; ++it) {
+       it != end;
+       ++it) {
     if ((*it)->is_viable(get_current_state_int(), _notification_number)) {
       /* Among escalations, we choose the smallest notification interval. */
       if (escalated) {
         if ((*it)->get_notification_interval() < notif_interv)
           notif_interv = (*it)->get_notification_interval();
-      }
-      else {
+      } else {
         /* Here is the first escalation, so we take its notification_interval.
          */
         escalated = true;
@@ -676,11 +646,13 @@ std::unordered_set<contact*> notifier::get_contacts_to_notify(
       for (contactgroup_map_unsafe::const_iterator
                cgit{(*it)->get_contactgroups().begin()},
            cgend{(*it)->get_contactgroups().end()};
-           cgit != cgend; ++cgit) {
+           cgit != cgend;
+           ++cgit) {
         for (contact_map_unsafe::const_iterator
                  cit{cgit->second->get_members().begin()},
              cend{cgit->second->get_members().end()};
-             cit != cend; ++cit) {
+             cit != cend;
+             ++cit) {
           assert(cit->second);
           if (cit->second->should_be_notified(cat, type, *this))
             retval.insert(cit->second);
@@ -694,7 +666,8 @@ std::unordered_set<contact*> notifier::get_contacts_to_notify(
      * for the moment if those contacts accept notification. */
     for (contact_map_unsafe::const_iterator it{get_contacts().begin()},
          end{get_contacts().end()};
-         it != end; ++it) {
+         it != end;
+         ++it) {
       assert(it->second);
       retval.insert(it->second);
     }
@@ -703,11 +676,13 @@ std::unordered_set<contact*> notifier::get_contacts_to_notify(
     for (contactgroup_map_unsafe::const_iterator
              it{get_contactgroups().begin()},
          end{get_contactgroups().end()};
-         it != end; ++it) {
+         it != end;
+         ++it) {
       for (contact_map_unsafe::const_iterator
                cit{it->second->get_members().begin()},
            cend{it->second->get_members().end()};
-           cit != cend; ++cit) {
+           cit != cend;
+           ++cit) {
         assert(cit->second);
         retval.insert(cit->second);
       }
@@ -756,9 +731,14 @@ int notifier::notify(notifier::reason_type type,
       get_contacts_to_notify(cat, type, notification_interval)};
 
   _current_notification_id = _next_notification_id++;
-  std::shared_ptr<notification> notif{new notification(
-      this, type, not_author, not_data, options, _current_notification_id,
-      _notification_number, notification_interval)};
+  std::shared_ptr<notification> notif{new notification(this,
+                                                       type,
+                                                       not_author,
+                                                       not_data,
+                                                       options,
+                                                       _current_notification_id,
+                                                       _notification_number,
+                                                       notification_interval)};
 
   /* Let's make the notification. */
   int retval{notif->execute(to_notify)};
@@ -937,9 +917,7 @@ void notifier::add_modified_attributes(uint32_t attr) {
   _modified_attributes |= attr;
 }
 
-std::list<escalation*>& notifier::get_escalations() {
-  return _escalations;
-}
+std::list<escalation*>& notifier::get_escalations() { return _escalations; }
 
 std::list<escalation*> const& notifier::get_escalations() const {
   return _escalations;
@@ -953,13 +931,9 @@ void notifier::set_flapping_comment_id(uint64_t comment_id) {
   _flapping_comment_id = comment_id;
 }
 
-int notifier::get_check_options(void) const {
-  return _check_options;
-}
+int notifier::get_check_options(void) const { return _check_options; }
 
-void notifier::set_check_options(int option) {
-  _check_options = option;
-}
+void notifier::set_check_options(int option) { _check_options = option; }
 
 int notifier::get_acknowledgement_type(void) const {
   return _acknowledgement_type;
@@ -981,7 +955,8 @@ bool notifier::get_retain_nonstatus_information(void) const {
   return _retain_nonstatus_information;
 }
 
-void notifier::set_retain_nonstatus_information(bool retain_non_status_informations) {
+void notifier::set_retain_nonstatus_information(
+    bool retain_non_status_informations) {
   _retain_nonstatus_information = retain_non_status_informations;
 }
 
@@ -1010,9 +985,7 @@ void notifier::set_no_more_notifications(bool no_more_notifications) {
   _no_more_notifications = no_more_notifications;
 }
 
-int notifier::get_notification_number() const {
-  return _notification_number;
-}
+int notifier::get_notification_number() const { return _notification_number; }
 
 /**
  *  Get the next notification id.
@@ -1031,7 +1004,8 @@ std::unordered_map<std::string, contact*>& notifier::get_contacts() {
   return _contacts;
 }
 
-std::unordered_map<std::string, contact*> const& notifier::get_contacts() const {
+std::unordered_map<std::string, contact*> const& notifier::get_contacts()
+    const {
   return _contacts;
 }
 
@@ -1059,14 +1033,16 @@ bool is_contact_for_notifier(com::centreon::engine::notifier* notif,
   // Search all individual contacts of this host.
   for (contact_map_unsafe::const_iterator it{notif->get_contacts().begin()},
        end{notif->get_contacts().end()};
-       it != end; ++it)
+       it != end;
+       ++it)
     if (it->second == cntct)
       return true;
 
   for (contactgroup_map_unsafe::const_iterator
            it{notif->get_contactgroups().begin()},
        end{notif->get_contactgroups().end()};
-       it != end; ++it) {
+       it != end;
+       ++it) {
     assert(it->second);
     if (it->second->get_members().find(cntct->get_name()) ==
         it->second->get_members().end())
@@ -1152,7 +1128,8 @@ void notifier::resolve(int& w, int& e) {
   /* check all contacts */
   for (contact_map_unsafe::iterator it{get_contacts().begin()},
        end{get_contacts().end()};
-       it != end; ++it) {
+       it != end;
+       ++it) {
     contact_map::const_iterator found_it{contact::contacts.find(it->first)};
     if (found_it == contact::contacts.end() || !found_it->second.get()) {
       logger(log_verification_error, basic)
@@ -1167,7 +1144,8 @@ void notifier::resolve(int& w, int& e) {
   /* check all contact groups */
   for (contactgroup_map_unsafe::iterator it{get_contactgroups().begin()},
        end{get_contactgroups().end()};
-       it != end; ++it) {
+       it != end;
+       ++it) {
     // Find the contact group.
     contactgroup_map::const_iterator found_it{
         contactgroup::contactgroups.find(it->first)};
@@ -1212,7 +1190,8 @@ void notifier::resolve(int& w, int& e) {
                          << "'";
 }
 
-std::array<int, MAX_STATE_HISTORY_ENTRIES> const& notifier::get_state_history() const {
+std::array<int, MAX_STATE_HISTORY_ENTRIES> const& notifier::get_state_history()
+    const {
   return _state_history;
 }
 
@@ -1298,8 +1277,7 @@ time_t notifier::get_next_notification_time(time_t offset) {
     set_no_more_notifications(false);
 
   logger(dbg_notifications, most) << "Interval used for calculating next valid "
-                                     "notification time: "
-                                  << interval_to_use;
+                                     "notification time: " << interval_to_use;
 
   /* calculate next notification time */
   time_t next_notification{
@@ -1309,9 +1287,7 @@ time_t notifier::get_next_notification_time(time_t offset) {
   return next_notification;
 }
 
-void notifier::set_flap_type(uint32_t type) {
-  _flap_type = type;
-}
+void notifier::set_flap_type(uint32_t type) { _flap_type = type; }
 
 timeperiod* notifier::get_notification_period_ptr() const {
   return _notification_period_ptr;
@@ -1452,7 +1428,6 @@ void notifier::set_notification(int32_t idx, std::string const& value) {
   }
 
   std::shared_ptr<notification> notif{std::make_shared<notification>(
-      this, type, author, "", options, id,
-      number, interval, escalated)};
+      this, type, author, "", options, id, number, interval, escalated)};
   _notification[idx] = notif;
 }

--- a/src/notifier.cc
+++ b/src/notifier.cc
@@ -201,7 +201,7 @@ void notifier::set_notification_number(int num) {
 }
 
 bool notifier::_is_notification_viable_normal(
-    reason_type type,
+    reason_type type __attribute__((unused)),
     notification_option options) {
   logger(dbg_functions, basic) << "notifier::is_notification_viable_normal()";
 

--- a/tests/notifications/service_normal_notification.cc
+++ b/tests/notifications/service_normal_notification.cc
@@ -1059,3 +1059,42 @@ TEST_F(ServiceNotification, NoServiceNotificationWhenHostDown) {
       "admin;test_host;test_svc;CRITICAL;cmd;service down")};
   ASSERT_EQ(step, std::string::npos);
 }
+
+TEST_F(ServiceNotification, WarnCritServiceNotification) {
+  /* We are using a local time() function defined in tests/timeperiod/utils.cc.
+   * If we call time(), it is not the glibc time() function that will be called.
+   */
+  ASSERT_EQ(_host->services.size(), 1u);
+  set_time(43200);
+  std::unique_ptr<engine::timeperiod> tperiod{
+      new engine::timeperiod("tperiod", "alias")};
+  for (int i = 0; i < 7; ++i)
+    tperiod->days[i].push_back(std::make_shared<engine::timerange>(0, 86400));
+
+  std::unique_ptr<engine::serviceescalation> service_escalation{
+      new engine::serviceescalation(
+          "test_host", "test_svc", 0, 1, 1.0, "tperiod", 7, Uuid())};
+  _svc->set_current_state(engine::service::state_critical);
+  _svc->set_last_state(engine::service::state_critical);
+  _svc->set_last_hard_state_change(43200);
+  _svc->set_state_type(checkable::hard);
+
+  ASSERT_TRUE(service_escalation);
+  uint64_t id{_svc->get_next_notification_id()};
+  _svc->set_notification_period_ptr(tperiod.get());
+  ASSERT_EQ(
+      _svc->notify(
+          notifier::reason_normal, "", "", notifier::notification_option_none),
+      OK);
+
+  _svc->set_current_state(engine::service::state_warning);
+  _svc->set_last_state(engine::service::state_warning);
+  _svc->set_last_hard_state_change(43500);
+  _svc->set_state_type(checkable::hard);
+
+  ASSERT_EQ(
+      _svc->notify(
+          notifier::reason_normal, "", "", notifier::notification_option_none),
+      OK);
+  ASSERT_EQ(id + 2, _svc->get_next_notification_id());
+}


### PR DESCRIPTION
Here is a fix on normal notifications.
A device is in warning hard => notification
The device changes to critical hard => notification (that was not the case)
The device changes again to warning hard => notification (that was not the case)
That should fix #294 