### PR TITLE
fix(downtime): Bad recursive way in downtimes deletions

### DIFF
--- a/inc/com/centreon/engine/common.hh
+++ b/inc/com/centreon/engine/common.hh
@@ -212,11 +212,6 @@
 #  define CMD_CUSTOM_COMMAND                                 999
 
 
-/* Scheduled downtime types. */
-#  define SERVICE_DOWNTIME 1 /* Service downtime. */
-#  define HOST_DOWNTIME    2 /* Host downtime. */
-#  define ANY_DOWNTIME     3 /* Host or service downtime. */
-
 /* Acknowledgement types. */
 #  define HOST_ACKNOWLEDGEMENT    0
 #  define SERVICE_ACKNOWLEDGEMENT 1

--- a/inc/com/centreon/engine/downtimes/downtime.hh
+++ b/inc/com/centreon/engine/downtimes/downtime.hh
@@ -19,83 +19,87 @@
 */
 
 #ifndef CCE_DOWNTIMES_DOWTIME_HH
-#  define CCE_DOWNTIMES_DOWTIME_HH
+#define CCE_DOWNTIMES_DOWTIME_HH
 
-#  include <sstream>
-#  include "com/centreon/engine/host.hh"
-#  include "com/centreon/engine/service.hh"
+#include <sstream>
+#include "com/centreon/engine/host.hh"
+#include "com/centreon/engine/service.hh"
 
 CCE_BEGIN()
 
