### PR TITLE
enh(grpc): remove GRPC def, launch grpc only when needed...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -609,7 +609,6 @@ add_subdirectory(modules)
 add_subdirectory(src/retention)
 add_subdirectory(enginerpc)
 include_directories(enginerpc)
-add_definitions(-DGRPC)
 
 # Library engine target.
 add_library(cce_core ${LIBRARY_TYPE} ${FILES})

--- a/src/events/loop.cc
+++ b/src/events/loop.cc
@@ -34,9 +34,7 @@
 #include "com/centreon/engine/logging/logger.hh"
 #include "com/centreon/engine/statusdata.hh"
 #include "com/centreon/logging/engine.hh"
-#ifdef GRPC
 #include "com/centreon/engine/command_manager.hh"
-#endif
 
 using namespace com::centreon::engine;
 using namespace com::centreon::engine::events;
@@ -408,9 +406,7 @@ void loop::_dispatching() {
                                 nullptr);
       }
 
-#ifdef GRPC
       command_manager::instance().execute();
-#endif
 
       // Set time to sleep so we don't hog the CPU...
       timespec sleep_time;

--- a/src/events/timed_event.cc
+++ b/src/events/timed_event.cc
@@ -33,9 +33,7 @@
 #include "com/centreon/engine/retention/dump.hh"
 #include "com/centreon/engine/statusdata.hh"
 #include "com/centreon/engine/string.hh"
-#ifdef GRPC
 #include "com/centreon/engine/command_manager.hh"
-#endif
 
 using namespace com::centreon::engine::downtimes;
 using namespace com::centreon::engine::logging;
@@ -132,12 +130,10 @@ void timed_event::_exec_event_command_check() {
  *
  */
 void timed_event::_exec_event_enginerpc_check() {
-#ifdef GRPC
   logger(dbg_events, basic) << "** EngineRPC Command Check Event";
 
   // send data to event broker.
   command_manager::instance().execute();
-#endif
 }
 
 /**

--- a/src/main.cc
+++ b/src/main.cc
@@ -51,9 +51,7 @@
 #include "com/centreon/engine/version.hh"
 #include "com/centreon/io/directory_entry.hh"
 #include "com/centreon/logging/engine.hh"
-#if defined GRPC
 #include "enginerpc.hh"
-#endif
 
 using namespace com::centreon::engine;
 
@@ -94,10 +92,6 @@ int main(int argc, char* argv[]) {
 
   // Load singletons and global variable.
   config = new configuration::state;
-
-#if defined GRPC
-  com::centreon::engine::enginerpc erpc("0.0.0.0", 50051);
-#endif
 
   logging::broker backend_broker_log;
 
@@ -312,6 +306,7 @@ int main(int argc, char* argv[]) {
     // Else start to monitor things.
     else {
       try {
+        com::centreon::engine::enginerpc erpc("0.0.0.0", 50051);
         // Parse configuration.
         configuration::state config;
         {
@@ -409,6 +404,8 @@ int main(int argc, char* argv[]) {
               << "Successfully shutdown ... (PID=" << getpid() << ")";
 
         retval = EXIT_SUCCESS;
+
+        erpc.shutdown();
       } catch (std::exception const& e) {
         // Log.
         logger(logging::log_runtime_error, logging::basic)
@@ -429,9 +426,6 @@ int main(int argc, char* argv[]) {
     logger(logging::log_runtime_error, logging::basic) << "Error: " << e.what();
   }
 
-#if defined GRPC
-  erpc.shutdown();
-#endif
   // Unload singletons and global objects.
   delete config;
   config = nullptr;


### PR DESCRIPTION
# Pull Request Template

## Description

Launch grpc only if needed...

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [X] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Acceptation should works now

#### Community contributors & Centreon team

- [X] I followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have made corresponding changes to the **documentation**.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [X] I have made sure that the **unit tests** related to the story are successful.
- [X] I have made sure that **unit tests cover 80%** of the code written for the story.
- [X] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
