### PR TITLE
fix(macro): fix TOTALXXXX macros (19.10)

### DIFF
--- a/doc/release_notes/engine19.10.rst
+++ b/doc/release_notes/engine19.10.rst
@@ -2,6 +2,10 @@
 Centreon Engine 19.10.11
 ========================
 
+*********
+Bug fixes
+*********
+
 Downtime cancellation was buggy
 ===============================
 
@@ -13,6 +17,12 @@ Incoherence between hard and soft state types
 A service could be in a hard state and the duration was not filled. Sometimes,
 it could also be the reverse. This is fixed and now displayed informations
 about soft/hard should be coherent.
+
+TOTALHOST* TOTALSERVICES macros
+===============================
+
+Some global macros like TOTALHOST* and TOTALSERVICES were replaced
+by empty strings instead of numeric values.
 
 ========================
 Centreon Engine 19.10.10

--- a/src/macros/grab_value.cc
+++ b/src/macros/grab_value.cc
@@ -730,23 +730,23 @@ static int handle_summary_macro(
       + services_unknown_unhandled;
 
     // These macros are time-intensive to compute, and will likely be
-    //r, so save them all for future use.
-    mac->x[MACRO_TOTALHOSTSUP] = hosts_up;
-    mac->x[MACRO_TOTALHOSTSDOWN] = hosts_down;
-    mac->x[MACRO_TOTALHOSTSUNREACHABLE] = hosts_unreachable;
-    mac->x[MACRO_TOTALHOSTSDOWNUNHANDLED] = hosts_down_unhandled;
-    mac->x[MACRO_TOTALHOSTSUNREACHABLEUNHANDLED] = hosts_unreachable_unhandled;
-    mac->x[MACRO_TOTALHOSTPROBLEMS] = host_problems;
-    mac->x[MACRO_TOTALHOSTPROBLEMSUNHANDLED] = host_problems_unhandled;
-    mac->x[MACRO_TOTALSERVICESOK] = services_ok;
-    mac->x[MACRO_TOTALSERVICESWARNING] = services_warning;
-    mac->x[MACRO_TOTALSERVICESCRITICAL] = services_critical;
-    mac->x[MACRO_TOTALSERVICESUNKNOWN] = services_unknown;
-    mac->x[MACRO_TOTALSERVICESWARNINGUNHANDLED] = services_warning_unhandled;
-    mac->x[MACRO_TOTALSERVICESCRITICALUNHANDLED] = services_critical_unhandled;
-    mac->x[MACRO_TOTALSERVICESUNKNOWNUNHANDLED] = services_unknown_unhandled;
-    mac->x[MACRO_TOTALSERVICEPROBLEMS] = service_problems;
-    mac->x[MACRO_TOTALSERVICEPROBLEMSUNHANDLED] = service_problems_unhandled;
+    // r, so save them all for future use.
+    mac->x[MACRO_TOTALHOSTSUP] = std::to_string(hosts_up);
+    mac->x[MACRO_TOTALHOSTSDOWN] = std::to_string(hosts_down);
+    mac->x[MACRO_TOTALHOSTSUNREACHABLE] = std::to_string(hosts_unreachable);
+    mac->x[MACRO_TOTALHOSTSDOWNUNHANDLED] = std::to_string(hosts_down_unhandled);
+    mac->x[MACRO_TOTALHOSTSUNREACHABLEUNHANDLED] = std::to_string(hosts_unreachable_unhandled);
+    mac->x[MACRO_TOTALHOSTPROBLEMS] = std::to_string(host_problems);
+    mac->x[MACRO_TOTALHOSTPROBLEMSUNHANDLED] = std::to_string(host_problems_unhandled);
+    mac->x[MACRO_TOTALSERVICESOK] = std::to_string(services_ok);
+    mac->x[MACRO_TOTALSERVICESWARNING] = std::to_string(services_warning);
+    mac->x[MACRO_TOTALSERVICESCRITICAL] = std::to_string(services_critical);
+    mac->x[MACRO_TOTALSERVICESUNKNOWN] = std::to_string(services_unknown);
+    mac->x[MACRO_TOTALSERVICESWARNINGUNHANDLED] = std::to_string(services_warning_unhandled);
+    mac->x[MACRO_TOTALSERVICESCRITICALUNHANDLED] = std::to_string(services_critical_unhandled);
+    mac->x[MACRO_TOTALSERVICESUNKNOWNUNHANDLED] = std::to_string(services_unknown_unhandled);
+    mac->x[MACRO_TOTALSERVICEPROBLEMS] = std::to_string(service_problems);
+    mac->x[MACRO_TOTALSERVICEPROBLEMSUNHANDLED] = std::to_string(service_problems_unhandled);
   }
 
   // Return only the macro the user requested.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -93,6 +93,7 @@ if (WITH_TESTING)
     "${TESTS_DIR}/custom_vars/extcmd.cc"
     "${TESTS_DIR}/downtimes/downtime.cc"
     "${TESTS_DIR}/downtimes/downtime_finder.cc"
