### PR TITLE
fix(notifier): Recovery are sent even if service is acknowledged.

### DIFF
--- a/doc/release_notes/engine19.10.rst
+++ b/doc/release_notes/engine19.10.rst
@@ -12,6 +12,12 @@ Notifications on volatile services
 On a volatile service, if notifications are disabled, it should not send
 notifications.
 
+Recovery notifications must be sent even after an acknowledgement
+=================================================================
+
+With the new notifications implementation, this behaviour had been changed.
+This new version reset this functionality as users expect it to work.
+
 =======================
 Centreon Engine 19.10.8
 =======================

--- a/inc/com/centreon/engine/notifier.hh
+++ b/inc/com/centreon/engine/notifier.hh
@@ -136,37 +136,37 @@ class notifier : public checkable {
 
   void set_notification(int32_t idx, std::string const& value);
 
-  bool get_notify_on(notification_flag type) const;
-  uint32_t get_notify_on() const;
-  void set_notify_on(uint32_t type);
-  void add_notify_on(notification_flag type);
-  void remove_notify_on(notification_flag type);
+  bool get_notify_on(notification_flag type) const noexcept;
+  uint32_t get_notify_on() const noexcept;
+  void set_notify_on(uint32_t type) noexcept;
+  void add_notify_on(notification_flag type) noexcept;
+  void remove_notify_on(notification_flag type) noexcept;
   virtual bool get_notify_on_current_state() const = 0;
 
-  bool get_notified_on(notification_flag type) const;
-  uint32_t get_notified_on() const;
-  void set_notified_on(uint32_t type);
-  void add_notified_on(notification_flag type);
-  void remove_notified_on(notification_flag type);
+  bool get_notified_on(notification_flag type) const noexcept;
+  uint32_t get_notified_on() const noexcept;
+  void set_notified_on(uint32_t type) noexcept;
+  void add_notified_on(notification_flag type) noexcept;
+  void remove_notified_on(notification_flag type) noexcept;
 
-  bool get_stalk_on(notification_flag type) const;
-  uint32_t get_stalk_on() const;
-  void set_stalk_on(uint32_t type);
-  void add_stalk_on(notification_flag type);
+  bool get_stalk_on(notification_flag type) const noexcept;
+  uint32_t get_stalk_on() const noexcept;
+  void set_stalk_on(uint32_t type) noexcept;
+  void add_stalk_on(notification_flag type) noexcept;
 
-  bool get_flap_detection_on(notification_flag type) const;
-  uint32_t get_flap_detection_on() const;
-  void set_flap_detection_on(uint32_t type);
-  void add_flap_detection_on(notification_flag type);
+  bool get_flap_detection_on(notification_flag type) const noexcept;
+  uint32_t get_flap_detection_on() const noexcept;
+  void set_flap_detection_on(uint32_t type) noexcept;
+  void add_flap_detection_on(notification_flag type) noexcept;
 
   unsigned long get_current_event_id() const;
-  void set_current_event_id(unsigned long current_event_id);
-  unsigned long get_last_event_id() const;
-  void set_last_event_id(unsigned long last_event_id);
-  unsigned long get_current_problem_id() const;
-  void set_current_problem_id(unsigned long current_problem_id);
-  unsigned long get_last_problem_id() const;
-  void set_last_problem_id(unsigned long last_problem_id);
+  void set_current_event_id(unsigned long current_event_id) noexcept;
+  unsigned long get_last_event_id() const noexcept;
+  void set_last_event_id(unsigned long last_event_id) noexcept;
+  unsigned long get_current_problem_id() const noexcept;
+  void set_current_problem_id(unsigned long current_problem_id) noexcept;
+  unsigned long get_last_problem_id() const noexcept;
+  void set_last_problem_id(unsigned long last_problem_id) noexcept;
 
   virtual void update_status(bool aggregated_dump) = 0;
   int notify(reason_type type,
@@ -174,8 +174,8 @@ class notifier : public checkable {
              std::string const& not_data,
              notification_option options);
 
-  void set_current_notification_id(uint64_t id);
-  uint64_t get_current_notification_id() const;
+  void set_current_notification_id(uint64_t id) noexcept;
+  uint64_t get_current_notification_id() const noexcept;
   virtual void grab_macros_r(nagios_macros* mac) = 0;
   virtual int notify_contact(nagios_macros* mac,
                              contact* cntct,
@@ -184,60 +184,60 @@ class notifier : public checkable {
                              std::string const& not_data,
                              int options,
                              int escalated) = 0;
-  time_t get_next_notification() const;
-  void set_next_notification(time_t next_notification);
-  time_t get_last_notification() const;
-  void set_last_notification(time_t last_notification);
+  time_t get_next_notification() const noexcept;
+  void set_next_notification(time_t next_notification) noexcept;
+  time_t get_last_notification() const noexcept;
+  void set_last_notification(time_t last_notification) noexcept;
   virtual void update_notification_flags() = 0;
   time_t get_next_notification_time(time_t offset);
-  void set_initial_notif_time(time_t notif_time);
-  time_t get_initial_notif_time() const;
-  void set_acknowledgement_timeout(int timeout);
-  void set_last_acknowledgement(time_t ack);
-  time_t get_last_acknowledgement() const;
-  uint32_t get_notification_interval(void) const;
-  void set_notification_interval(uint32_t notification_interval);
-  std::string const& get_notification_period() const;
-  void set_notification_period(std::string const& notification_period);
+  void set_initial_notif_time(time_t notif_time) noexcept;
+  time_t get_initial_notif_time() const noexcept;
+  void set_acknowledgement_timeout(int timeout) noexcept;
+  void set_last_acknowledgement(time_t ack) noexcept;
+  time_t get_last_acknowledgement() const noexcept;
+  uint32_t get_notification_interval(void) const noexcept;
+  void set_notification_interval(uint32_t notification_interval) noexcept;
+  std::string const& get_notification_period() const noexcept;
+  void set_notification_period(std::string const& notification_period) noexcept;
 
-  uint32_t get_first_notification_delay(void) const;
-  void set_first_notification_delay(uint32_t notification_delay);
-  uint32_t get_recovery_notification_delay(void) const;
-  void set_recovery_notification_delay(uint32_t notification_delay);
-  bool get_notifications_enabled() const;
-  void set_notifications_enabled(bool notifications_enabled);
-  uint64_t get_flapping_comment_id(void) const;
-  void set_flapping_comment_id(uint64_t comment_id);
-  int get_check_options(void) const;
-  void set_check_options(int option);
-  int get_acknowledgement_type(void) const;
-  void set_acknowledgement_type(int acknowledge_type);
-  int get_retain_status_information(void) const;
-  void set_retain_status_information(bool retain_status_informations);
-  bool get_retain_nonstatus_information(void) const;
-  void set_retain_nonstatus_information(bool retain_non_status_informations);
-  bool get_is_being_freshened(void) const;
-  void set_is_being_freshened(bool freshened);
-  std::list<escalation*>& get_escalations();
-  std::list<escalation*> const& get_escalations() const;
+  uint32_t get_first_notification_delay(void) const noexcept;
+  void set_first_notification_delay(uint32_t notification_delay) noexcept;
+  uint32_t get_recovery_notification_delay(void) const noexcept;
+  void set_recovery_notification_delay(uint32_t notification_delay) noexcept;
+  bool get_notifications_enabled() const noexcept;
+  void set_notifications_enabled(bool notifications_enabled) noexcept;
+  uint64_t get_flapping_comment_id(void) const noexcept;
+  void set_flapping_comment_id(uint64_t comment_id) noexcept;
+  int get_check_options(void) const noexcept;
+  void set_check_options(int option) noexcept;
+  int get_acknowledgement_type(void) const noexcept;
+  void set_acknowledgement_type(int acknowledge_type) noexcept;
+  int get_retain_status_information(void) const noexcept;
+  void set_retain_status_information(bool retain_status_informations) noexcept;
+  bool get_retain_nonstatus_information(void) const noexcept;
+  void set_retain_nonstatus_information(bool retain_non_status_informations) noexcept;
+  bool get_is_being_freshened(void) const noexcept;
+  void set_is_being_freshened(bool freshened) noexcept;
+  std::list<escalation*>& get_escalations() noexcept;
+  std::list<escalation*> const& get_escalations() const noexcept;
   virtual bool is_valid_escalation_for_notification(escalation const* e,
                                                     int options) const = 0;
-  void add_modified_attributes(uint32_t attr);
-  uint32_t get_modified_attributes() const;
-  void set_modified_attributes(uint32_t modified_attributes);
-  bool get_problem_has_been_acknowledged() const;
-  void set_problem_has_been_acknowledged(bool problem_has_been_acknowledged);
+  void add_modified_attributes(uint32_t attr) noexcept;
+  uint32_t get_modified_attributes() const noexcept;
+  void set_modified_attributes(uint32_t modified_attributes) noexcept;
+  bool get_problem_has_been_acknowledged() const noexcept;
+  void set_problem_has_been_acknowledged(bool problem_has_been_acknowledged) noexcept;
   virtual bool recovered() const = 0;
   virtual int get_current_state_int() const = 0;
-  bool get_no_more_notifications() const;
-  void set_no_more_notifications(bool no_more_notifications);
+  bool get_no_more_notifications() const noexcept;
+  void set_no_more_notifications(bool no_more_notifications) noexcept;
   bool notifications_available(int options) const;
-  int get_notification_number() const;
+  int get_notification_number() const noexcept;
   void set_notification_number(int number);
 
   virtual bool authorized_by_dependencies(
       dependency::types dependency_type) const = 0;
-  uint64_t get_next_notification_id() const;
+  uint64_t get_next_notification_id() const noexcept;
   virtual timeperiod* get_notification_timeperiod() const = 0;
   notification_category get_category(reason_type type) const;
   bool is_notification_viable(notification_category cat,
@@ -247,11 +247,11 @@ class notifier : public checkable {
       notification_category cat,
       reason_type type,
       uint32_t& notification_interval);
-  notifier_type get_notifier_type() const;
-  std::unordered_map<std::string, contact*>& get_contacts();
-  std::unordered_map<std::string, contact*> const& get_contacts() const;
-  contactgroup_map_unsafe& get_contactgroups();
-  contactgroup_map_unsafe const& get_contactgroups() const;
+  notifier_type get_notifier_type() const noexcept;
+  std::unordered_map<std::string, contact*>& get_contacts() noexcept;
+  std::unordered_map<std::string, contact*> const& get_contacts() const noexcept;
+  contactgroup_map_unsafe& get_contactgroups() noexcept;
+  contactgroup_map_unsafe const& get_contactgroups() const noexcept;
   void resolve(int& w, int& e);
   std::array<int, MAX_STATE_HISTORY_ENTRIES> const& get_state_history() const;
   std::array<int, MAX_STATE_HISTORY_ENTRIES>& get_state_history();
@@ -261,10 +261,10 @@ class notifier : public checkable {
   void inc_pending_flex_downtime() noexcept;
   void dec_pending_flex_downtime() noexcept;
   virtual bool get_is_volatile() const = 0;
-  void set_flap_type(uint32_t type);
-  timeperiod* get_notification_period_ptr() const;
-  void set_notification_period_ptr(timeperiod* tp);
-  int get_acknowledgement_timeout() const;
+  void set_flap_type(uint32_t type) noexcept;
+  timeperiod* get_notification_period_ptr() const noexcept;
+  void set_notification_period_ptr(timeperiod* tp) noexcept;
+  int get_acknowledgement_timeout() const noexcept;
 
   map_customvar custom_variables;
 

--- a/inc/com/centreon/engine/retention/host.hh
+++ b/inc/com/centreon/engine/retention/host.hh
@@ -165,10 +165,10 @@ class host : public object {
   bool _set_percent_state_change(double value);
   bool _set_performance_data(std::string const& value);
   bool _set_plugin_output(std::string const& value);
-  bool _set_problem_has_been_acknowledged(bool value);
-  bool _set_process_performance_data(int value);
-  bool _set_retry_check_interval(unsigned int value);
-  bool _set_state_history(std::string const& value);
+  bool _set_problem_has_been_acknowledged(bool value) noexcept;
+  bool _set_process_performance_data(int value) noexcept;
+  bool _set_retry_check_interval(unsigned int value) noexcept;
+  bool _set_state_history(std::string const& value) noexcept;
   bool _set_state_type(int value);
 
   opt<int> _acknowledgement_type;

--- a/src/notifier.cc
+++ b/src/notifier.cc
@@ -142,31 +142,32 @@ unsigned long notifier::get_current_event_id() const {
   return _current_event_id;
 }
 
-void notifier::set_current_event_id(unsigned long current_event_id) {
+void notifier::set_current_event_id(unsigned long current_event_id) noexcept {
   _current_event_id = current_event_id;
 }
 
-unsigned long notifier::get_last_event_id() const {
+unsigned long notifier::get_last_event_id() const noexcept {
   return _last_event_id;
 }
 
-void notifier::set_last_event_id(unsigned long last_event_id) {
+void notifier::set_last_event_id(unsigned long last_event_id) noexcept {
   _last_event_id = last_event_id;
 }
 
-unsigned long notifier::get_current_problem_id() const {
+unsigned long notifier::get_current_problem_id() const noexcept {
   return _current_notification_id;
 }
 
-void notifier::set_current_problem_id(unsigned long current_problem_id) {
+void notifier::set_current_problem_id(
+    unsigned long current_problem_id) noexcept {
   _current_problem_id = current_problem_id;
 }
 
-unsigned long notifier::get_last_problem_id() const {
+unsigned long notifier::get_last_problem_id() const noexcept {
   return _last_problem_id;
 }
 
-void notifier::set_last_problem_id(unsigned long last_problem_id) {
+void notifier::set_last_problem_id(unsigned long last_problem_id) noexcept {
   _last_problem_id = last_problem_id;
 }
 
@@ -726,7 +727,7 @@ int notifier::notify(notifier::reason_type type,
      * has been sent. */
     if (_notification[cat_normal] &&          // there is a notification
         type == reason_recovery &&            // It is time to recovery
-        _recovery_notification_delay == 0) {   // And there is no recovery delay
+        _recovery_notification_delay == 0) {  // And there is no recovery delay
       _notification_number = 0;
       _notification[cat_normal].reset();
     }
@@ -778,279 +779,286 @@ int notifier::notify(notifier::reason_type type,
         default:
           _notification[cat].reset();
       }
-      _notification_number = 0;
+      /* In case of an acknowledgement, we must keep the _notification_number
+       * otherwise the recovery notification won't be sent when needed. */
+      if (cat != cat_acknowledgement)
+        _notification_number = 0;
     }
   }
 
   return retval;
 }
 
-void notifier::set_current_notification_id(uint64_t id) {
+void notifier::set_current_notification_id(uint64_t id) noexcept {
   _current_notification_id = id;
 }
 
-uint64_t notifier::get_current_notification_id() const {
+uint64_t notifier::get_current_notification_id() const noexcept {
   return _current_notification_id;
 }
 
-time_t notifier::get_next_notification() const {
+time_t notifier::get_next_notification() const noexcept {
   return _next_notification;
 }
 
-void notifier::set_next_notification(time_t next_notification) {
+void notifier::set_next_notification(time_t next_notification) noexcept {
   _next_notification = next_notification;
 }
 
-time_t notifier::get_last_notification() const {
+time_t notifier::get_last_notification() const noexcept {
   return _last_notification;
 }
 
-void notifier::set_last_notification(time_t last_notification) {
+void notifier::set_last_notification(time_t last_notification) noexcept {
   _last_notification = last_notification;
 }
 
-void notifier::set_initial_notif_time(time_t notif_time) {
+void notifier::set_initial_notif_time(time_t notif_time) noexcept {
   _initial_notif_time = notif_time;
 }
 
-time_t notifier::get_initial_notif_time() const {
+time_t notifier::get_initial_notif_time() const noexcept {
   return _initial_notif_time;
 }
 
-void notifier::set_acknowledgement_timeout(int timeout) {
+void notifier::set_acknowledgement_timeout(int timeout) noexcept {
   _acknowledgement_timeout = timeout;
 }
 
-void notifier::set_last_acknowledgement(time_t ack) {
+void notifier::set_last_acknowledgement(time_t ack) noexcept {
   _last_acknowledgement = ack;
 }
 
-time_t notifier::get_last_acknowledgement() const {
+time_t notifier::get_last_acknowledgement() const noexcept {
   return _last_acknowledgement;
 }
 
-uint32_t notifier::get_notification_interval(void) const {
+uint32_t notifier::get_notification_interval(void) const noexcept {
   return _notification_interval;
 }
 
-void notifier::set_notification_interval(uint32_t notification_interval) {
+void notifier::set_notification_interval(
+    uint32_t notification_interval) noexcept {
   _notification_interval = notification_interval;
 }
 
-std::string const& notifier::get_notification_period() const {
+std::string const& notifier::get_notification_period() const noexcept {
   return _notification_period;
 }
 
-void notifier::set_notification_period(std::string const& notification_period) {
+void notifier::set_notification_period(
+    std::string const& notification_period) noexcept {
   _notification_period = notification_period;
 }
 
-bool notifier::get_notify_on(notification_flag type) const {
+bool notifier::get_notify_on(notification_flag type) const noexcept {
   return _out_notification_type & type;
 }
 
-uint32_t notifier::get_notify_on() const {
+uint32_t notifier::get_notify_on() const noexcept {
   return _out_notification_type;
 }
 
-void notifier::add_notify_on(notification_flag type) {
+void notifier::add_notify_on(notification_flag type) noexcept {
   _out_notification_type |= type;
 }
 
-void notifier::set_notify_on(uint32_t type) {
+void notifier::set_notify_on(uint32_t type) noexcept {
   _out_notification_type = type;
 }
 
-void notifier::remove_notify_on(notification_flag type) {
+void notifier::remove_notify_on(notification_flag type) noexcept {
   _out_notification_type &= ~type;
 }
 
-uint32_t notifier::get_first_notification_delay(void) const {
+uint32_t notifier::get_first_notification_delay(void) const noexcept {
   return _first_notification_delay;
 }
 
-void notifier::set_first_notification_delay(uint32_t first_notification_delay) {
+void notifier::set_first_notification_delay(
+    uint32_t first_notification_delay) noexcept {
   _first_notification_delay = first_notification_delay;
 }
 
-uint32_t notifier::get_recovery_notification_delay(void) const {
+uint32_t notifier::get_recovery_notification_delay(void) const noexcept {
   return _recovery_notification_delay;
 }
 
 void notifier::set_recovery_notification_delay(
-    uint32_t recovery_notification_delay) {
+    uint32_t recovery_notification_delay) noexcept {
   _recovery_notification_delay = recovery_notification_delay;
 }
 
-bool notifier::get_notifications_enabled() const {
+bool notifier::get_notifications_enabled() const noexcept {
   return _notifications_enabled;
 }
 
-void notifier::set_notifications_enabled(bool notifications_enabled) {
+void notifier::set_notifications_enabled(bool notifications_enabled) noexcept {
   _notifications_enabled = notifications_enabled;
 }
 
-bool notifier::get_notified_on(notification_flag type) const {
+bool notifier::get_notified_on(notification_flag type) const noexcept {
   return _current_notifications & type;
 }
 
-uint32_t notifier::get_notified_on() const {
+uint32_t notifier::get_notified_on() const noexcept {
   return _current_notifications;
 }
 
-void notifier::add_notified_on(notification_flag type) {
+void notifier::add_notified_on(notification_flag type) noexcept {
   _current_notifications |= type;
 }
 
-void notifier::set_notified_on(uint32_t type) {
+void notifier::set_notified_on(uint32_t type) noexcept {
   _current_notifications = type;
 }
 
-void notifier::remove_notified_on(notification_flag type) {
+void notifier::remove_notified_on(notification_flag type) noexcept {
   _current_notifications &= ~type;
 }
 
-bool notifier::get_flap_detection_on(notification_flag type) const {
+bool notifier::get_flap_detection_on(notification_flag type) const noexcept {
   return _flap_type & type;
 }
 
-uint32_t notifier::get_flap_detection_on() const {
-  return _flap_type;
-}
+uint32_t notifier::get_flap_detection_on() const noexcept { return _flap_type; }
 
-void notifier::set_flap_detection_on(uint32_t type) {
+void notifier::set_flap_detection_on(uint32_t type) noexcept {
   _flap_type = type;
 }
 
-void notifier::add_flap_detection_on(notification_flag type) {
+void notifier::add_flap_detection_on(notification_flag type) noexcept {
   _flap_type |= type;
 }
 
-bool notifier::get_stalk_on(notification_flag type) const {
+bool notifier::get_stalk_on(notification_flag type) const noexcept {
   return _stalk_type & type;
 }
 
-uint32_t notifier::get_stalk_on() const {
-  return _stalk_type;
-}
+uint32_t notifier::get_stalk_on() const noexcept { return _stalk_type; }
 
-void notifier::set_stalk_on(uint32_t type) {
-  _stalk_type = type;
-}
+void notifier::set_stalk_on(uint32_t type) noexcept { _stalk_type = type; }
 
-void notifier::add_stalk_on(notification_flag type) {
+void notifier::add_stalk_on(notification_flag type) noexcept {
   _stalk_type |= type;
 }
 
-uint32_t notifier::get_modified_attributes() const {
+uint32_t notifier::get_modified_attributes() const noexcept {
   return _modified_attributes;
 }
 
-void notifier::set_modified_attributes(uint32_t modified_attributes) {
+void notifier::set_modified_attributes(uint32_t modified_attributes) noexcept {
   _modified_attributes = modified_attributes;
 }
 
-void notifier::add_modified_attributes(uint32_t attr) {
+void notifier::add_modified_attributes(uint32_t attr) noexcept {
   _modified_attributes |= attr;
 }
 
-std::list<escalation*>& notifier::get_escalations() { return _escalations; }
-
-std::list<escalation*> const& notifier::get_escalations() const {
+std::list<escalation*>& notifier::get_escalations() noexcept {
   return _escalations;
 }
 
-uint64_t notifier::get_flapping_comment_id(void) const {
+std::list<escalation*> const& notifier::get_escalations() const noexcept {
+  return _escalations;
+}
+
+uint64_t notifier::get_flapping_comment_id(void) const noexcept {
   return _flapping_comment_id;
 }
 
-void notifier::set_flapping_comment_id(uint64_t comment_id) {
+void notifier::set_flapping_comment_id(uint64_t comment_id) noexcept {
   _flapping_comment_id = comment_id;
 }
 
-int notifier::get_check_options(void) const { return _check_options; }
+int notifier::get_check_options(void) const noexcept { return _check_options; }
 
-void notifier::set_check_options(int option) { _check_options = option; }
+void notifier::set_check_options(int option) noexcept {
+  _check_options = option;
+}
 
-int notifier::get_acknowledgement_type(void) const {
+int notifier::get_acknowledgement_type(void) const noexcept {
   return _acknowledgement_type;
 }
 
-void notifier::set_acknowledgement_type(int acknowledge_type) {
+void notifier::set_acknowledgement_type(int acknowledge_type) noexcept {
   _acknowledgement_type = acknowledge_type;
 }
 
-int notifier::get_retain_status_information(void) const {
+int notifier::get_retain_status_information(void) const noexcept {
   return _retain_status_information;
 }
 
-void notifier::set_retain_status_information(bool retain_status_informations) {
+void notifier::set_retain_status_information(
+    bool retain_status_informations) noexcept {
   _retain_status_information = retain_status_informations;
 }
 
-bool notifier::get_retain_nonstatus_information(void) const {
+bool notifier::get_retain_nonstatus_information(void) const noexcept {
   return _retain_nonstatus_information;
 }
 
 void notifier::set_retain_nonstatus_information(
-    bool retain_non_status_informations) {
+    bool retain_non_status_informations) noexcept {
   _retain_nonstatus_information = retain_non_status_informations;
 }
 
-bool notifier::get_is_being_freshened(void) const {
+bool notifier::get_is_being_freshened(void) const noexcept {
   return _is_being_freshened;
 }
 
-void notifier::set_is_being_freshened(bool freshened) {
+void notifier::set_is_being_freshened(bool freshened) noexcept {
   _is_being_freshened = freshened;
 }
 
-bool notifier::get_problem_has_been_acknowledged() const {
+bool notifier::get_problem_has_been_acknowledged() const noexcept {
   return _problem_has_been_acknowledged;
 }
 
 void notifier::set_problem_has_been_acknowledged(
-    bool problem_has_been_acknowledged) {
+    bool problem_has_been_acknowledged) noexcept {
   _problem_has_been_acknowledged = problem_has_been_acknowledged;
 }
 
-bool notifier::get_no_more_notifications() const {
+bool notifier::get_no_more_notifications() const noexcept {
   return _no_more_notifications;
 }
 
-void notifier::set_no_more_notifications(bool no_more_notifications) {
+void notifier::set_no_more_notifications(bool no_more_notifications) noexcept {
   _no_more_notifications = no_more_notifications;
 }
 
-int notifier::get_notification_number() const { return _notification_number; }
+int notifier::get_notification_number() const noexcept {
+  return _notification_number;
+}
 
 /**
  *  Get the next notification id.
  *
  * @return a long unsigned integer.
  */
-uint64_t notifier::get_next_notification_id() const {
+uint64_t notifier::get_next_notification_id() const noexcept {
   return _next_notification_id;
 }
 
-notifier::notifier_type notifier::get_notifier_type() const {
+notifier::notifier_type notifier::get_notifier_type() const noexcept {
   return _notifier_type;
 }
 
-std::unordered_map<std::string, contact*>& notifier::get_contacts() {
+std::unordered_map<std::string, contact*>& notifier::get_contacts() noexcept {
   return _contacts;
 }
 
-std::unordered_map<std::string, contact*> const& notifier::get_contacts()
-    const {
+std::unordered_map<std::string, contact*> const& notifier::get_contacts() const
+    noexcept {
   return _contacts;
 }
 
-contactgroup_map_unsafe& notifier::get_contactgroups() {
+contactgroup_map_unsafe& notifier::get_contactgroups() noexcept {
   return _contact_groups;
 }
 
-contactgroup_map_unsafe const& notifier::get_contactgroups() const {
+contactgroup_map_unsafe const& notifier::get_contactgroups() const noexcept {
   return _contact_groups;
 }
 
@@ -1324,17 +1332,17 @@ time_t notifier::get_next_notification_time(time_t offset) {
   return next_notification;
 }
 
-void notifier::set_flap_type(uint32_t type) { _flap_type = type; }
+void notifier::set_flap_type(uint32_t type) noexcept { _flap_type = type; }
 
-timeperiod* notifier::get_notification_period_ptr() const {
+timeperiod* notifier::get_notification_period_ptr() const noexcept {
   return _notification_period_ptr;
 }
 
-int notifier::get_acknowledgement_timeout() const {
+int notifier::get_acknowledgement_timeout() const noexcept {
   return _acknowledgement_timeout;
 }
 
-void notifier::set_notification_period_ptr(timeperiod* tp) {
+void notifier::set_notification_period_ptr(timeperiod* tp) noexcept {
   _notification_period_ptr = tp;
 }
 

--- a/src/retention/host.cc
+++ b/src/retention/host.cc
@@ -1274,7 +1274,7 @@ bool host::_set_plugin_output(std::string const& value) {
  *
  *  @param[in] value The new problem_has_been_acknowledged.
  */
-bool host::_set_problem_has_been_acknowledged(bool value) {
+bool host::_set_problem_has_been_acknowledged(bool value) noexcept {
   _problem_has_been_acknowledged = value;
   return true;
 }
@@ -1284,7 +1284,7 @@ bool host::_set_problem_has_been_acknowledged(bool value) {
  *
  *  @param[in] value The new process_performance_data.
  */
-bool host::_set_process_performance_data(int value) {
+bool host::_set_process_performance_data(int value) noexcept {
   _process_performance_data = value;
   return true;
 }
@@ -1294,7 +1294,7 @@ bool host::_set_process_performance_data(int value) {
  *
  *  @param[in] value The new retry_check_interval.
  */
-bool host::_set_retry_check_interval(unsigned int value) {
+bool host::_set_retry_check_interval(unsigned int value) noexcept {
   _retry_check_interval = value;
   return true;
 }
@@ -1304,7 +1304,7 @@ bool host::_set_retry_check_interval(unsigned int value) {
  *
  *  @param[in] value The new state_history.
  */
-bool host::_set_state_history(std::string const& value) {
+bool host::_set_state_history(std::string const& value) noexcept {
   unsigned int x(0);
   std::list<std::string> lst_history;
   string::split(value, lst_history, ',');

--- a/src/service.cc
+++ b/src/service.cc
@@ -1297,14 +1297,14 @@ int service::handle_async_check_result(check_result* queued_check_result) {
     if (ACKNOWLEDGEMENT_NORMAL == this->get_acknowledgement_type() &&
         (state_change || !hard_state_change)) {
       set_problem_has_been_acknowledged(false);
-      this->set_acknowledgement_type(ACKNOWLEDGEMENT_NONE);
+      set_acknowledgement_type(ACKNOWLEDGEMENT_NONE);
 
       /* remove any non-persistant comments associated with the ack */
       comment::delete_service_acknowledgement_comments(this);
     } else if (this->get_acknowledgement_type() == ACKNOWLEDGEMENT_STICKY &&
                _current_state == service::state_ok) {
       set_problem_has_been_acknowledged(false);
-      this->set_acknowledgement_type(ACKNOWLEDGEMENT_NONE);
+      set_acknowledgement_type(ACKNOWLEDGEMENT_NONE);
 
       /* remove any non-persistant comments associated with the ack */
       comment::delete_service_acknowledgement_comments(this);

--- a/tests/notifications/service_normal_notification.cc
+++ b/tests/notifications/service_normal_notification.cc
@@ -1141,3 +1141,65 @@ TEST_F(ServiceNotification, SimpleNormalVolatileServiceNotification) {
             OK);
   ASSERT_EQ(id, _svc->get_next_notification_id());
 }
+
+
+TEST_F(ServiceNotification, RecoveryNotifEvenIfServiceAcknowledged) {
+  /* We are using a local time() function defined in tests/timeperiod/utils.cc.
+   * If we call time(), it is not the glibc time() function that will be called.
+   */
+  ASSERT_EQ(_host->services.size(), 1u);
+  set_time(43200);
+  std::unique_ptr<engine::timeperiod> tperiod{
+      new engine::timeperiod("tperiod", "alias")};
+  for (int i = 0; i < 7; ++i)
+    tperiod->days[i].push_back(std::make_shared<engine::timerange>(0, 86400));
+
+  std::unique_ptr<engine::serviceescalation> service_escalation{
+      new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0,
+                                    "tperiod", 7, Uuid())};
+  _svc->set_current_state(engine::service::state_critical);
+  _svc->set_last_state(engine::service::state_critical);
+  _svc->set_last_hard_state_change(43200);
+  _svc->set_state_type(checkable::hard);
+
+  /* Critical notification is sent */
+  uint64_t id{_svc->get_next_notification_id()};
+  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
+                         notifier::notification_option_none),
+            OK);
+  ASSERT_EQ(id + 1, _svc->get_next_notification_id());
+
+  set_time(43700);
+  /* The service is acknowledged */
+  _svc->set_problem_has_been_acknowledged(true);
+  _svc->set_acknowledgement_type(ACKNOWLEDGEMENT_NORMAL);
+  time_t now = time(nullptr);
+  _svc->set_last_acknowledgement(now);
+
+  id = _svc->get_next_notification_id();
+  ASSERT_EQ(_svc->notify(notifier::reason_acknowledgement, "", "",
+                         notifier::notification_option_none),
+            OK);
+  ASSERT_EQ(id + 1, _svc->get_next_notification_id());
+
+  set_time(44000);
+  /* The service is acknowledged => no more normal notification */
+  id = _svc->get_next_notification_id();
+  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
+                         notifier::notification_option_none),
+            OK);
+  ASSERT_EQ(id, _svc->get_next_notification_id());
+
+  set_time(44500);
+  _svc->set_current_state(engine::service::state_ok);
+  _svc->set_last_state(engine::service::state_ok);
+  _svc->set_last_hard_state_change(44500);
+  _svc->set_state_type(checkable::hard);
+
+  /* Critical notification is sent */
+  id = _svc->get_next_notification_id();
+  ASSERT_EQ(_svc->notify(notifier::reason_recovery, "", "",
+                         notifier::notification_option_none),
+            OK);
+  ASSERT_EQ(id + 1, _svc->get_next_notification_id());
+}


### PR DESCRIPTION
# Pull Request Template

## Description

This is a fix so that a recovery notification is sent even if the service/host has been acknowledged.

**Fixes** # (issue)

MON-4594

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 18.10.x
- [ ] 19.04.x
- [X] 19.10.x
- [X] 20.04.x (master)
