### PR TITLE
Fix notification volatile 20.04

### DIFF
--- a/doc/release_notes/engine19.10.rst
+++ b/doc/release_notes/engine19.10.rst
@@ -1,4 +1,18 @@
 =======================
+Centreon Engine 19.10.9
+=======================
+
+*********
+Bug fixes
+*********
+
+Notifications on volatile services
+==================================
+
+On a volatile service, if notifications are disabled, it should not send
+notifications.
+
+=======================
 Centreon Engine 19.10.8
 =======================
 

--- a/src/notifier.cc
+++ b/src/notifier.cc
@@ -188,13 +188,6 @@ bool notifier::_is_notification_viable_normal(reason_type type
                                               notification_option options) {
   logger(dbg_functions, basic) << "notifier::is_notification_viable_normal()";
 
-  /* On volatile services notifications are always sent */
-  if (get_is_volatile()) {
-    logger(dbg_notifications, more)
-        << "This is a volatile service notification, so it is sent.";
-    return true;
-  }
-
   /* forced notifications bust through everything */
   if (options & notification_option_forced) {
     logger(dbg_notifications, more)
@@ -216,6 +209,13 @@ bool notifier::_is_notification_viable_normal(reason_type type
         << "Notifications are temporarily disabled for "
            "this notifier, so we won't send one out.";
     return false;
+  }
+
+  /* On volatile services notifications are always sent */
+  if (get_is_volatile()) {
+    logger(dbg_notifications, more)
+        << "This is a volatile service notification, so it is sent.";
+    return true;
   }
 
   timeperiod* tp{get_notification_timeperiod()};


### PR DESCRIPTION
# Pull Request Template

## Description

Configure a volatile passive service with notifications sent to a user.
When the service is set to the critical state, it notifies.
When the service is set to the warning state, it notifies.

Now disable notifications on this service.
When the service is set to the critical state, it should **not** notify. This patch fixes this point.
## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 18.10.x
- [ ] 19.04.x
- [X] 19.10.x
- [X] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

The *procedure* is given in the description.
