### PR TITLE
fix(connector): timestamp is in milliseconds now.

### DIFF
--- a/doc/release_notes/engine20.04.rst
+++ b/doc/release_notes/engine20.04.rst
@@ -28,3 +28,11 @@ Notifications between two fixed contiguous downtimes
 
 It was possible to have notifications sent between the two downtimes even if
 the space duration is 0.
+
+Centreon connectors timeout
+===========================
+
+The timeout applied on checks execute by connectors were shorter than the
+timeout passed as parameter (near of 1s of difference). To fix this, timeouts
+are checked as milliseconds values now (more accurate) and the good duration is
+considered by connectors.

--- a/src/commands/connector.cc
+++ b/src/commands/connector.cc
@@ -595,11 +595,10 @@ void connector::_recv_query_execute(char const* data) {
     res.exit_status = process::normal;
     res.start_time = info->start_time;
 
-    time_t execution_time((res.end_time - res.start_time).to_seconds());
+    uint32_t execution_time((res.end_time - res.start_time).to_mseconds());
 
     // Check if the check timeout.
-    if (info->timeout > 0 &&
-        static_cast<uint32_t>(execution_time) > info->timeout) {
+    if (info->timeout > 0 && execution_time > info->timeout * 1000) {
       res.exit_status = process::timeout;
       res.output = "(Process Timeout)";
     }


### PR DESCRIPTION
# Pull Request Template

## Description

Same PR as MON-4969-timeout adapted to the master branch.