+    "${TESTS_DIR}/macros/macro.cc"
     "${TESTS_DIR}/macros/url_encode.cc"
     "${TESTS_DIR}/external_commands/host.cc"
     "${TESTS_DIR}/external_commands/service.cc"

--- a/tests/external_commands/service.cc
+++ b/tests/external_commands/service.cc
@@ -52,9 +52,9 @@ class ServiceExternalCommand : public ::testing::Test {
   void TearDown() override {
     configuration::applier::state::unload();
     checks::checker::unload();
+    timezone_manager::unload();
     delete config;
     config = nullptr;
-    timezone_manager::unload();
     com::centreon::logging::engine::unload();
     clib::unload();
   }

--- a/tests/macros/macro.cc
+++ b/tests/macros/macro.cc
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2019 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+#include <com/centreon/clib.hh>
+#include <com/centreon/engine/checks/checker.hh>
+#include <com/centreon/engine/configuration/applier/host.hh>
+#include <com/centreon/engine/configuration/applier/state.hh>
+#include <com/centreon/engine/configuration/parser.hh>
+#include <com/centreon/engine/hostescalation.hh>
+#include <com/centreon/engine/macros/grab_host.hh>
+#include <com/centreon/engine/macros/process.hh>
+#include <com/centreon/engine/macros.hh>
+#include <com/centreon/engine/timezone_manager.hh>
+#include <com/centreon/engine/broker/loader.hh>
+#include <fstream>
+#include <gtest/gtest.h>
+
+using namespace com::centreon;
+using namespace com::centreon::engine;
+
+extern configuration::state* config;
+
+class Macro : public ::testing::Test {
+ public:
+  void SetUp() override {
+    clib::load();
+    com::centreon::logging::engine::load();
+    if (config == nullptr)
+      config = new configuration::state;
+    timezone_manager::load();
+    configuration::applier::state::load();  // Needed to create a contact
+    broker::loader::load();
+  }
+
+  void TearDown() override {
+    broker::loader::unload();
+    configuration::applier::state::unload();
+    checks::checker::unload();
+    timezone_manager::unload();
+    delete config;
+    config = nullptr;
+    com::centreon::logging::engine::unload();
+    clib::unload();
+  }
+};
+
+// Given host configuration without host_id
+// Then the applier add_object throws an exception.
+TEST_F(Macro, TotalServicesOkZero) {
+  std::string out;
+  nagios_macros mac;
+  process_macros_r(&mac, "$TOTALSERVICESOK$", out, 0);
+  ASSERT_EQ(out, "0");
+}
+
+// Given host configuration without host_id
+// Then the applier add_object throws an exception.
+TEST_F(Macro, TotalHostOk) {
+  configuration::applier::host hst_aply;
+  configuration::service svc;
+  configuration::host hst;
+  ASSERT_TRUE(hst.parse("host_name", "test_host"));
+  ASSERT_TRUE(hst.parse("address", "127.0.0.1"));
+  ASSERT_TRUE(hst.parse("_HOST_ID", "12"));
+  ASSERT_NO_THROW(hst_aply.add_object(hst));
+  ASSERT_EQ(1u, host::hosts.size());
+  init_macros();
+
+  nagios_macros mac;
+  std::string out;
+  host::hosts["test_host"]->set_current_state(host::state_up);
+  host::hosts["test_host"]->set_has_been_checked(true);
+  process_macros_r(&mac, "$TOTALHOSTSUP$", out, 1);
+  ASSERT_EQ(out, "1");
+}


### PR DESCRIPTION
 fix TOTALXXXX macros
# Pull Request Template

## Description

TOTALSERVICESOK TOTALSERVICESWARNING TOTALSERVICESCRITICAL ... were not working, they were replaced by empty values.

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 18.10.x
- [ ] 19.04.x
- [X] 19.10.x
- [ ] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

create a command with an $TOTALSERVICESOK$ macro. this macro should be replaced by a numerical value 

## Checklist

#### Community contributors & Centreon team

- [X] I followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have made corresponding changes to the **documentation**.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [X] I have made sure that the **unit tests** related to the story are successful.
- [X] I have made sure that **unit tests cover 80%** of the code written for the story.
- [X] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
