### PR TITLE
fix(retention): parser could truncate values.

### DIFF
--- a/doc/release_notes/engine19.10.rst
+++ b/doc/release_notes/engine19.10.rst
@@ -12,6 +12,12 @@ stalk options on services
 Stalk options were changed on modified services when engine was reload or
 restarted.
 
+Perfdata truncated when read from retention
+===========================================
+
+values containing a ';' character were truncated when read from the retention
+file. This new release fixes this issue.
+
 =======================
 Centreon Engine 19.10.9
 =======================

--- a/src/retention/parser.cc
+++ b/src/retention/parser.cc
@@ -17,6 +17,7 @@
 ** <http://www.gnu.org/licenses/>.
 */
 
+#include <string>
 #include <fstream>
 #include "com/centreon/engine/error.hh"
 #include "com/centreon/engine/retention/parser.hh"
@@ -59,7 +60,25 @@ void parser::parse(std::string const& path, state& retention) {
   std::shared_ptr<object> obj;
   std::string input;
   unsigned int current_line(0);
-  while (string::get_next_line(stream, input, current_line)) {
+  auto next_line = [](
+      std::ifstream & stream, std::string & input, uint32_t & line)->bool {
+    while (std::getline(stream, input, '\n')) {
+      ++line;
+      size_t sstart = input.find_first_not_of(" \t");
+      size_t send = input.find_last_not_of(" \t");
+      if (sstart)
+        input = input.substr(sstart, send - sstart + 1);
+      else
+        input.erase(send + 1);
+      if (!input.empty()) {
+        char c = input[0];
+        if (c != '#' && c != 0)
+          return true;
+      }
+    }
+    return false;
+  };
+  while (next_line(stream, input, current_line)) {
     if (obj == nullptr) {
       std::size_t pos(input.find_first_of(" \t"));
       if (pos == std::string::npos)

--- a/src/retention/parser.cc
+++ b/src/retention/parser.cc
@@ -61,7 +61,7 @@ void parser::parse(std::string const& path, state& retention) {
   std::string input;
   unsigned int current_line(0);
   auto next_line = [](
-      std::ifstream & stream, std::string & input, uint32_t & line)->bool {
+      std::ifstream& stream, std::string& input, uint32_t& line) -> bool {
     while (std::getline(stream, input, '\n')) {
       ++line;
       size_t sstart = input.find_first_not_of(" \t");
@@ -78,6 +78,7 @@ void parser::parse(std::string const& path, state& retention) {
     }
     return false;
   };
+
   while (next_line(stream, input, current_line)) {
     if (obj == nullptr) {
       std::size_t pos(input.find_first_of(" \t"));

--- a/src/string.cc
+++ b/src/string.cc
@@ -204,7 +204,7 @@ void string::split(
  *
  *  @return The trimming stream.
  */
-std::string& string::trim(std::string& str) throw () {
+std::string& string::trim(std::string& str) noexcept {
   // First, search backward for the last non-space character.
   size_t pos(str.find_last_not_of(whitespaces));
   if (pos == std::string::npos)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -105,6 +105,7 @@ if (WITH_TESTING)
     "${TESTS_DIR}/perfdata/perfdata.cc"
     "${TESTS_DIR}/retention/host.cc"
     "${TESTS_DIR}/retention/service.cc"
+    "${TESTS_DIR}/string/string.cc"
     "${TESTS_DIR}/test_engine.cc"
     "${TESTS_DIR}/timeperiod/get_next_valid_time/between_two_years.cc"
     "${TESTS_DIR}/timeperiod/get_next_valid_time/calendar_date.cc"

--- a/tests/string/string.cc
+++ b/tests/string/string.cc
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2020 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
 #include "gtest/gtest.h"
 #include "com/centreon/engine/string.hh"
 

--- a/tests/string/string.cc
+++ b/tests/string/string.cc
@@ -1,0 +1,18 @@
+#include "gtest/gtest.h"
+#include "com/centreon/engine/string.hh"
+
+using namespace com::centreon::engine;
+
+TEST(string_utils, trim) {
+  std::string str("Hi guys!");
+  string::trim(str);
+  ASSERT_EQ(str, "Hi guys!");
+
+  str = " a b c  ";
+  string::trim(str);
+  ASSERT_EQ(str, "a b c");
+
+  str = "performance_data=rta=0.053ms;3000.000;5000.000;0; pl=0%;80;100;0;100 rtmax=0.053ms;;;; rtmin=0.053ms;;;;";
+  string::trim(str);
+  ASSERT_EQ(str, "performance_data=rta=0.053ms");
+}


### PR DESCRIPTION
# Pull Request Template

## Description

When engine was restarted, perfdata were get back from the retention.dat file. And when they were read, they were split at the first ';' character encountered. The impact was perfdata were badly written in the centreon_storage database.

**Fixes** # (issue)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 18.10.x
- [ ] 19.04.x
- [X] 19.10.x
- [ ] 20.04.x (master)