-namespace                      downtimes {
-class                          downtime {
+namespace downtimes {
+class downtime {
  public:
-                               downtime(
-                                 int type,
-                                 std::string const& host_name,
-                                 time_t entry_time,
-                                 std::string const& author,
-                                 std::string const& comment,
-                                 time_t start_time,
-                                 time_t end_time,
-                                 bool fixed,
-                                 uint64_t triggered_by,
-                                 int32_t duration,
-                                 uint64_t downtime_id);
-                               downtime(downtime const& other) = delete;
-                               downtime(downtime&& other) = delete;
-  virtual                      ~downtime();
+  enum type {
+    service_downtime = 1,
+    host_downtime = 2,
+    any_downtime = 3
+  };
+  downtime(type type,
+           std::string const& host_name,
+           time_t entry_time,
+           std::string const& author,
+           std::string const& comment,
+           time_t start_time,
+           time_t end_time,
+           bool fixed,
+           uint64_t triggered_by,
+           int32_t duration,
+           uint64_t downtime_id);
+  downtime(downtime const& other) = delete;
+  downtime(downtime&& other) = delete;
+  virtual ~downtime();
 
-  int                          get_type() const;
-  virtual bool                 is_stale() const = 0;
-  virtual void                 schedule() = 0;
-  virtual int                  unschedule() = 0;
-  virtual int                  subscribe() = 0;
-  virtual int                  handle() = 0;
-  std::string const&           get_hostname() const;
-  virtual void                 print(std::ostream& os) const = 0;
-  virtual void                 retention(std::ostream& os) const = 0;
-  std::string const&           get_author() const;
-  std::string const&           get_comment() const;
-  uint64_t                     get_downtime_id() const;
-  uint64_t                     get_triggered_by() const;
-  bool                         is_fixed() const;
-  time_t                       get_entry_time() const;
-  time_t                       get_start_time() const;
-  time_t                       get_end_time() const;
-  int32_t                      get_duration() const;
-  bool                         is_in_effect() const;
-  void                         start_flex_downtime();
+  type get_type() const;
+  virtual bool is_stale() const = 0;
+  virtual void schedule() = 0;
+  virtual int unschedule() = 0;
+  virtual int subscribe() = 0;
+  virtual int handle() = 0;
+  std::string const& get_hostname() const;
+  virtual void print(std::ostream& os) const = 0;
+  virtual void retention(std::ostream& os) const = 0;
+  std::string const& get_author() const;
+  std::string const& get_comment() const;
+  uint64_t get_downtime_id() const;
+  uint64_t get_triggered_by() const;
+  bool is_fixed() const;
+  time_t get_entry_time() const;
+  time_t get_start_time() const;
+  time_t get_end_time() const;
+  int32_t get_duration() const;
+  bool is_in_effect() const;
+  void start_flex_downtime();
 
  private:
-  int                          _type;
+  type _type;
 
  protected:
-  void                         _set_in_effect(bool in_effect);
-  uint64_t                     _get_comment_id() const;
+  void _set_in_effect(bool in_effect);
+  uint64_t _get_comment_id() const;
 
-  std::string                  _hostname;
-  time_t                       _entry_time;
-  std::string                  _author;
-  std::string                  _comment;
-  time_t                       _start_time;
-  time_t                       _end_time;
-  bool                         _fixed;
-  uint64_t                     _triggered_by;
-  int32_t                      _duration;
-  uint64_t                     _downtime_id;
-  bool                         _in_effect;
-  uint64_t                     _comment_id;
-  int                          _start_flex_downtime;
-  bool                         _incremented_pending_downtime;
+  std::string _hostname;
+  time_t _entry_time;
+  std::string _author;
+  std::string _comment;
+  time_t _start_time;
+  time_t _end_time;
+  bool _fixed;
+  uint64_t _triggered_by;
+  int32_t _duration;
+  uint64_t _downtime_id;
+  bool _in_effect;
+  uint64_t _comment_id;
+  int _start_flex_downtime;
+  bool _incremented_pending_downtime;
 };
 }
 
 CCE_END()
 
-int                            handle_scheduled_downtime_by_id(
-                                 uint64_t downtime_id);
+int handle_scheduled_downtime_by_id(uint64_t downtime_id);
 
-std::ostream& operator<<(std::ostream& os, com::centreon::engine::downtimes::downtime const& dt);
+std::ostream& operator<<(std::ostream& os,
+                         com::centreon::engine::downtimes::downtime const& dt);
 
-#endif // !CCE_DOWNTIMES_DOWTIME_HH
+#endif  // !CCE_DOWNTIMES_DOWTIME_HH

--- a/inc/com/centreon/engine/downtimes/downtime_manager.hh
+++ b/inc/com/centreon/engine/downtimes/downtime_manager.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Centreon (https://www.centreon.com/)
+ * Copyright 2019 - 2020 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,88 +18,85 @@
  */
 
 #ifndef CCE_DOWNTIMES_DOWTIME_MANAGER_HH
-#  define CCE_DOWNTIMES_DOWTIME_MANAGER_HH
+#define CCE_DOWNTIMES_DOWTIME_MANAGER_HH
 
 #include <map>
 #include "com/centreon/engine/downtimes/downtime.hh"
 
 CCE_BEGIN()
 
-namespace                           downtimes {
-class                               downtime_manager {
+namespace downtimes {
+class downtime_manager {
  public:
-  static downtime_manager&          instance() {
+  static downtime_manager& instance() {
     static downtime_manager instance;
     return instance;
   }
-  std::multimap<time_t, std::shared_ptr<downtime>> const&
-                                    get_scheduled_downtimes() const;
+  std::multimap<time_t, std::shared_ptr<downtime> > const&
+      get_scheduled_downtimes() const;
 
-  void                              delete_downtime(int type, uint64_t downtime_id);
-  int                               unschedule_downtime(int type, uint64_t downtime_id);
-  std::shared_ptr<downtime>         find_downtime(int type, uint64_t downtime_id);
-  int                               check_pending_flex_host_downtime(host* hst);
-  int                               check_pending_flex_service_downtime(service* svc);
-  void                              add_downtime(downtime* dt) noexcept;
-  void                              clear_scheduled_downtimes();
-  int                               check_for_expired_downtime();
-  int                               delete_downtime_by_hostname_service_description_start_time_comment(
-                                      std::string const& hostname,
-                                      std::string const& service_description,
-                                      time_t start_time,
-                                      std::string const& comment);
-  void                              insert_downtime(std::shared_ptr<downtime> dt);
-  int                               delete_host_downtime(uint64_t downtime_id);
-  int                               delete_service_downtime(uint64_t downtime_id);
-  void                              initialize_downtime_data();
-  int                               xdddefault_validate_downtime_data();
-  uint64_t                          get_next_downtime_id();
-  downtime*                         add_new_host_downtime(std::string const& host_name,
-                                      time_t             entry_time,
-                                      char const*        author,
-                                      char const*        comment_data,
-                                      time_t             start_time,
-                                      time_t             end_time,
-                                      bool               fixed,
-                                      uint64_t           triggered_by,
-                                      unsigned long      duration,
-                                      uint64_t*          downtime_id);
-  downtime*                         add_new_service_downtime(
-                                      std::string const& host_name,
-                                      std::string const& service_description,
-                                      time_t entry_time,
-                                      std::string const& author,
-                                      std::string const& comment_data,
-                                      time_t start_time,
-                                      time_t end_time,
-                                      bool fixed,
-                                      uint64_t triggered_by,
-                                      unsigned long duration,
-                                      uint64_t* downtime_id);
-  int                               schedule_downtime(
-                                      int                type,
-                                      std::string const& host_name,
-                                      std::string const& service_description,
-                                      time_t             entry_time,
-                                      char const*        author,
-                                      char const*        comment_data,
-                                      time_t             start_time,
-                                      time_t             end_time,
-                                      bool               fixed,
-                                      uint64_t           triggered_by,
-                                      unsigned long      duration,
-                                      uint64_t*          new_downtime_id);
-  int                               register_downtime(int type, uint64_t downtime_id);
+  void delete_downtime(downtime::type type, uint64_t downtime_id);
+  int unschedule_downtime(downtime::type type, uint64_t downtime_id);
+  std::shared_ptr<downtime> find_downtime(downtime::type type,
+                                          uint64_t downtime_id);
+  int check_pending_flex_host_downtime(host* hst);
+  int check_pending_flex_service_downtime(service* svc);
+  void add_downtime(downtime* dt) noexcept;
+  void clear_scheduled_downtimes();
+  int check_for_expired_downtime();
+  int delete_downtime_by_hostname_service_description_start_time_comment(
+      std::string const& hostname,
+      std::string const& service_description,
+      time_t start_time,
+      std::string const& comment);
+  void insert_downtime(std::shared_ptr<downtime> dt);
+  int delete_host_downtime(uint64_t downtime_id);
+  int delete_service_downtime(uint64_t downtime_id);
+  void initialize_downtime_data();
+  int xdddefault_validate_downtime_data();
+  uint64_t get_next_downtime_id();
+  downtime* add_new_host_downtime(std::string const& host_name,
+                                  time_t entry_time,
+                                  char const* author,
+                                  char const* comment_data,
+                                  time_t start_time,
+                                  time_t end_time,
+                                  bool fixed,
+                                  uint64_t triggered_by,
+                                  unsigned long duration,
+                                  uint64_t* downtime_id);
+  downtime* add_new_service_downtime(std::string const& host_name,
+                                     std::string const& service_description,
+                                     time_t entry_time,
+                                     std::string const& author,
+                                     std::string const& comment_data,
+                                     time_t start_time,
+                                     time_t end_time,
+                                     bool fixed,
+                                     uint64_t triggered_by,
+                                     unsigned long duration,
+                                     uint64_t* downtime_id);
+  int schedule_downtime(downtime::type type,
+                        std::string const& host_name,
+                        std::string const& service_description,
+                        time_t entry_time,
+                        char const* author,
+                        char const* comment_data,
+                        time_t start_time,
+                        time_t end_time,
+                        bool fixed,
+                        uint64_t triggered_by,
+                        unsigned long duration,
+                        uint64_t* new_downtime_id);
+  int register_downtime(downtime::type type, uint64_t downtime_id);
 
  private:
-                                    downtime_manager() = default;
-  std::multimap<time_t, std::shared_ptr<downtime>>
-                                    _scheduled_downtimes;
-  uint64_t                          _next_id;
+  downtime_manager() = default;
+  std::multimap<time_t, std::shared_ptr<downtime> > _scheduled_downtimes;
+  uint64_t _next_id;
 };
 }
 
 CCE_END()
 
-
-#endif // !CCE_DOWNTIMES_DOWNTIME_MANAGER_HH
+#endif  // !CCE_DOWNTIMES_DOWNTIME_MANAGER_HH

--- a/inc/com/centreon/engine/events/timed_event.hh
+++ b/inc/com/centreon/engine/events/timed_event.hh
@@ -2,7 +2,7 @@
 ** Copyright 2007-2008 Ethan Galstad
 ** Copyright 2007,2010 Andreas Ericsson
 ** Copyright 2010      Max Schubert
-** Copyright 2011-2013 Merethis
+** Copyright 2011-2020 Centreon
 **
 ** This file is part of Centreon Engine.
 **
@@ -21,12 +21,13 @@
 */
 
 #ifndef CCE_EVENTS_TIMED_EVENT_HH
-#  define CCE_EVENTS_TIMED_EVENT_HH
+#define CCE_EVENTS_TIMED_EVENT_HH
 
-#  include <deque>
-#  include <stdint.h>
-#  include <time.h>
-#  include "com/centreon/engine/namespace.hh"
+#include <deque>
+#include <stdint.h>
+#include <time.h>
+#include "com/centreon/engine/downtimes/downtime.hh"
+#include "com/centreon/engine/namespace.hh"
 
 CCE_BEGIN()
 class timed_event;
@@ -35,92 +36,89 @@ CCE_END()
 typedef std::deque<com::centreon::engine::timed_event*> timed_event_list;
 
 CCE_BEGIN()
-class                        timed_event{
+class timed_event {
  public:
-  enum                priority {
+  enum priority {
     low = 0,
     high = 1,
     priority_num
   };
-                            timed_event();
-                            timed_event(
-                                uint32_t event_type,
-                                time_t run_time,
-                                bool recurring,
-                                unsigned long event_interval,
-                                void* timing_func,
-                                bool compensate_for_time_change,
-                                void* event_data,
-                                void* event_args,
-                                int32_t event_options);
+  timed_event();
+  timed_event(uint32_t event_type,
+              time_t run_time,
+              bool recurring,
+              unsigned long event_interval,
+              void* timing_func,
+              bool compensate_for_time_change,
+              void* event_data,
+              void* event_args,
+              int32_t event_options);
 
-  uint32_t                   event_type;
-  time_t                     run_time;
-  bool                       recurring;
-  unsigned long              event_interval;
-  bool                       compensate_for_time_change;
-  void*                      timing_func;
-  void*                      event_data;
-  void*                      event_args;
-  int32_t                    event_options;
+  uint32_t event_type;
+  time_t run_time;
+  bool recurring;
+  unsigned long event_interval;
+  bool compensate_for_time_change;
+  void* timing_func;
+  void* event_data;
+  void* event_args;
+  int32_t event_options;
 
-  static timed_event_list    event_list_high;
-  static timed_event_list    event_list_low;
+  static timed_event_list event_list_high;
+  static timed_event_list event_list_low;
 
-  static timed_event*        find_event(timed_event::priority, uint32_t event, void *data);
+  static timed_event* find_event(timed_event::priority,
+                                 uint32_t event,
+                                 void* data);
   void schedule(bool high_priority);
 };
 CCE_END()
 
-#  ifdef __cplusplus
+#ifdef __cplusplus
 extern "C" {
-#  endif /* C++ */
+#endif /* C++ */
 
-void add_event(
-       com::centreon::engine::timed_event* event,
-       com::centreon::engine::timed_event::priority priority);
-time_t adjust_timestamp_for_time_change(
-       time_t last_time,
-       time_t current_time,
-       uint64_t time_difference,
-       time_t ts);
-void compensate_for_system_time_change(
-       unsigned long last_time,
-       unsigned long current_time);
-int  handle_timed_event(com::centreon::engine::timed_event* event);
-void remove_event(
-  com::centreon::engine::timed_event* event,
-  com::centreon::engine::timed_event::priority priority);
-void reschedule_event(
-  com::centreon::engine::timed_event* event,
-  com::centreon::engine::timed_event::priority priority);
+void add_event(com::centreon::engine::timed_event* event,
+               com::centreon::engine::timed_event::priority priority);
+time_t adjust_timestamp_for_time_change(time_t last_time,
+                                        time_t current_time,
+                                        uint64_t time_difference,
+                                        time_t ts);
+void compensate_for_system_time_change(unsigned long last_time,
+                                       unsigned long current_time);
+int handle_timed_event(com::centreon::engine::timed_event* event);
+void remove_downtime(com::centreon::engine::downtimes::downtime::type type,
+                     uint64_t downtime_id);
+void remove_event(com::centreon::engine::timed_event* event,
+                  com::centreon::engine::timed_event::priority priority);
+void reschedule_event(com::centreon::engine::timed_event* event,
+                      com::centreon::engine::timed_event::priority priority);
 void resort_event_list(com::centreon::engine::timed_event::priority priority);
 
-#  ifdef __cplusplus
+#ifdef __cplusplus
 }
-#  endif /* C++ */
+#endif /* C++ */
 
-#  ifdef __cplusplus
+#ifdef __cplusplus
 
-#    include <ostream>
-#    include "com/centreon/engine/namespace.hh"
+#include <ostream>
+#include "com/centreon/engine/namespace.hh"
 
 CCE_BEGIN()
 
-namespace            events {
-  std::string const& name(timed_event const& evt);
+namespace events {
+std::string const& name(timed_event const& evt);
 }
 
 CCE_END()
 
-bool          operator==(
-  com::centreon::engine::timed_event const& obj1,
-  com::centreon::engine::timed_event const& obj2) throw ();
-bool          operator!=(
-  com::centreon::engine::timed_event const& obj1,
-  com::centreon::engine::timed_event const& obj2) throw ();
-std::ostream& operator<<(std::ostream& os, com::centreon::engine::timed_event const& obj);
+bool operator==(com::centreon::engine::timed_event const& obj1,
+                com::centreon::engine::timed_event const& obj2) throw();
+bool operator!=(com::centreon::engine::timed_event const& obj1,
+                com::centreon::engine::timed_event const& obj2) throw();
+std::ostream& operator<<(std::ostream& os,
+                         com::centreon::engine::timed_event const& obj);
 
-#  endif /* C++ */
+#endif /* C++ */
 
-#endif // !CCE_EVENTS_TIMED_EVENT_HH
+#endif  // !CCE_EVENTS_TIMED_EVENT_HH

--- a/modules/external_commands/src/commands.cc
+++ b/modules/external_commands/src/commands.cc
@@ -1026,7 +1026,7 @@ int cmd_schedule_downtime(int cmd, time_t entry_time, char* args) {
 
   case CMD_SCHEDULE_HOST_DOWNTIME:
     downtime_manager::instance().schedule_downtime(
-      HOST_DOWNTIME,
+      downtime::host_downtime,
       host_name,
       "",
       entry_time,
@@ -1042,7 +1042,7 @@ int cmd_schedule_downtime(int cmd, time_t entry_time, char* args) {
 
   case CMD_SCHEDULE_SVC_DOWNTIME:
     downtime_manager::instance().schedule_downtime(
-      SERVICE_DOWNTIME,
+      downtime::service_downtime,
       host_name,
       svc_description,
       entry_time,
@@ -1065,7 +1065,7 @@ int cmd_schedule_downtime(int cmd, time_t entry_time, char* args) {
       if (!it->second)
         continue;
       downtime_manager::instance().schedule_downtime(
-        SERVICE_DOWNTIME,
+        downtime::service_downtime,
         host_name,
         it->second->get_description(),
         entry_time,
@@ -1087,7 +1087,7 @@ int cmd_schedule_downtime(int cmd, time_t entry_time, char* args) {
          it != end;
          ++it)
       downtime_manager::instance().schedule_downtime(
-        HOST_DOWNTIME,
+        downtime::host_downtime,
         it->first,
         "",
         entry_time,
@@ -1117,7 +1117,7 @@ int cmd_schedule_downtime(int cmd, time_t entry_time, char* args) {
         if (!it2->second)
           continue;
         downtime_manager::instance().schedule_downtime(
-          SERVICE_DOWNTIME,
+          downtime::service_downtime,
           it2->second->get_hostname(),
           it2->second->get_description(),
           entry_time, author,
@@ -1147,7 +1147,7 @@ int cmd_schedule_downtime(int cmd, time_t entry_time, char* args) {
       if (last_host == temp_host)
         continue;
       downtime_manager::instance().schedule_downtime(
-        HOST_DOWNTIME,
+        downtime::host_downtime,
         it->first.first,
         "",
         entry_time,
@@ -1170,7 +1170,7 @@ int cmd_schedule_downtime(int cmd, time_t entry_time, char* args) {
          it != end;
          ++it)
       downtime_manager::instance().schedule_downtime(
-        SERVICE_DOWNTIME,
+        downtime::service_downtime,
         it->first.first,
         it->first.second,
         entry_time, author,
@@ -1186,7 +1186,7 @@ int cmd_schedule_downtime(int cmd, time_t entry_time, char* args) {
   case CMD_SCHEDULE_AND_PROPAGATE_HOST_DOWNTIME:
     /* schedule downtime for "parent" host */
     downtime_manager::instance().schedule_downtime(
-      HOST_DOWNTIME,
+      downtime::host_downtime,
       host_name,
       "",
       entry_time,
@@ -1215,7 +1215,7 @@ int cmd_schedule_downtime(int cmd, time_t entry_time, char* args) {
   case CMD_SCHEDULE_AND_PROPAGATE_TRIGGERED_HOST_DOWNTIME:
     /* schedule downtime for "parent" host */
     downtime_manager::instance().schedule_downtime(
-      HOST_DOWNTIME,
+      downtime::host_downtime,
       host_name,
       "",
       entry_time,
@@ -1253,17 +1253,17 @@ int cmd_delete_downtime(int cmd, char* args) {
   char* temp_ptr(nullptr);
 
   /* Get the id of the downtime to delete. */
-  if (nullptr == (temp_ptr = my_strtok(args,"\n")))
+  if (nullptr == (temp_ptr = my_strtok(args, "\n")))
     return ERROR;
 
   downtime_id = strtoul(temp_ptr, nullptr, 10);
 
   if (CMD_DEL_HOST_DOWNTIME == cmd)
-    downtime_manager::instance().unschedule_downtime(HOST_DOWNTIME, downtime_id);
+    return downtime_manager::instance().unschedule_downtime(downtime::host_downtime,
+                                                            downtime_id);
   else
-    downtime_manager::instance().unschedule_downtime(SERVICE_DOWNTIME, downtime_id);
-
-  return OK;
+    return downtime_manager::instance().unschedule_downtime(downtime::service_downtime,
+                                                            downtime_id);
 }
 
 /**
@@ -1282,16 +1282,16 @@ int cmd_delete_downtime_full(int cmd, char* args) {
   if (*temp_ptr)
     criterias.push_back(downtime_finder::criteria("host", temp_ptr));
   // Service description and downtime type.
-  int downtime_type;
+  downtime::type downtime_type;
   if (cmd == CMD_DEL_SVC_DOWNTIME_FULL) {
-    downtime_type = SERVICE_DOWNTIME;
+    downtime_type = downtime::service_downtime;
     if (!(temp_ptr = my_strtok(nullptr, ";")))
       return ERROR;
     if (*temp_ptr)
       criterias.push_back(downtime_finder::criteria("service", temp_ptr));
   }
   else {
-    downtime_type = HOST_DOWNTIME;
+    downtime_type = downtime::host_downtime;
     criterias.push_back(downtime_finder::criteria("service", ""));
   }
   // Start time.
@@ -2855,7 +2855,7 @@ void schedule_and_propagate_downtime(
 
     /* schedule downtime for this host */
     downtime_manager::instance().schedule_downtime(
-      HOST_DOWNTIME,
+      downtime::host_downtime,
       it->first,
       "",
       entry_time,

--- a/src/downtimes/downtime.cc
+++ b/src/downtimes/downtime.cc
@@ -38,7 +38,7 @@ using namespace com::centreon::engine::downtimes;
 using namespace com::centreon::engine::logging;
 using namespace com::centreon::engine::string;
 
-downtime::downtime(int type,
+downtime::downtime(downtime::type type,
                    std::string const& host_name,
                    time_t entry_time,
                    std::string const& author,
@@ -66,7 +66,7 @@ downtime::downtime(int type,
       _incremented_pending_downtime{false} {
 
   /* don't add triggered downtimes that don't have a valid parent */
-  if (triggered_by > 0 && !downtime_manager::instance().find_downtime(ANY_DOWNTIME, triggered_by))
+  if (triggered_by > 0 && !downtime_manager::instance().find_downtime(downtime::any_downtime, triggered_by))
     throw engine_error()
         << "can not add triggered host downtime without a valid parent";
 
@@ -81,7 +81,7 @@ downtime::~downtime() {}
 /* handles scheduled downtime (id passed from timed event queue) */
 int handle_scheduled_downtime_by_id(uint64_t downtime_id) {
   std::shared_ptr<downtime> temp_downtime{
-      downtime_manager::instance().find_downtime(ANY_DOWNTIME, downtime_id)};
+      downtime_manager::instance().find_downtime(downtime::any_downtime, downtime_id)};
   /* find the downtime entry */
   if (!temp_downtime)
     return ERROR;
@@ -97,9 +97,9 @@ int handle_scheduled_downtime_by_id(uint64_t downtime_id) {
 /**
  * @brief  Get the downtime type
  *
- * @return an integer that can be HOST_DOWNTIME = 2 or SERVICE_DOWNTIME = 1
+ * @return an integer that can be downtime::host_downtime = 2 or downtime::service_downtime = 1
  */
-int downtime::get_type() const {
+downtime::type downtime::get_type() const {
   return _type;
 }
 

--- a/src/downtimes/downtime_finder.cc
+++ b/src/downtimes/downtime_finder.cc
@@ -81,11 +81,11 @@ downtime_finder::result_set downtime_finder::find_matching_all(
          it != end;
          ++it) {
       switch (dt.second->get_type()) {
-        case HOST_DOWNTIME:
+        case downtime::host_downtime:
           if (!_match_criteria(*std::static_pointer_cast<host_downtime>(dt.second), *it))
             matched_all = false;
           break;
-        case SERVICE_DOWNTIME:
+        case downtime::service_downtime:
           if (!_match_criteria(*std::static_pointer_cast<service_downtime>(dt.second), *it))
             matched_all = false;
           break;

--- a/src/downtimes/host_downtime.cc
+++ b/src/downtimes/host_downtime.cc
@@ -43,7 +43,7 @@ host_downtime::host_downtime(std::string const& host_name,
                              uint64_t triggered_by,
                              int32_t duration,
                              uint64_t downtime_id)
-    : downtime(HOST_DOWNTIME,
+    : downtime(downtime::host_downtime,
                host_name,
                entry_time,
                author,
@@ -59,7 +59,7 @@ host_downtime::~host_downtime() {
   comment::delete_comment(_get_comment_id());
   /* send data to event broker */
   broker_downtime_data(NEBTYPE_DOWNTIME_DELETE, NEBFLAG_NONE, NEBATTR_NONE,
-                       HOST_DOWNTIME, _hostname.c_str(), nullptr, _entry_time,
+                       downtime::host_downtime, _hostname.c_str(), nullptr, _entry_time,
                        _author.c_str(), _comment.c_str(), get_start_time(),
                        get_end_time(), is_fixed(), get_triggered_by(),
                        get_duration(), get_downtime_id(), nullptr);
@@ -496,7 +496,7 @@ void host_downtime::schedule() {
 
   /* send data to event broker */
   broker_downtime_data(NEBTYPE_DOWNTIME_LOAD, NEBFLAG_NONE, NEBATTR_NONE,
-                       HOST_DOWNTIME, _hostname.c_str(), nullptr, _entry_time,
+                       downtime::host_downtime, _hostname.c_str(), nullptr, _entry_time,
                        _author.c_str(), _comment.c_str(), _start_time, _end_time, _fixed,
                        _triggered_by, _duration, _downtime_id, nullptr);
 }

--- a/src/downtimes/service_downtime.cc
+++ b/src/downtimes/service_downtime.cc
@@ -47,21 +47,21 @@ service_downtime::service_downtime(std::string const& host_name,
                                    uint64_t triggered_by,
                                    int32_t duration,
                                    uint64_t downtime_id)
-    : downtime{SERVICE_DOWNTIME, host_name,  entry_time, author,
+    : downtime{downtime::service_downtime, host_name,  entry_time, author,
                comment_data,     start_time, end_time,   fixed,
                triggered_by,     duration,   downtime_id},
       _service_description{service_desc} {}
 
 /* finds a specific service downtime entry */
 downtime* find_service_downtime(uint64_t downtime_id) {
-  return downtime_manager::instance().find_downtime(SERVICE_DOWNTIME, downtime_id).get();
+  return downtime_manager::instance().find_downtime(downtime::service_downtime, downtime_id).get();
 }
 
 service_downtime::~service_downtime() {
   comment::delete_comment(_get_comment_id());
   /* send data to event broker */
   broker_downtime_data(
-      NEBTYPE_DOWNTIME_DELETE, NEBFLAG_NONE, NEBATTR_NONE, SERVICE_DOWNTIME,
+      NEBTYPE_DOWNTIME_DELETE, NEBFLAG_NONE, NEBATTR_NONE, downtime::service_downtime,
       get_hostname().c_str(), get_service_description().c_str(), _entry_time,
       get_author().c_str(), get_comment().c_str(), get_start_time(),
       get_end_time(), is_fixed(), get_triggered_by(), get_duration(),
@@ -538,7 +538,7 @@ void service_downtime::schedule() {
 
   /* send data to event broker */
   broker_downtime_data(NEBTYPE_DOWNTIME_LOAD, NEBFLAG_NONE, NEBATTR_NONE,
-                       SERVICE_DOWNTIME, _hostname.c_str(),
+                       downtime::service_downtime, _hostname.c_str(),
                        _service_description.c_str(), _entry_time, _author.c_str(),
                        _comment.c_str(), _start_time, _end_time, _fixed, _triggered_by,
                        _duration, _downtime_id, nullptr);

--- a/src/events/timed_event.cc
+++ b/src/events/timed_event.cc
@@ -788,6 +788,36 @@ int handle_timed_event(timed_event* event) {
 }
 
 /**
+ * remove from scheduled events, the downtime with the given downtime_id if
+ * its type matches with the one provided.
+ *
+ * @param type The downtime type (ANY_DOWNTIME, HOST_DOWNTIME, SERVICE_DOWNTIME)
+ * @param downtime_id
+ */
+void remove_downtime(downtime::type type, uint64_t downtime_id) {
+  logger(dbg_functions, basic)
+    << "timed_event::remove_downtime()";
+
+  for (auto it = timed_event::event_list_high.begin(),
+            end = timed_event::event_list_high.end();
+       it != end;
+       ++it) {
+    if ((*it)->event_type != EVENT_SCHEDULED_DOWNTIME)
+      continue;
+    if (((uint64_t)(*it)->event_data) == downtime_id) {
+      // send event data to broker.
+      broker_timed_event(NEBTYPE_TIMEDEVENT_REMOVE,
+                         NEBFLAG_NONE,
+                         NEBATTR_NONE,
+                         *it,
+                         nullptr);
+      timed_event::event_list_high.erase(it);
+      break;
+    }
+  }
+}
+
+/**
  *  Remove an event from the queue.
  *
  *  @param[in]     event           The event to remove.

--- a/src/retention/applier/downtime.cc
+++ b/src/retention/applier/downtime.cc
@@ -63,7 +63,7 @@ void applier::downtime::_add_host_downtime(
     obj.duration(),
     obj.downtime_id())};
   dt->schedule();
-  downtimes::downtime_manager::instance().register_downtime(HOST_DOWNTIME, obj.downtime_id());
+  downtimes::downtime_manager::instance().register_downtime(downtimes::downtime::host_downtime, obj.downtime_id());
 }
 
 /**
@@ -86,5 +86,5 @@ void applier::downtime::_add_service_downtime(
     obj.duration(),
     obj.downtime_id())};
   dt->schedule();
-  downtimes::downtime_manager::instance().register_downtime(SERVICE_DOWNTIME, obj.downtime_id());
+  downtimes::downtime_manager::instance().register_downtime(downtimes::downtime::service_downtime, obj.downtime_id());
 }


### PR DESCRIPTION
Add 100 downtimes on 100 hosts
Remove 20 of them.
Wait for them to start all.
Verify there are exactly 80 downtimes running.