### PR TITLE
fix(customvariable): modified is set to false in the constructor

### DIFF
--- a/src/customvariable.cc
+++ b/src/customvariable.cc
@@ -29,7 +29,7 @@ using namespace com::centreon::engine;
  *  broker
  */
 customvariable::customvariable(std::string const& value, bool is_sent)
-    : _value{value}, _is_sent{is_sent}, _modified{true} {}
+    : _value{value}, _is_sent{is_sent}, _modified{false} {}
 
 /**
  *  Copy constructor
@@ -39,7 +39,7 @@ customvariable::customvariable(std::string const& value, bool is_sent)
 customvariable::customvariable(customvariable const& other)
     : _value{other._value},
       _is_sent{other._is_sent},
-      _modified{other._modified} {}
+      _modified{false} {}
 
 /**
  *  Affectation operator of customvariable


### PR DESCRIPTION
# Pull Request Template

## Description

Little fix, so that a macro, when constructed, has its modified flag set to false.
**Fixes** # (issue)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

Tests can be done as explained by Colin.
