### PR TITLE
fix(retention/parser): perfdata truncated when retention read.

### DIFF
--- a/src/string.cc
+++ b/src/string.cc
@@ -195,7 +195,7 @@ void string::split(std::string const& data,
  *
  *  @return The trimming stream.
  */
-std::string& string::trim(std::string& str) throw() {
+std::string& string::trim(std::string& str) noexcept {
   // First, search backward for the last non-space character.
   size_t pos(str.find_last_not_of(whitespaces));
   if (pos == std::string::npos)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -117,6 +117,7 @@ if (WITH_TESTING)
     "${TESTS_DIR}/perfdata/perfdata.cc"
     "${TESTS_DIR}/retention/host.cc"
     "${TESTS_DIR}/retention/service.cc"
+    "${TESTS_DIR}/string/string.cc"
     "${TESTS_DIR}/test_engine.cc"
     "${TESTS_DIR}/timeperiod/get_next_valid_time/between_two_years.cc"
     "${TESTS_DIR}/timeperiod/get_next_valid_time/calendar_date.cc"

--- a/tests/string/string.cc
+++ b/tests/string/string.cc
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+#include "gtest/gtest.h"
+#include "com/centreon/engine/string.hh"
+
+using namespace com::centreon::engine;
+
+TEST(string_utils, trim) {
+  std::string str("Hi guys!");
+  string::trim(str);
+  ASSERT_EQ(str, "Hi guys!");
+
+  str = " a b c  ";
+  string::trim(str);
+  ASSERT_EQ(str, "a b c");
+
+  str =
+      "performance_data=rta=0.053ms;3000.000;5000.000;0; pl=0%;80;100;0;100 "
+      "rtmax=0.053ms;;;; rtmin=0.053ms;;;;";
+  string::trim(str);
+  ASSERT_EQ(str, "performance_data=rta=0.053ms");
+}


### PR DESCRIPTION
# Pull Request Template

## Description

When the retention is read, values could be split. This fixed by this patch.