### PR TITLE
fix(extcmd): fix a 19.10 regression in CHANGE_CUSTOM_X_VAR

### DIFF
--- a/doc/release_notes/engine19.10.rst
+++ b/doc/release_notes/engine19.10.rst
@@ -18,6 +18,13 @@ Recovery notifications must be sent even after an acknowledgement
 With the new notifications implementation, this behaviour had been changed.
 This new version reset this functionality as users expect it to work.
 
+External Command CHANGE_CUSTOM_X_VAR was not working
+====================================================
+
+A bug was introduced on 19.10 for the extcmd CHANGE_CUSTOM_X_VAR. When
+we were updating a custom variable with a command, the updated value
+was always empty string.
+
 =======================
 Centreon Engine 19.10.8
 =======================

--- a/modules/external_commands/src/commands.cc
+++ b/modules/external_commands/src/commands.cc
@@ -1953,12 +1953,7 @@ int cmd_change_object_custom_var(int cmd, char* args) {
   args += pos + 1;
 
   /* get the custom variable value */
-  temp_ptr = index(args, ';');
-  std::string varvalue;
-  if (temp_ptr) {
-    pos = temp_ptr - args;
-    varvalue = std::string(args, pos);
-  }
+  std::string varvalue {args};
 
   std::transform(varname.begin(), varname.end(), varname.begin(), ::toupper);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -98,6 +98,7 @@ if (WITH_TESTING)
     "${TESTS_DIR}/configuration/service.cc"
     "${TESTS_DIR}/contacts/contactgroup-config.cc"
     "${TESTS_DIR}/contacts/simple-contactgroup.cc"
+    "${TESTS_DIR}/custom_vars/extcmd.cc"
     "${TESTS_DIR}/downtimes/downtime.cc"
     "${TESTS_DIR}/downtimes/downtime_finder.cc"
     "${TESTS_DIR}/macros/macro.cc"

--- a/tests/custom_vars/extcmd.cc
+++ b/tests/custom_vars/extcmd.cc
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2005 - 2019 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+#include <iostream>
+#include <gtest/gtest.h>
+#include "../timeperiod/utils.hh"
+#include "com/centreon/clib.hh"
+#include "com/centreon/engine/checks/checker.hh"
+#include "com/centreon/engine/configuration/applier/command.hh"
+#include "com/centreon/engine/configuration/applier/contact.hh"
+#include "com/centreon/engine/configuration/applier/host.hh"
+#include "com/centreon/engine/configuration/applier/state.hh"
+#include "com/centreon/engine/configuration/state.hh"
+#include "com/centreon/engine/macros/grab_host.hh"
+#include "com/centreon/engine/modules/external_commands/commands.hh"
+#include "com/centreon/engine/timezone_manager.hh"
+#include <com/centreon/engine/configuration/applier/macros.hh>
+
+using namespace com::centreon;
+using namespace com::centreon::engine;
+using namespace com::centreon::engine::configuration;
+
+extern configuration::state* config;
+
+class CustomVar : public ::testing::Test {
+ public:
+  void SetUp() override {
+    if (config == nullptr)
+      config = new configuration::state;
+    clib::load();
+    com::centreon::logging::engine::load();
+    applier::state::load();  // Needed to create a contact
+    timezone_manager::load();
+    checks::checker::load();
+  }
+
+  void TearDown() override {
+    configuration::applier::state::unload();
+    com::centreon::logging::engine::unload();
+    clib::unload();
+    checks::checker::unload();
+    delete config;
+    config = nullptr;
+    timezone_manager::unload();
+  }
+
+};
+
+// Given simple command (without connector) applier already applied with
+// all objects created.
+// When the command is removed from the configuration,
+// Then the command is totally removed.
+TEST_F(CustomVar, UpdateHostCustomVar) {
+  configuration::applier::command cmd_aply;
+  configuration::applier::host hst_aply;
+  configuration::applier::contact cnt_aply;
+
+  configuration::command cmd("base_centreon_ping");
+  cmd.parse("command_line", "$USER1$/check_icmp -H $HOSTADDRESS$ -n $_HOSTPACKETNUMBER$ -w $_HOSTWARNING$ -c $_HOSTCRITICAL$ $CONTACTNAME$");
+  cmd_aply.add_object(cmd);
+
+
+  configuration::contact cnt;
+  ASSERT_TRUE(cnt.parse("contact_name", "user"));
+  ASSERT_TRUE(cnt.parse("email", "contact@centreon.com"));
+  ASSERT_TRUE(cnt.parse("pager", "0473729383"));
+  ASSERT_TRUE(cnt.parse("host_notification_period", "24x7"));
+  ASSERT_TRUE(cnt.parse("service_notification_period", "24x7"));
+  cnt_aply.add_object(cnt);
+
+  configuration::host hst;
+  ASSERT_TRUE(hst.parse("host_name", "hst_test"));
+  ASSERT_TRUE(hst.parse("address", "127.0.0.1"));
+  ASSERT_TRUE(hst.parse("_HOST_ID", "1"));
+  ASSERT_TRUE(hst.parse("_PACKETNUMBER", "42"));
+  ASSERT_TRUE(hst.parse("_WARNING", "200,20%"));
+  ASSERT_TRUE(hst.parse("_CRITICAL", "400,50%"));
+  ASSERT_TRUE(hst.parse("check_command", "base_centreon_ping"));
+  ASSERT_TRUE(hst.parse("contacts", "user"));
+  hst_aply.add_object(hst);
+
+  command_map::iterator cmd_found{
+      commands::command::commands.find("base_centreon_ping")};
+  ASSERT_NE(cmd_found, commands::command::commands.end());
+  ASSERT_TRUE(config->commands().size() == 1);
+
+  host_map::iterator hst_found{engine::host::hosts.find("hst_test")};
+  ASSERT_NE(hst_found, engine::host::hosts.end());
+  ASSERT_TRUE(config->hosts().size() == 1);
+
+  hst_aply.expand_objects(*config);
+  hst_aply.resolve_object(hst);
+  ASSERT_TRUE(hst_found->second->custom_variables.size() == 3);
+  nagios_macros macros;
+  grab_host_macros_r(&macros, hst_found->second.get());
+  std::string processed_cmd(hst_found->second->get_check_command_ptr()->process_cmd(&macros));
+  ASSERT_EQ(processed_cmd, "/check_icmp -H 127.0.0.1 -n 42 -w 200,20% -c 400,50% user");
+
+  cmd_change_object_custom_var(CMD_CHANGE_CUSTOM_HOST_VAR, "hst_test;PACKETNUMBER;44");
+  grab_host_macros_r(&macros, hst_found->second.get());
+  std::string processed_cmd2(hst_found->second->get_check_command_ptr()->process_cmd(&macros));
+  ASSERT_EQ(processed_cmd2, "/check_icmp -H 127.0.0.1 -n 44 -w 200,20% -c 400,50% user");
+}


### PR DESCRIPTION
# Pull Request Template

## Description

A bug was introduced on 19.10 for the extcmd CHANGE_CUSTOM_X_VAR. When
we were updating a custom variable with a command, the updated value
was always empty string.
**Fixes** #4616

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [X] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

try a CHANGE_CUSTOM_HOST_VAR extcmd and a CHANGE_CUSTOM_SVC_VAR extcmd

## Checklist

#### Community contributors & Centreon team

- [X] I followed the **coding style guidelines** provided by Centreon
- [X] I have made corresponding changes to the **documentation**.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [X] I have made sure that the **unit tests** related to the story are successful.
- [X] I have made sure that **unit tests cover 80%** of the code written for the story.
