### PR TITLE
fix(notifier): A volatile service should not be notified when in dt

### DIFF
--- a/doc/release_notes/engine19.10.rst
+++ b/doc/release_notes/engine19.10.rst
@@ -14,6 +14,13 @@ timeout passed as parameter (near of 1s of difference). To fix this, timeouts
 are checked as milliseconds values now (more accurate) and the good duration is
 considered by connectors.
 
+Volatile services and notifications
+===================================
+
+This version of Engine fixes the following behabiour: if a service is volatile,
+configured to send normal notifications. It won't send anymore them if it is
+in downtime.
+
 ========================
 Centreon Engine 19.10.12
 ========================

--- a/src/notifier.cc
+++ b/src/notifier.cc
@@ -212,6 +212,15 @@ bool notifier::_is_notification_viable_normal(reason_type type
     return false;
   }
 
+  /* if this notifier is currently in a scheduled downtime period, don't send
+   * the notification */
+  if (is_in_downtime()) {
+    logger(dbg_notifications, more)
+        << "This notifier is currently in a scheduled downtime, so "
+           "we won't send notifications.";
+    return false;
+  }
+
   /* On volatile services notifications are always sent */
   if (get_is_volatile()) {
     logger(dbg_notifications, more)
@@ -228,15 +237,6 @@ bool notifier::_is_notification_viable_normal(reason_type type
     logger(dbg_notifications, more)
         << "This notifier shouldn't have notifications sent out "
            "at this time.";
-    return false;
-  }
-
-  /* if this notifier is currently in a scheduled downtime period, don't send
-   * the notification */
-  if (is_in_downtime()) {
-    logger(dbg_notifications, more)
-        << "This notifier is currently in a scheduled downtime, so "
-           "we won't send notifications.";
     return false;
   }
 

--- a/tests/notifications/service_normal_notification.cc
+++ b/tests/notifications/service_normal_notification.cc
@@ -1293,3 +1293,26 @@ TEST_F(ServiceNotification, RecoveryNotifEvenIfServiceAcknowledged) {
             OK);
   ASSERT_EQ(id + 1, _svc->get_next_notification_id());
 }
+
+TEST_F(ServiceNotification, SimpleVolatileServiceNotificationWithDowntime) {
+  std::unique_ptr<engine::timeperiod> tperiod{
+      new engine::timeperiod("tperiod", "alias")};
+  set_time(20000);
+
+  _svc->set_scheduled_downtime_depth(30);
+  _svc->set_is_volatile(true);
+  uint64_t id{_svc->get_next_notification_id()};
+  for (int i = 0; i < 7; ++i)
+    tperiod->days[i].push_back(std::make_shared<engine::timerange>(0, 86400));
+
+  std::unique_ptr<engine::serviceescalation> service_escalation{
+      new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0, "", 7, Uuid())};
+  _svc->set_notification_period_ptr(tperiod.get());
+
+  ASSERT_TRUE(service_escalation);
+  ASSERT_EQ(
+      _svc->notify(
+          notifier::reason_normal, "", "", notifier::notification_option_none),
+      OK);
+  ASSERT_EQ(id, _svc->get_next_notification_id());
+}


### PR DESCRIPTION
# Pull Request Template

## Description

There is a bug in Engine 19.10.x: When a service is volatile, configured to send notifications on critical, warning, recovery states, it sends notifications on those states even if it is in downtime.
This is wrong, in downtime notifications should not be sent.

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 18.10.x
- [ ] 19.04.x
- [X] 19.10.x
- [X] 20.04.x (master)
