### PR TITLE
fix(downtime): Removing downtimes produced memory issues

### DIFF
--- a/doc/release_notes/engine19.10.rst
+++ b/doc/release_notes/engine19.10.rst
@@ -6,6 +6,11 @@ Centreon Engine 19.10.11
 Bug fixes
 *********
 
+Downtime cancellation was buggy
+===============================
+
+The downtime cancellation is fixed now.
+
 TOTALHOST* TOTALSERVICES macros
 ===============================
 

--- a/inc/com/centreon/engine/common.hh
+++ b/inc/com/centreon/engine/common.hh
@@ -212,11 +212,6 @@
 #define CMD_DEL_SVC_DOWNTIME_FULL 502
 #define CMD_CUSTOM_COMMAND 999
 
-/* Scheduled downtime types. */
-#define SERVICE_DOWNTIME 1 /* Service downtime. */
-#define HOST_DOWNTIME 2    /* Host downtime. */
-#define ANY_DOWNTIME 3     /* Host or service downtime. */
-
 /* Acknowledgement types. */
 #define HOST_ACKNOWLEDGEMENT 0
 #define SERVICE_ACKNOWLEDGEMENT 1

--- a/inc/com/centreon/engine/downtimes/downtime.hh
+++ b/inc/com/centreon/engine/downtimes/downtime.hh
@@ -30,7 +30,12 @@ CCE_BEGIN()
 namespace downtimes {
 class downtime {
  public:
-  downtime(int type,
+  enum type {
+    service_downtime = 1,
+    host_downtime = 2,
+    any_downtime = 3
+  };
+  downtime(type type,
            std::string const& host_name,
            time_t entry_time,
            std::string const& author,
@@ -41,11 +46,11 @@ class downtime {
            uint64_t triggered_by,
            int32_t duration,
            uint64_t downtime_id);
-  downtime(downtime const& other) = delete;
-  downtime(downtime&& other) = delete;
+  downtime(downtime const&) = delete;
+  downtime(downtime&&) = delete;
   virtual ~downtime();
 
-  int get_type() const;
+  type get_type() const;
   virtual bool is_stale() const = 0;
   virtual void schedule() = 0;
   virtual int unschedule() = 0;
@@ -67,7 +72,7 @@ class downtime {
   void start_flex_downtime();
 
  private:
-  int _type;
+  type _type;
 
  protected:
   void _set_in_effect(bool in_effect);

--- a/inc/com/centreon/engine/downtimes/downtime_manager.hh
+++ b/inc/com/centreon/engine/downtimes/downtime_manager.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Centreon (https://www.centreon.com/)
+ * Copyright 2019 - 2020 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,9 +35,9 @@ class downtime_manager {
   std::multimap<time_t, std::shared_ptr<downtime>> const&
   get_scheduled_downtimes() const;
 
-  void delete_downtime(int type, uint64_t downtime_id);
-  int unschedule_downtime(int type, uint64_t downtime_id);
-  std::shared_ptr<downtime> find_downtime(int type, uint64_t downtime_id);
+  void delete_downtime(downtime::type type, uint64_t downtime_id);
+  int unschedule_downtime(downtime::type type, uint64_t downtime_id);
+  std::shared_ptr<downtime> find_downtime(downtime::type type, uint64_t downtime_id);
   int check_pending_flex_host_downtime(host* hst);
   int check_pending_flex_service_downtime(service* svc);
   void add_downtime(downtime* dt) noexcept;
@@ -49,8 +49,6 @@ class downtime_manager {
       time_t start_time,
       std::string const& comment);
   void insert_downtime(std::shared_ptr<downtime> dt);
-  int delete_host_downtime(uint64_t downtime_id);
-  int delete_service_downtime(uint64_t downtime_id);
   void initialize_downtime_data();
   int xdddefault_validate_downtime_data();
   uint64_t get_next_downtime_id();
@@ -75,7 +73,7 @@ class downtime_manager {
                                      uint64_t triggered_by,
                                      unsigned long duration,
                                      uint64_t* downtime_id);
-  int schedule_downtime(int type,
+  int schedule_downtime(downtime::type type,
                         std::string const& host_name,
                         std::string const& service_description,
                         time_t entry_time,
@@ -87,7 +85,7 @@ class downtime_manager {
                         uint64_t triggered_by,
                         unsigned long duration,
                         uint64_t* new_downtime_id);
-  int register_downtime(int type, uint64_t downtime_id);
+  int register_downtime(downtime::type type, uint64_t downtime_id);
 
  private:
   downtime_manager() = default;

--- a/inc/com/centreon/engine/events/loop.hh
+++ b/inc/com/centreon/engine/events/loop.hh
@@ -70,6 +70,7 @@ class loop {
   void add_event(timed_event* event, priority priority);
   void compensate_for_system_time_change(unsigned long last_time,
                                          unsigned long current_time);
+  void remove_downtime(uint64_t downtime_id);
   void remove_event(timed_event* event, priority priority);
   void remove_events(priority, uint32_t event_type, void* data) noexcept;
   timed_event* find_event(priority priority,

--- a/inc/com/centreon/engine/events/timed_event.hh
+++ b/inc/com/centreon/engine/events/timed_event.hh
@@ -2,7 +2,7 @@
 ** Copyright 2007-2008      Ethan Galstad
 ** Copyright 2007,2010      Andreas Ericsson
 ** Copyright 2010           Max Schubert
-** Copyright 2011-2013,2019 Centreon
+** Copyright 2011-2020i     Centreon
 **
 ** This file is part of Centreon Engine.
 **
@@ -23,9 +23,10 @@
 #ifndef CCE_EVENTS_TIMED_EVENT_HH
 #define CCE_EVENTS_TIMED_EVENT_HH
 
+#include <deque>
 #include <stdint.h>
 #include <time.h>
-#include <string>
+#include "com/centreon/engine/downtimes/downtime.hh"
 #include "com/centreon/engine/namespace.hh"
 
 CCE_BEGIN()

--- a/src/downtimes/downtime.cc
+++ b/src/downtimes/downtime.cc
@@ -37,7 +37,7 @@ using namespace com::centreon::engine::downtimes;
 using namespace com::centreon::engine::logging;
 using namespace com::centreon::engine::string;
 
-downtime::downtime(int type,
+downtime::downtime(downtime::type type,
                    std::string const& host_name,
                    time_t entry_time,
                    std::string const& author,
@@ -65,7 +65,7 @@ downtime::downtime(int type,
       _incremented_pending_downtime{false} {
   /* don't add triggered downtimes that don't have a valid parent */
   if (triggered_by > 0 &&
-      !downtime_manager::instance().find_downtime(ANY_DOWNTIME, triggered_by))
+      !downtime_manager::instance().find_downtime(downtime::any_downtime, triggered_by))
     throw engine_error()
         << "can not add triggered host downtime without a valid parent";
 
@@ -80,7 +80,7 @@ downtime::~downtime() {}
 /* handles scheduled downtime (id passed from timed event queue) */
 int handle_scheduled_downtime_by_id(uint64_t downtime_id) {
   std::shared_ptr<downtime> temp_downtime{
-      downtime_manager::instance().find_downtime(ANY_DOWNTIME, downtime_id)};
+      downtime_manager::instance().find_downtime(downtime::any_downtime, downtime_id)};
   /* find the downtime entry */
   if (!temp_downtime)
     return ERROR;
@@ -98,7 +98,7 @@ int handle_scheduled_downtime_by_id(uint64_t downtime_id) {
  *
  * @return an integer that can be HOST_DOWNTIME = 2 or SERVICE_DOWNTIME = 1
  */
-int downtime::get_type() const {
+downtime::type downtime::get_type() const {
   return _type;
 }
 

--- a/src/downtimes/downtime_finder.cc
+++ b/src/downtimes/downtime_finder.cc
@@ -80,12 +80,12 @@ downtime_finder::result_set downtime_finder::find_matching_all(
          end(criterias.end());
          it != end; ++it) {
       switch (dt.second->get_type()) {
-        case HOST_DOWNTIME:
+        case downtime::host_downtime:
           if (!_match_criteria(
                   *std::static_pointer_cast<host_downtime>(dt.second), *it))
             matched_all = false;
           break;
-        case SERVICE_DOWNTIME:
+        case downtime::service_downtime:
           if (!_match_criteria(
                   *std::static_pointer_cast<service_downtime>(dt.second), *it))
             matched_all = false;

--- a/src/downtimes/host_downtime.cc
+++ b/src/downtimes/host_downtime.cc
@@ -42,7 +42,7 @@ host_downtime::host_downtime(std::string const& host_name,
                              uint64_t triggered_by,
                              int32_t duration,
                              uint64_t downtime_id)
-    : downtime(HOST_DOWNTIME,
+    : downtime(downtime::host_downtime,
                host_name,
                entry_time,
                author,
@@ -58,7 +58,7 @@ host_downtime::~host_downtime() {
   comment::delete_comment(_get_comment_id());
   /* send data to event broker */
   broker_downtime_data(NEBTYPE_DOWNTIME_DELETE, NEBFLAG_NONE, NEBATTR_NONE,
-                       HOST_DOWNTIME, _hostname.c_str(), nullptr, _entry_time,
+                       downtime::host_downtime, _hostname.c_str(), nullptr, _entry_time,
                        _author.c_str(), _comment.c_str(), get_start_time(),
                        get_end_time(), is_fixed(), get_triggered_by(),
                        get_duration(), get_downtime_id(), nullptr);
@@ -403,7 +403,8 @@ int host_downtime::handle() {
     }
 
     /* delete downtime entry */
-    downtime_manager::instance().delete_host_downtime(get_downtime_id());
+    downtime_manager::instance().delete_downtime(downtime::host_downtime,
+                                                 get_downtime_id());
   }
   /* else we are just starting the scheduled downtime */
   else {
@@ -474,7 +475,7 @@ void host_downtime::schedule() {
 
   /* send data to event broker */
   broker_downtime_data(NEBTYPE_DOWNTIME_LOAD, NEBFLAG_NONE, NEBATTR_NONE,
-                       HOST_DOWNTIME, _hostname.c_str(), nullptr, _entry_time,
+                       downtime::host_downtime, _hostname.c_str(), nullptr, _entry_time,
                        _author.c_str(), _comment.c_str(), _start_time,
                        _end_time, _fixed, _triggered_by, _duration,
                        _downtime_id, nullptr);

--- a/src/downtimes/service_downtime.cc
+++ b/src/downtimes/service_downtime.cc
@@ -46,7 +46,7 @@ service_downtime::service_downtime(std::string const& host_name,
                                    uint64_t triggered_by,
                                    int32_t duration,
                                    uint64_t downtime_id)
-    : downtime{SERVICE_DOWNTIME, host_name,  entry_time, author,
+    : downtime{downtime::service_downtime, host_name,  entry_time, author,
                comment_data,     start_time, end_time,   fixed,
                triggered_by,     duration,   downtime_id},
       _service_description{service_desc} {}
@@ -54,7 +54,7 @@ service_downtime::service_downtime(std::string const& host_name,
 /* finds a specific service downtime entry */
 downtime* find_service_downtime(uint64_t downtime_id) {
   return downtime_manager::instance()
-      .find_downtime(SERVICE_DOWNTIME, downtime_id)
+      .find_downtime(downtime::service_downtime, downtime_id)
       .get();
 }
 
@@ -62,7 +62,7 @@ service_downtime::~service_downtime() {
   comment::delete_comment(_get_comment_id());
   /* send data to event broker */
   broker_downtime_data(
-      NEBTYPE_DOWNTIME_DELETE, NEBFLAG_NONE, NEBATTR_NONE, SERVICE_DOWNTIME,
+      NEBTYPE_DOWNTIME_DELETE, NEBFLAG_NONE, NEBATTR_NONE, downtime::service_downtime,
       get_hostname().c_str(), get_service_description().c_str(), _entry_time,
       get_author().c_str(), get_comment().c_str(), get_start_time(),
       get_end_time(), is_fixed(), get_triggered_by(), get_duration(),
@@ -435,7 +435,8 @@ int service_downtime::handle() {
     }
 
     /* delete downtime entry */
-    downtime_manager::instance().delete_service_downtime(get_downtime_id());
+    downtime_manager::instance().delete_downtime(downtime::service_downtime,
+                                                 get_downtime_id());
   }
   /* else we are just starting the scheduled downtime */
   else {
@@ -521,7 +522,7 @@ void service_downtime::schedule() {
 
   /* send data to event broker */
   broker_downtime_data(
-      NEBTYPE_DOWNTIME_LOAD, NEBFLAG_NONE, NEBATTR_NONE, SERVICE_DOWNTIME,
+      NEBTYPE_DOWNTIME_LOAD, NEBFLAG_NONE, NEBATTR_NONE, downtime::service_downtime,
       _hostname.c_str(), _service_description.c_str(), _entry_time,
       _author.c_str(), _comment.c_str(), _start_time, _end_time, _fixed,
       _triggered_by, _duration, _downtime_id, nullptr);

--- a/src/retention/applier/downtime.cc
+++ b/src/retention/applier/downtime.cc
@@ -55,8 +55,8 @@ void applier::downtime::_add_host_downtime(
       obj.start_time(), obj.end_time(), obj.fixed(), obj.triggered_by(),
       obj.duration(), obj.downtime_id())};
   dt->schedule();
-  downtimes::downtime_manager::instance().register_downtime(HOST_DOWNTIME,
-                                                            obj.downtime_id());
+  downtimes::downtime_manager::instance().register_downtime(
+      downtimes::downtime::host_downtime, obj.downtime_id());
 }
 
 /**
@@ -71,6 +71,6 @@ void applier::downtime::_add_service_downtime(
       obj.author(), obj.comment_data(), obj.start_time(), obj.end_time(),
       obj.fixed(), obj.triggered_by(), obj.duration(), obj.downtime_id())};
   dt->schedule();
-  downtimes::downtime_manager::instance().register_downtime(SERVICE_DOWNTIME,
-                                                            obj.downtime_id());
+  downtimes::downtime_manager::instance().register_downtime(
+      downtimes::downtime::service_downtime, obj.downtime_id());
 }


### PR DESCRIPTION
# Pull Request Template

## Description

When downtimes were removed, there were some memory issues and downtimes were badly removed. This is fixed with this patch.

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 18.10.x
- [ ] 19.04.x
- [X] 19.10.x
- [X] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Create 100 hosts. Apply on each of them one downtime. All the downtimes have to start at the same time. Then, before they all start, remove 20 of them.

When it is time, you should have exactly 80 downtimes that start.
