### PR TITLE
Mon 4058 hard soft duration

### DIFF
--- a/src/service.cc
+++ b/src/service.cc
@@ -1218,13 +1218,9 @@ int service::handle_async_check_result(check_result* queued_check_result) {
     }
   }
 
-  /*
-   **** NOTE - THIS WAS MOVED UP FROM LINE 1049 BELOW TO FIX PROBLEMS ****
-   **** WHERE CURRENT ATTEMPT VALUE WAS ACTUALLY "LEADING" REAL VALUE ****
-   * increment the current attempt number if this is a soft state
-   * (service was rechecked)
-   */
-  if (get_state_type() == soft &&
+  if (_last_state == state_ok && _current_state != _last_state)
+    set_current_attempt(1);
+  else if (get_state_type() == soft &&
       get_current_attempt() < get_max_attempts())
     add_current_attempt(1);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -70,6 +70,7 @@ if (WITH_TESTING)
     "${PROJECT_SOURCE_DIR}/modules/external_commands/src/internal.cc"
     "${PROJECT_SOURCE_DIR}/modules/external_commands/src/processing.cc"
     "${TESTS_DIR}/parse-check-output.cc"
+    "${TESTS_DIR}/checks/service_check.cc"
     "${TESTS_DIR}/commands/simple-command.cc"
     "${TESTS_DIR}/commands/connector.cc"
     "${TESTS_DIR}/configuration/applier/applier-command.cc"

--- a/tests/checks/service_check.cc
+++ b/tests/checks/service_check.cc
@@ -1,0 +1,286 @@
+/*
+ * Copyright 2020 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+#include <gtest/gtest.h>
+#include <time.h>
+#include <cstring>
+#include <iostream>
+#include <memory>
+#include "../test_engine.hh"
+#include "../timeperiod/utils.hh"
+#include "com/centreon/clib.hh"
+#include "com/centreon/engine/checks/checker.hh"
+#include "com/centreon/engine/configuration/applier/command.hh"
+#include "com/centreon/engine/configuration/applier/contact.hh"
+#include "com/centreon/engine/configuration/applier/contactgroup.hh"
+#include "com/centreon/engine/configuration/applier/host.hh"
+#include "com/centreon/engine/configuration/applier/service.hh"
+#include "com/centreon/engine/configuration/applier/servicedependency.hh"
+#include "com/centreon/engine/configuration/applier/serviceescalation.hh"
+#include "com/centreon/engine/configuration/applier/state.hh"
+#include "com/centreon/engine/configuration/applier/timeperiod.hh"
+#include "com/centreon/engine/configuration/host.hh"
+#include "com/centreon/engine/configuration/service.hh"
+#include "com/centreon/engine/configuration/state.hh"
+#include "com/centreon/engine/error.hh"
+#include "com/centreon/engine/modules/external_commands/commands.hh"
+#include "com/centreon/engine/serviceescalation.hh"
+#include "com/centreon/engine/timezone_manager.hh"
+
+using namespace com::centreon;
+using namespace com::centreon::engine;
+using namespace com::centreon::engine::configuration;
+using namespace com::centreon::engine::configuration::applier;
+
+extern configuration::state* config;
+
+class ServiceCheck : public TestEngine {
+ public:
+  void SetUp() override {
+    clib::load();
+    com::centreon::logging::engine::load();
+    if (!config)
+      config = new configuration::state;
+    timezone_manager::load();
+    configuration::applier::state::load();  // Needed to create a contact
+    // Do not unload this in the tear down function, it is done by the
+    // other unload function... :-(
+    checks::checker::load();
+
+    configuration::applier::contact ct_aply;
+    configuration::contact ctct{new_configuration_contact("admin", true)};
+    ct_aply.add_object(ctct);
+    ct_aply.expand_objects(*config);
+    ct_aply.resolve_object(ctct);
+
+    configuration::host hst{new_configuration_host("test_host", "admin")};
+    configuration::applier::host hst_aply;
+    hst_aply.add_object(hst);
+
+    configuration::service svc{
+        new_configuration_service("test_host", "test_svc", "admin")};
+    configuration::applier::service svc_aply;
+    svc_aply.add_object(svc);
+
+    hst_aply.resolve_object(hst);
+    svc_aply.resolve_object(svc);
+
+    host_map const& hm{engine::host::hosts};
+    _host = hm.begin()->second;
+    _host->set_current_state(engine::host::state_up);
+    _host->set_state_type(checkable::hard);
+    _host->set_problem_has_been_acknowledged(false);
+    _host->set_notify_on(static_cast<uint32_t>(-1));
+
+    service_map const& sm{engine::service::services};
+    _svc = sm.begin()->second;
+    _svc->set_current_state(engine::service::state_ok);
+    _svc->set_state_type(checkable::hard);
+    _svc->set_problem_has_been_acknowledged(false);
+    _svc->set_notify_on(static_cast<uint32_t>(-1));
+  }
+
+  void TearDown() override {
+    configuration::applier::state::unload();
+    checks::checker::unload();
+    delete config;
+    config = nullptr;
+    timezone_manager::unload();
+    com::centreon::logging::engine::unload();
+    clib::unload();
+  }
+
+ protected:
+  std::shared_ptr<engine::host> _host;
+  std::shared_ptr<engine::service> _svc;
+};
+
+/* The following test comes from this array (inherited from Nagios behaviour):
+ *
+ * | Time | Check # | State | State type | State change |
+ * ------------------------------------------------------
+ * | 0    | 1       | OK    | HARD       | No           |
+ * | 1    | 1       | CRTCL | SOFT       | Yes          |
+ * | 2    | 2       | WARN  | SOFT       | Yes          |
+ * | 3    | 3       | CRTCL | HARD       | Yes          |
+ * | 4    | 3       | WARN  | HARD       | Yes          |
+ * | 5    | 3       | WARN  | HARD       | No           |
+ * | 6    | 1       | OK    | HARD       | Yes          |
+ * | 7    | 1       | OK    | HARD       | No           |
+ * | 8    | 1       | UNKNWN| SOFT       | Yes          |
+ * | 9    | 2       | OK    | SOFT       | Yes          |
+ * | 10   | 1       | OK    | HARD       | No           |
+ * ------------------------------------------------------
+ */
+TEST_F(ServiceCheck, SimpleCheck) {
+  set_time(50000);
+  _svc->set_current_state(engine::service::state_ok);
+  _svc->set_last_hard_state(engine::service::state_ok);
+  _svc->set_last_hard_state_change(50000);
+  _svc->set_state_type(checkable::hard);
+  _svc->set_accept_passive_checks(true);
+  _svc->set_current_attempt(1);
+
+  set_time(50500);
+
+  std::ostringstream oss;
+  std::time_t now{std::time(nullptr)};
+  oss << '[' << now << ']'
+    << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;service critical";
+  std::string cmd{oss.str()};
+  process_external_command(cmd.c_str());
+  checks::checker::instance().reap();
+  ASSERT_EQ(_svc->get_state_type(), checkable::soft);
+  ASSERT_EQ(_svc->get_current_state(), engine::service::state_critical);
+  ASSERT_EQ(_svc->get_last_state_change(), now);
+  ASSERT_EQ(_svc->get_current_attempt(), 1);
+
+  set_time(51000);
+
+  now = std::time(nullptr);
+  oss.str("");
+  oss << '[' << now << ']'
+    << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;1;service warning";
+  cmd = oss.str();
+  process_external_command(cmd.c_str());
+  checks::checker::instance().reap();
+  ASSERT_EQ(_svc->get_state_type(), checkable::soft);
+  ASSERT_EQ(_svc->get_current_state(), engine::service::state_warning);
+  ASSERT_EQ(_svc->get_last_state_change(), now);
+  ASSERT_EQ(_svc->get_current_attempt(), 2);
+
+  set_time(51500);
+
+  now = std::time(nullptr);
+  oss.str("");
+  oss << '[' << now << ']'
+    << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;service critical";
+  cmd = oss.str();
+  process_external_command(cmd.c_str());
+  checks::checker::instance().reap();
+  ASSERT_EQ(_svc->get_state_type(), checkable::hard);
+  ASSERT_EQ(_svc->get_current_state(), engine::service::state_critical);
+  ASSERT_EQ(_svc->get_last_hard_state_change(), now);
+  ASSERT_EQ(_svc->get_current_attempt(), 3);
+
+  set_time(52000);
+
+  now = std::time(nullptr);
+  oss.str("");
+  oss << '[' << now << ']'
+    << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;1;service warning";
+  cmd = oss.str();
+  process_external_command(cmd.c_str());
+  checks::checker::instance().reap();
+  ASSERT_EQ(_svc->get_state_type(), checkable::hard);
+  ASSERT_EQ(_svc->get_current_state(), engine::service::state_warning);
+  ASSERT_EQ(_svc->get_last_hard_state_change(), now);
+  ASSERT_EQ(_svc->get_current_attempt(), 3);
+
+  set_time(52500);
+
+  time_t previous = now;
+  now = std::time(nullptr);
+  oss.str("");
+  oss << '[' << now << ']'
+    << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;1;service warning";
+  cmd = oss.str();
+  process_external_command(cmd.c_str());
+  checks::checker::instance().reap();
+  ASSERT_EQ(_svc->get_state_type(), checkable::hard);
+  ASSERT_EQ(_svc->get_current_state(), engine::service::state_warning);
+  ASSERT_EQ(_svc->get_last_hard_state_change(), previous);
+  ASSERT_EQ(_svc->get_current_attempt(), 3);
+
+  set_time(53000);
+
+  previous = now;
+  now = std::time(nullptr);
+  oss.str("");
+  oss << '[' << now << ']'
+    << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;0;service ok";
+  cmd = oss.str();
+  process_external_command(cmd.c_str());
+  checks::checker::instance().reap();
+  ASSERT_EQ(_svc->get_state_type(), checkable::hard);
+  ASSERT_EQ(_svc->get_current_state(), engine::service::state_ok);
+  ASSERT_EQ(_svc->get_last_hard_state_change(), now);
+  ASSERT_EQ(_svc->get_current_attempt(), 1);
+
+  set_time(53500);
+
+  previous = now;
+  now = std::time(nullptr);
+  oss.str("");
+  oss << '[' << now << ']'
+    << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;0;service ok";
+  cmd = oss.str();
+  process_external_command(cmd.c_str());
+  checks::checker::instance().reap();
+  ASSERT_EQ(_svc->get_state_type(), checkable::hard);
+  ASSERT_EQ(_svc->get_current_state(), engine::service::state_ok);
+  ASSERT_EQ(_svc->get_last_hard_state_change(), previous);
+  ASSERT_EQ(_svc->get_current_attempt(), 1);
+
+  set_time(54000);
+
+  previous = now;
+  now = std::time(nullptr);
+  oss.str("");
+  oss << '[' << now << ']'
+    << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;4;service unknown";
+  cmd = oss.str();
+  process_external_command(cmd.c_str());
+  checks::checker::instance().reap();
+  ASSERT_EQ(_svc->get_state_type(), checkable::soft);
+  ASSERT_EQ(_svc->get_current_state(), engine::service::state_unknown);
+  ASSERT_EQ(_svc->get_last_hard_state_change(), now - 1000);
+  ASSERT_EQ(_svc->get_last_state_change(), now);
+  ASSERT_EQ(_svc->get_current_attempt(), 1);
+
+  set_time(54500);
+
+  previous = now;
+  now = std::time(nullptr);
+  oss.str("");
+  oss << '[' << now << ']'
+    << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;0;service ok";
+  cmd = oss.str();
+  process_external_command(cmd.c_str());
+  checks::checker::instance().reap();
+  ASSERT_EQ(_svc->get_state_type(), checkable::soft);
+  ASSERT_EQ(_svc->get_current_state(), engine::service::state_ok);
+  ASSERT_EQ(_svc->get_last_state_change(), now);
+  ASSERT_EQ(_svc->get_current_attempt(), 2);
+
+  set_time(55000);
+
+  previous = now;
+  now = std::time(nullptr);
+  oss.str("");
+  oss << '[' << now << ']'
+    << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;0;service ok";
+  cmd = oss.str();
+  process_external_command(cmd.c_str());
+  checks::checker::instance().reap();
+  ASSERT_EQ(_svc->get_state_type(), checkable::hard);
+  ASSERT_EQ(_svc->get_current_state(), engine::service::state_ok);
+  ASSERT_EQ(_svc->get_last_hard_state_change(), now);
+  ASSERT_EQ(_svc->get_current_attempt(), 1);
+}

--- a/tests/commands/simple-command.cc
+++ b/tests/commands/simple-command.cc
@@ -34,6 +34,7 @@ extern configuration::state* config;
 class SimpleCommand : public ::testing::Test {
  public:
   void SetUp() override {
+    set_time(-1);
     clib::load();
     com::centreon::logging::engine::load();
     configuration::applier::state::load();  // Needed to store commands


### PR DESCRIPTION
# Pull Request Template

## Description

Hard and Soft states are not always coherent. This was due to a bad code in the service::handle_async_check_result() method.

Several tests have been added to match use cases, but maybe we do not cover all of them.

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [X] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 18.10.x
- [ ] 19.04.x
- [X] 19.10.x
- [ ] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

You must know all the stories about soft and hard state types and test them.
