### PR TITLE
Mon 4554 first notif delay no recovery

### DIFF
--- a/doc/release_notes/engine19.10.rst
+++ b/doc/release_notes/engine19.10.rst
@@ -18,6 +18,12 @@ Second notification with state change
 When a notification has been sent for a warning state. If the device changes to
 a critical state, no notification was sent. This is fixed in this version.
 
+First notification delay if no recovery notification configured
+===============================================================
+
+When a first notification delay but no recovery notification are configured,
+the first notification delay is not applied. This is fixed in this release.
+
 =======================
 Centreon Engine 19.10.7
 =======================

--- a/src/notifier.cc
+++ b/src/notifier.cc
@@ -721,8 +721,15 @@ int notifier::notify(notifier::reason_type type,
   notification_category cat{get_category(type)};
 
   /* Has this notification got sense? */
-  if (!is_notification_viable(cat, type, options))
+  if (!is_notification_viable(cat, type, options)) {
+    /* In case of a recovery, we have to remove the normal notification if is
+     * has been sent. */
+    if (_notification[cat_normal] && type == reason_recovery) {
+      _notification_number = 0;
+      _notification[cat_normal].reset();
+    }
     return OK;
+  }
 
   /* For a first notification, we store what type of notification we try to
    * send and we fix the notification number to 1. */


### PR DESCRIPTION
When a service is configured with a first delay notification but without recovery notification, the first delay notification does not work as expected.
