### PR TITLE
Scheduler regression

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,15 @@
 cmake_minimum_required(VERSION 2.8)
 project("Centreon Engine" C CXX)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+
+# With libasan
+option(WITH_ASAN "Add the libasan to check memory leaks and other memory issues." OFF)
+if (WITH_ASAN)
+  set(CMAKE_BUILD_TYPE Debug)
+  set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+  set (CMAKE_LINKER_FLAGS_DEBUG "${CMAKE_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+endif ()
+
 set(INC_DIR "${PROJECT_SOURCE_DIR}/inc")
 set(SCRIPT_DIR "${PROJECT_SOURCE_DIR}/scripts")
 set(SRC_DIR "${PROJECT_SOURCE_DIR}/src")

--- a/inc/com/centreon/engine/checks/checker.hh
+++ b/inc/com/centreon/engine/checks/checker.hh
@@ -53,14 +53,14 @@ class checker : public commands::command_listener {
            double latency = 0.0,
            bool scheduled_check = false,
            bool reschedule_check = false,
-           int* time_is_valid = NULL,
+           bool* time_is_valid = NULL,
            time_t* preferred_time = NULL);
   void run(service* svc,
            int check_options = CHECK_OPTION_NONE,
            double latency = 0.0,
            bool scheduled_check = false,
            bool reschedule_check = false,
-           int* time_is_valid = NULL,
+           bool* time_is_valid = NULL,
            time_t* preferred_time = NULL);
   void run_sync(host* hst,
                 host::host_state* check_result_code,

--- a/inc/com/centreon/engine/configuration/applier/scheduler.hh
+++ b/inc/com/centreon/engine/configuration/applier/scheduler.hh
@@ -45,8 +45,8 @@ class scheduler {
              difference<set_service> const& diff_services);
   static scheduler& instance();
   void clear();
-  void remove_host(configuration::host const& h);
-  void remove_service(configuration::service const& s);
+  void remove_host(uint64_t host_id);
+  void remove_service(uint64_t host_id, uint64_t service_id);
 
  private:
   scheduler();

--- a/inc/com/centreon/engine/events/timed_event.hh
+++ b/inc/com/centreon/engine/events/timed_event.hh
@@ -2,7 +2,7 @@
 ** Copyright 2007-2008      Ethan Galstad
 ** Copyright 2007,2010      Andreas Ericsson
 ** Copyright 2010           Max Schubert
-** Copyright 2011-2020i     Centreon
+** Copyright 2011-2020      Centreon
 **
 ** This file is part of Centreon Engine.
 **

--- a/inc/com/centreon/engine/host.hh
+++ b/inc/com/centreon/engine/host.hh
@@ -124,7 +124,7 @@ class host : public notifier {
                       double latency,
                       int scheduled_check,
                       int reschedule_check,
-                      int* time_is_valid,
+                      bool* time_is_valid,
                       time_t* preferred_time);
   void schedule_check(time_t check_time, int options);
   void check_for_flapping(bool update,
@@ -144,7 +144,7 @@ class host : public notifier {
   int handle_state();
   void update_performance_data();
   int verify_check_viability(int check_options,
-                             int* time_is_valid,
+                             bool* time_is_valid,
                              time_t* new_time);
   void grab_macros_r(nagios_macros* mac) override;
   bool operator==(host const& other) = delete;  // throw ();

--- a/inc/com/centreon/engine/service.hh
+++ b/inc/com/centreon/engine/service.hh
@@ -148,7 +148,7 @@ class service : public notifier {
                       double latency,
                       int scheduled_check,
                       int reschedule_check,
-                      int* time_is_valid,
+                      bool* time_is_valid,
                       time_t* preferred_time);
   void schedule_check(time_t check_time, int options);
   void set_flap(double percent_change,
@@ -163,7 +163,7 @@ class service : public notifier {
   void disable_flap_detection();
   void update_status(bool aggregated_dump) override;
   int verify_check_viability(int check_options,
-                             int* time_is_valid,
+                             bool* time_is_valid,
                              time_t* new_time);
   void grab_macros_r(nagios_macros* mac) override;
   int notify_contact(nagios_macros* mac,
@@ -230,10 +230,6 @@ class service : public notifier {
 };
 CCE_END()
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* C++ */
-
 com::centreon::engine::service* add_service(
     uint64_t host_id,
     uint64_t service_id,
@@ -286,9 +282,6 @@ com::centreon::engine::service* add_service(
     bool obsess_over,
     std::string const& timezone);
 
-#ifdef __cplusplus
-}
-
 std::ostream& operator<<(std::ostream& os,
                          com::centreon::engine::service const& obj);
 std::ostream& operator<<(std::ostream& os, service_map_unsafe const& obj);
@@ -303,7 +296,5 @@ std::pair<uint64_t, uint64_t> get_host_and_service_id(std::string const& host,
 uint64_t get_service_id(std::string const& host, std::string const& svc);
 
 CCE_END()
-
-#endif /* C++ */
 
 #endif  // !CCE_SERVICE_HH

--- a/src/checks/checker.cc
+++ b/src/checks/checker.cc
@@ -261,7 +261,7 @@ void checker::run(host* hst,
                   double latency,
                   bool scheduled_check,
                   bool reschedule_check,
-                  int* time_is_valid,
+                  bool* time_is_valid,
                   time_t* preferred_time) {
   logger(dbg_functions, basic)
       << "checker::run: hst=" << hst << ", check_options=" << check_options
@@ -453,7 +453,7 @@ void checker::run(service* svc,
                   double latency,
                   bool scheduled_check,
                   bool reschedule_check,
-                  int* time_is_valid,
+                  bool* time_is_valid,
                   time_t* preferred_time) {
   logger(dbg_functions, basic)
       << "checker::run: svc=" << svc << ", check_options=" << check_options

--- a/src/configuration/applier/host.cc
+++ b/src/configuration/applier/host.cc
@@ -424,7 +424,7 @@ void applier::host::remove_object(configuration::host const& obj) {
             obj.host_name(), "", (time_t)0, "");
 
     // Remove events related to this host.
-    applier::scheduler::instance().remove_host(obj);
+    applier::scheduler::instance().remove_host(obj.key());
 
     //remove host from hostgroup->members
     for (auto& it_h: it->second->get_parent_groups())

--- a/src/configuration/applier/scheduler.cc
+++ b/src/configuration/applier/scheduler.cc
@@ -205,9 +205,9 @@ void applier::scheduler::clear() {
  *
  *  @param[in] h  Host configuration.
  */
-void applier::scheduler::remove_host(configuration::host const& h) {
-  host_map const& hosts(engine::host::hosts);
-  host_map::const_iterator hst(hosts.find(h.host_name()));
+void applier::scheduler::remove_host(uint64_t host_id) {
+  host_id_map const& hosts(engine::host::hosts_by_id);
+  host_id_map::const_iterator hst(hosts.find(host_id));
   if (hst != hosts.end()) {
     std::vector<com::centreon::engine::host*> hvec;
     hvec.push_back(hst->second.get());
@@ -220,10 +220,9 @@ void applier::scheduler::remove_host(configuration::host const& h) {
  *
  *  @param[in] s  Service configuration.
  */
-void applier::scheduler::remove_service(configuration::service const& s) {
+void applier::scheduler::remove_service(uint64_t host_id, uint64_t service_id) {
   service_id_map const& services(engine::service::services_by_id);
-  service_id_map::const_iterator svc(
-      services.find({s.host_id(), s.service_id()}));
+  service_id_map::const_iterator svc(services.find({host_id, service_id}));
   if (svc != services.end()) {
     std::vector<engine::service*> svec;
     svec.push_back(svc->second.get());

--- a/src/configuration/applier/scheduler.cc
+++ b/src/configuration/applier/scheduler.cc
@@ -234,17 +234,17 @@ void applier::scheduler::remove_service(uint64_t host_id, uint64_t service_id) {
  *  Default constructor.
  */
 applier::scheduler::scheduler()
-    : _config(NULL),
-      _evt_check_reaper(NULL),
-      _evt_command_check(NULL),
-      _evt_hfreshness_check(NULL),
-      _evt_host_perfdata(NULL),
-      _evt_orphan_check(NULL),
-      _evt_reschedule_checks(NULL),
-      _evt_retention_save(NULL),
-      _evt_sfreshness_check(NULL),
-      _evt_service_perfdata(NULL),
-      _evt_status_save(NULL),
+    : _config(nullptr),
+      _evt_check_reaper(nullptr),
+      _evt_command_check(nullptr),
+      _evt_hfreshness_check(nullptr),
+      _evt_host_perfdata(nullptr),
+      _evt_orphan_check(nullptr),
+      _evt_reschedule_checks(nullptr),
+      _evt_retention_save(nullptr),
+      _evt_sfreshness_check(nullptr),
+      _evt_service_perfdata(nullptr),
+      _evt_status_save(nullptr),
       _old_auto_rescheduling_interval(0),
       _old_check_reaper_interval(0),
       _old_command_check_interval(0),
@@ -253,9 +253,7 @@ applier::scheduler::scheduler()
       _old_retention_update_interval(0),
       _old_service_freshness_check_interval(0),
       _old_service_perfdata_file_processing_interval(0),
-      _old_status_update_interval(0) {
-  memset(&scheduling_info, 0, sizeof(scheduling_info));
-}
+      _old_status_update_interval(0) {}
 
 /**
  *  Default destructor.

--- a/src/configuration/applier/service.cc
+++ b/src/configuration/applier/service.cc
@@ -507,7 +507,8 @@ void applier::service::remove_object(configuration::service const& obj) {
             host_name, service_description, (time_t)0, "");
 
     // Remove events related to this service.
-    applier::scheduler::instance().remove_service(obj);
+    applier::scheduler::instance().remove_service(obj.host_id(),
+                                                  obj.service_id());
 
     //remove service from servicegroup->members
     for (auto& it_s: it->second->get_parent_groups())

--- a/src/configuration/applier/state.cc
+++ b/src/configuration/applier/state.cc
@@ -1,5 +1,5 @@
 /*
-** Copyright 2011-2019 Centreon
+** Copyright 2011-2020 Centreon
 **
 ** This file is part of Centreon Engine.
 **
@@ -18,10 +18,13 @@
 */
 
 #include "com/centreon/engine/configuration/applier/state.hh"
+
 #include <unistd.h>
+
 #include <array>
 #include <cassert>
 #include <unordered_map>
+
 #include "com/centreon/engine/broker.hh"
 #include "com/centreon/engine/commands/connector.hh"
 #include "com/centreon/engine/config.hh"
@@ -165,8 +168,7 @@ void applier::state::clear() {
 /**
  *  Default constructor.
  */
-applier::state::state() : _config(nullptr), _processing_state(state_ready) {
-}
+applier::state::state() : _config(nullptr), _processing_state(state_ready) {}
 
 /**
  *  Destructor.

--- a/src/host.cc
+++ b/src/host.cc
@@ -1480,7 +1480,7 @@ int host::run_scheduled_check(int check_options, double latency) {
   time_t current_time = 0L;
   time_t preferred_time = 0L;
   time_t next_valid_time = 0L;
-  int time_is_valid = true;
+  bool time_is_valid = true;
 
   logger(dbg_functions, basic) << "run_scheduled_host_check_3x()";
 
@@ -1569,7 +1569,7 @@ int host::run_async_check(int check_options,
                           double latency,
                           int scheduled_check,
                           int reschedule_check,
-                          int* time_is_valid,
+                          bool* time_is_valid,
                           time_t* preferred_time) {
   try {
     checks::checker::instance().run(this, check_options, latency,
@@ -2119,7 +2119,7 @@ void host::update_performance_data() {
 
 /* checks viability of performing a host check */
 int host::verify_check_viability(int check_options,
-                                 int* time_is_valid,
+                                 bool* time_is_valid,
                                  time_t* new_time) {
   int result = OK;
   int perform_check = true;


### PR DESCRIPTION
# Pull Request Template

## Description

Some time ago, we changed how singletons are started. No more load() methods.
There was an impact on the scheduler because it initializes the schedule info when it is created whereas the schedule info is already initialized...

This fix does the job. A new one will come with the anomalydetection :smile: that will be better.

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [X] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

When the bug is there, the scheduler is going mad. If you configure engine with 2000 services,
you can see in the status.dat file many services (almost all) with a very big latency.

Fix the bug and latencies become numbers near of zero.
