### PR TITLE
fix(connector): timestamp is in milliseconds now.

### DIFF
--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -34,7 +34,7 @@ include_directories("${INC_DIR}/compatibility")
 # Version.
 set(CENTREON_ENGINE_MAJOR 19)
 set(CENTREON_ENGINE_MINOR 04)
-set(CENTREON_ENGINE_PATCH 2)
+set(CENTREON_ENGINE_PATCH 3)
 set(CENTREON_ENGINE_VERSION "${CENTREON_ENGINE_MAJOR}.${CENTREON_ENGINE_MINOR}.${CENTREON_ENGINE_PATCH}")
 message(STATUS "Generating version header (${CENTREON_ENGINE_VERSION}).")
 configure_file("${INC_DIR}/com/centreon/engine/version.hh.in"

--- a/doc/release_notes/engine19.04.rst
+++ b/doc/release_notes/engine19.04.rst
@@ -1,4 +1,20 @@
 =======================
+Centreon Engine 19.04.3
+=======================
+
+*********
+Bug fixes
+*********
+
+Centreon connectors timeout
+===========================
+
+The timeout applied on checks execute by connectors were shorter than the
+timeout passed as parameter (near of 1s of difference). To fix this, timeouts
+are checked as milliseconds values now (more accurate) and the good duration is
+considered by connectors.
+
+=======================
 Centreon Engine 19.04.2
 =======================
 

--- a/src/commands/connector.cc
+++ b/src/commands/connector.cc
@@ -642,11 +642,10 @@ void connector::_recv_query_execute(char const* data) {
     res.exit_status = process::normal;
     res.start_time = info->start_time;
 
-    time_t execution_time((res.end_time - res.start_time).to_seconds());
+    unsigned int execution_time((res.end_time - res.start_time).to_mseconds());
 
     // Check if the check timeout.
-    if (info->timeout > 0
-        && static_cast<unsigned int>(execution_time) > info->timeout) {
+    if (info->timeout > 0 && execution_time > info->timeout * 1000) {
       res.exit_status = process::timeout;
       res.output = "(Process Timeout)";
     }


### PR DESCRIPTION
See branch MON-4969-timeout.