### PR TITLE
Mon 4719 stalk options changed on modification

### DIFF
--- a/cmake.sh
+++ b/cmake.sh
@@ -1,6 +1,6 @@
 mkdir build
 cd build
-CXXFLAGS="-Wall -Wextra" cmake -DWITH_PREFIX=/usr -DWITH_PREFIX_BIN=/usr/sbin -DWITH_USER=centreon-engine -DWITH_GROUP=centreon-engine -DCMAKE_BUILD_TYPE=Debug -DWITH_RW_DIR=/var/lib/centreon-engine/rw -DWITH_PREFIX_CONF=/etc/centreon-engine -DWITH_VAR_DIR=/var/log/centreon-engine -DWITH_PREFIX_LIB=/usr/lib64/centreon-engine -DWITH_TESTING=On -DWITH_SIMU=On $* -DWITH_CREATE_FILES=OFF ..
+CXXFLAGS="-Wall -Wextra" cmake -DWITH_PREFIX=/usr -DWITH_PREFIX_BIN=/usr/sbin -DWITH_USER=centreon-engine -DWITH_GROUP=centreon-engine -DCMAKE_BUILD_TYPE=Debug -DWITH_RW_DIR=/var/lib/centreon-engine/rw -DWITH_PREFIX_CONF=/etc/centreon-engine -DWITH_VAR_DIR=/var/log/centreon-engine -DWITH_PREFIX_LIB=/usr/lib64/centreon-engine -DWITH_TESTING=On -DWITH_SIMU=On $* -DWITH_CREATE_FILES=OFF -DWITH_BENCH=On ..
 
 #CXX=/usr/bin/clang++ CC=/usr/bin/clang cmake -DWITH_PREFIX=/usr -DWITH_PREFIX_BIN=/usr/sbin -DWITH_USER=centreon-engine -DWITH_GROUP=centreon-engine -DCMAKE_BUILD_TYPE=Debug -DWITH_RW_DIR=/var/lib/centreon-engine/rw -DWITH_PREFIX_CONF=/etc/centreon-engine -DWITH_VAR_DIR=/var/log/centreon-engine -DWITH_PREFIX_LIB=/usr/lib64/centreon-engine -DWITH_TESTING=On -DWITH_SIMU=On .
 

--- a/doc/release_notes/engine19.10.rst
+++ b/doc/release_notes/engine19.10.rst
@@ -1,3 +1,17 @@
+========================
+Centreon Engine 19.10.10
+========================
+
+*********
+Bug fixes
+*********
+
+stalk options on services
+=========================
+
+Stalk options were changed on modified services when engine was reload or
+restarted.
+
 =======================
 Centreon Engine 19.10.9
 =======================

--- a/src/configuration/applier/service.cc
+++ b/src/configuration/applier/service.cc
@@ -360,16 +360,16 @@ void applier::service::modify_object(configuration::service const& obj) {
   s->set_first_notification_delay(
       static_cast<double>(obj.first_notification_delay()));
 
-  s->add_stalk_on(obj.notification_options() & configuration::service::ok
+  s->add_stalk_on(obj.stalking_options() & configuration::service::ok
                       ? notifier::ok
                       : notifier::none);
-  s->add_stalk_on(obj.notification_options() & configuration::service::warning
+  s->add_stalk_on(obj.stalking_options() & configuration::service::warning
                       ? notifier::warning
                       : notifier::none);
-  s->add_stalk_on(obj.notification_options() & configuration::service::unknown
+  s->add_stalk_on(obj.stalking_options() & configuration::service::unknown
                       ? notifier::unknown
                       : notifier::none);
-  s->add_stalk_on(obj.notification_options() & configuration::service::critical
+  s->add_stalk_on(obj.stalking_options() & configuration::service::critical
                       ? notifier::critical
                       : notifier::none);
 

--- a/src/service.cc
+++ b/src/service.cc
@@ -753,12 +753,10 @@ com::centreon::engine::service* add_service(
     obj->set_retain_nonstatus_information(retain_nonstatus_information > 0);
     obj->set_retain_status_information(retain_status_information > 0);
     obj->set_should_be_scheduled(true);
-    uint32_t stalk_on;
-    stalk_on = none;
-    stalk_on |= (stalk_on_critical > 0 ? notifier::critical : 0);
-    stalk_on |= (stalk_on_ok > 0 ? notifier::ok : 0);
-    stalk_on |= (stalk_on_unknown > 0 ? notifier::warning : 0);
-    stalk_on |= (stalk_on_warning > 0 ? notifier::unknown : 0);
+    uint32_t stalk_on = (stalk_on_critical ? notifier::critical : 0) |
+                        (stalk_on_ok ? notifier::ok : 0) |
+                        (stalk_on_unknown ? notifier::unknown : 0) |
+                        (stalk_on_warning ? notifier::warning : 0);
     obj->set_stalk_on(stalk_on);
     obj->set_state_type(notifier::hard);
 


### PR DESCRIPTION
# Pull Request Template

## Description

Please include a short resume of the changes and what is the purpose of PR. Any relevant information should be added to help:
* **QA Team** (Quality Assurance) with tests.
* **reviewers** to understand what are the stakes of the pull request.

**Fixes** # (issue)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [X] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Configure a service with all the notification flags enabled and no stalk flags.

Push the configuration. Then modify the service to change a little thing (not the notification or stalk flags).

Push again the configuration. If the bug is there, you should see in the centreon_storage that stalk
flags are not all set to 0. If the bug is fixed, you should see all the stalk flags set to 0.

With the patched version, you should also test the same steps but with only the unknown flag enabled for the stalks and the critical flag enabled for the notifications or anything else.

The query to check in the database is:
`SELECT stalk_on_critical, stalk_on_ok, stalk_on_unknown, stalk_on_warning FROM services WHERE service_id = <id of service>\G`
