### PR TITLE
fix(downtime): Regression on downtime fixed.

### DIFF
--- a/src/objects/downtime.cc
+++ b/src/objects/downtime.cc
@@ -735,7 +735,8 @@ int handle_scheduled_downtime(scheduled_downtime*  temp_downtime) {
       event_time
         = (time_t)((unsigned long)time(NULL) + temp_downtime->duration);
     else
-      event_time = temp_downtime->end_time + 1;
+      event_time = temp_downtime->end_time + 1 > 0 ? temp_downtime->end_time + 1
+                                                   : temp_downtime->end_time;
     new_downtime_id = new unsigned long;
     *new_downtime_id = temp_downtime->downtime_id;
     schedule_new_event(


### PR DESCRIPTION
# Pull Request Template

## Description

If end_time == LongLong::max() then end_time + 1 < 0 which is the bug.
This case appears when a downtime is sent from broker on a BA.

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 18.10.x
- [X] 19.04.x
- [X] 19.10.x
- [X] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

You can program a downtime with an end_time == LongLong::max()
such this one : SCHEDULE_SVC_DOWNTIME;_Module_BAM_1;ba_1;1575373885;9223372036854775807;1;0;0;Centreon Broker BAM
You may notice the value of the end_time that is very big!

Otherwise, run the TA, if they pass, it is good!
