### PR TITLE
Fix check result lookup

### DIFF
--- a/inc/com/centreon/engine/check_result.hh
+++ b/inc/com/centreon/engine/check_result.hh
@@ -34,7 +34,7 @@ enum check_source { service_check, host_check };
 CCE_BEGIN()
 class check_result {
  public:
-  check_result();
+  check_result() = delete;
   check_result(enum check_source object_check_type,
                notifier* notifier,
                enum checkable::check_type check_type,

--- a/inc/com/centreon/engine/check_result.hh
+++ b/inc/com/centreon/engine/check_result.hh
@@ -36,8 +36,7 @@ class check_result {
  public:
   check_result();
   check_result(enum check_source object_check_type,
-               uint64_t host_id,
-               uint64_t service_id,
+               notifier* notifier,
                enum checkable::check_type check_type,
                int check_options,
                bool reschedule_check,
@@ -54,10 +53,8 @@ class check_result {
 
   enum check_source get_object_check_type() const;
   void set_object_check_type(enum check_source object_check_type);
-  uint64_t get_host_id() const;
-  void set_host_id(uint64_t host_id);
-  uint64_t get_service_id() const;
-  void set_service_id(uint64_t service_id);
+  notifier* get_notifier();
+  void set_notifier(notifier* notifier);
   struct timeval get_finish_time() const;
   void set_finish_time(struct timeval finish_time);
   struct timeval get_start_time() const;
@@ -81,8 +78,7 @@ class check_result {
 
  private:
   enum check_source _object_check_type;  // is this a service or a host check?
-  uint64_t _host_id;
-  uint64_t _service_id;
+  notifier* _notifier;
   // was this an active or passive service check?
   enum checkable::check_type _check_type;
   int _check_options;

--- a/src/anomalydetection.cc
+++ b/src/anomalydetection.cc
@@ -612,8 +612,7 @@ int anomalydetection::run_async_check(int check_options,
   // Init check result info.
   std::unique_ptr<check_result> check_result_info(
       new check_result(service_check,
-                       get_host_id(),
-                       get_service_id(),
+                       this,
                        checkable::check_active,
                        check_options,
                        reschedule_check,

--- a/src/check_result.cc
+++ b/src/check_result.cc
@@ -25,22 +25,6 @@
 
 using namespace com::centreon::engine;
 
-//check_result_list check_result::results;
-
-//check_result::check_result()
-//    : _object_check_type{host_check},
-//      _notifier{nullptr},
-//      _check_type(checkable::check_active),
-//      _check_options{CHECK_OPTION_NONE},
-//      _reschedule_check{false},
-//      _latency{0.0},
-//      _early_timeout{false},
-//      _exited_ok{false},
-//      _return_code{0},
-//      _start_time{0, 0},
-//      _finish_time{0, 0},
-//      _output{""} {}
-
 check_result::check_result(enum check_source object_check_type,
                            notifier* notifier,
                            enum checkable::check_type check_type,

--- a/src/check_result.cc
+++ b/src/check_result.cc
@@ -1,5 +1,5 @@
 /*
-** Copyright 2011-2019 Centreon
+** Copyright 2011-2020 Centreon
 **
 ** This file is part of Centreon Engine.
 **
@@ -27,19 +27,19 @@ using namespace com::centreon::engine;
 
 //check_result_list check_result::results;
 
-check_result::check_result()
-    : _object_check_type{host_check},
-      _notifier{nullptr},
-      _check_type(checkable::check_active),
-      _check_options{CHECK_OPTION_NONE},
-      _reschedule_check{false},
-      _latency{0.0},
-      _early_timeout{false},
-      _exited_ok{false},
-      _return_code{0},
-      _output{""},
-      _start_time{0, 0},
-      _finish_time{0, 0} {}
+//check_result::check_result()
+//    : _object_check_type{host_check},
+//      _notifier{nullptr},
+//      _check_type(checkable::check_active),
+//      _check_options{CHECK_OPTION_NONE},
+//      _reschedule_check{false},
+//      _latency{0.0},
+//      _early_timeout{false},
+//      _exited_ok{false},
+//      _return_code{0},
+//      _start_time{0, 0},
+//      _finish_time{0, 0},
+//      _output{""} {}
 
 check_result::check_result(enum check_source object_check_type,
                            notifier* notifier,

--- a/src/check_result.cc
+++ b/src/check_result.cc
@@ -29,8 +29,7 @@ using namespace com::centreon::engine;
 
 check_result::check_result()
     : _object_check_type{host_check},
-      _host_id{0UL},
-      _service_id{0UL},
+      _notifier{nullptr},
       _check_type(checkable::check_active),
       _check_options{CHECK_OPTION_NONE},
       _reschedule_check{false},
@@ -43,8 +42,7 @@ check_result::check_result()
       _finish_time{0, 0} {}
 
 check_result::check_result(enum check_source object_check_type,
-                           uint64_t host_id,
-                           uint64_t service_id,
+                           notifier* notifier,
                            enum checkable::check_type check_type,
                            int check_options,
                            bool reschedule_check,
@@ -56,8 +54,7 @@ check_result::check_result(enum check_source object_check_type,
                            int return_code,
                            std::string const& output)
     : _object_check_type{object_check_type},
-      _host_id{host_id},
-      _service_id{service_id},
+      _notifier{notifier},
       _check_type(check_type),
       _check_options{check_options},
       _reschedule_check{reschedule_check},
@@ -77,20 +74,12 @@ void check_result::set_object_check_type(enum check_source object_check_type) {
   _object_check_type = object_check_type;
 }
 
-uint64_t check_result::get_host_id() const {
-  return _host_id;
+notifier* check_result::get_notifier() {
+  return _notifier;
 }
 
-void check_result::set_host_id(uint64_t host_id) {
-  _host_id = host_id;
-}
-
-uint64_t check_result::get_service_id() const {
-  return _service_id;
-}
-
-void check_result::set_service_id(uint64_t service_id) {
-  _service_id = service_id;
+void check_result::set_notifier(notifier* notifier) {
+  _notifier = notifier;
 }
 
 struct timeval check_result::get_finish_time() const {

--- a/src/checks/checker.cc
+++ b/src/checks/checker.cc
@@ -109,49 +109,32 @@ void checker::reap() {
 
       // Service check result->
       if (service_check == result->get_object_check_type()) {
-        service_id_map::iterator it = service::services_by_id.find(
-            {result->get_host_id(), result->get_service_id()});
-        if (it == service::services_by_id.end()) {
-          logger(log_runtime_error, basic)
-              << "Warning: Check result queue contained results for service "
-              << result->get_host_id() << "/" << result->get_service_id()
-              << ", but the service could not be found! Perhaps you forgot to "
-                 "define the service in your config files ?";
-        } else {
-          try {
-            // Check if the service exists.
-            logger(dbg_checks, more)
-                << "Handling check result for service " << result->get_host_id()
-                << "/" << result->get_service_id() << "...";
-            it->second->handle_async_check_result(result);
-          } catch (std::exception const& e) {
-            logger(log_runtime_warning, basic)
-                << "Check result queue errors for service "
-                << result->get_host_id() << "/" << result->get_service_id()
-                << " : " << e.what();
-          }
+        service* svc = static_cast<service*>(result->get_notifier());
+        try {
+          // Check if the service exists.
+          logger(dbg_checks, more)
+              << "Handling check result for service " << svc->get_host_id()
+              << "/" << svc->get_service_id() << "...";
+          svc->handle_async_check_result(result);
+        } catch (std::exception const& e) {
+          logger(log_runtime_warning, basic)
+              << "Check result queue errors for service "
+              << svc->get_host_id() << "/" << svc->get_service_id()
+              << " : " << e.what();
         }
       }
       // Host check result->
       else {
-        host_id_map::iterator it = host::hosts_by_id.find(result->get_host_id());
-        if (it == host::hosts_by_id.end())
-          logger(log_runtime_warning, basic)
-              << "Warning: Check result queue contained results for "
-              << "host " << result->get_host_id() << ", but the host could "
-              << "not be found! Perhaps you forgot to define the host in "
-              << "your config files ?";
-        else {
-          try {
-            // Process the check result->
-            logger(dbg_checks, more) << "Handling check result for host "
-                                     << result->get_host_id() << "...";
-            it->second->handle_async_check_result_3x(result);
-          } catch (std::exception const& e) {
-            logger(log_runtime_error, basic)
-                << "Check result queue errors for "
-                << "host " << result->get_host_id() << " : " << e.what();
-          }
+        host* hst = static_cast<host*>(result->get_notifier());
+        try {
+          // Process the check result->
+          logger(dbg_checks, more) << "Handling check result for host "
+                                   << hst->get_host_id() << "...";
+          hst->handle_async_check_result_3x(result);
+        } catch (std::exception const& e) {
+          logger(log_runtime_error, basic)
+              << "Check result queue errors for "
+              << "host " << hst->get_host_id() << " : " << e.what();
         }
       }
 

--- a/src/command_manager.cc
+++ b/src/command_manager.cc
@@ -124,8 +124,7 @@ int command_manager::process_passive_service_check(time_t check_time,
 
   check_result* result =
       new check_result(service_check,
-                       found->second->get_host_id(),
-                       found->second->get_service_id(),
+                       found->second.get(),
                        checkable::check_passive,
                        CHECK_OPTION_NONE,
                        false,
@@ -199,8 +198,7 @@ int command_manager::process_passive_host_check(time_t check_time,
 
   check_result* result =
       new check_result(host_check,
-                       it->second->get_host_id(),
-                       0UL,
+                       it->second.get(),
                        checkable::check_passive,
                        CHECK_OPTION_NONE,
                        false,

--- a/src/host.cc
+++ b/src/host.cc
@@ -1723,19 +1723,10 @@ int host::run_async_check(int check_options,
   std::unique_ptr<check_result> check_result_info;
   do {
     // Init check result info.
-    check_result_info.reset(new check_result(host_check,
-                                             get_host_id(),
-                                             0UL,
-                                             checkable::check_active,
-                                             check_options,
-                                             reschedule_check,
-                                             latency,
-                                             start_time,
-                                             start_time,
-                                             false,
-                                             true,
-                                             service::state_ok,
-                                             ""));
+    check_result_info.reset(
+        new check_result(host_check, this, checkable::check_active,
+                         check_options, reschedule_check, latency, start_time,
+                         start_time, false, true, service::state_ok, ""));
 
     retry = false;
     try {

--- a/src/service.cc
+++ b/src/service.cc
@@ -2426,19 +2426,10 @@ int service::run_async_check(int check_options,
   std::unique_ptr<check_result> check_result_info;
   do {
     // Init check result info.
-    check_result_info.reset(new check_result(service_check,
-                                             get_host_id(),
-                                             get_service_id(),
-                                             checkable::check_active,
-                                             check_options,
-                                             reschedule_check,
-                                             latency,
-                                             start_time,
-                                             start_time,
-                                             false,
-                                             true,
-                                             service::state_ok,
-                                             ""));
+    check_result_info.reset(
+        new check_result(service_check, this, checkable::check_active,
+                         check_options, reschedule_check, latency, start_time,
+                         start_time, false, true, service::state_ok, ""));
 
     retry = false;
     try {

--- a/tests/notifications/service_flapping_notification.cc
+++ b/tests/notifications/service_flapping_notification.cc
@@ -252,10 +252,6 @@ TEST_F(ServiceFlappingNotification, SimpleServiceFlappingStopTwoTimes) {
 }
 
 TEST_F(ServiceFlappingNotification, CheckFlapping) {
-  check_result r;
-
-  r.set_exited_ok(true);
-
   config->enable_flap_detection(true);
   _service->set_flap_detection_enabled(true);
   _service->add_flap_detection_on(engine::service::ok);
@@ -354,10 +350,6 @@ TEST_F(ServiceFlappingNotification, CheckFlapping) {
 }
 
 TEST_F(ServiceFlappingNotification, RetentionFlappingNotification) {
-  check_result r;
-
-  r.set_exited_ok(true);
-
   config->enable_flap_detection(true);
   _service->set_flap_detection_enabled(true);
   _service->add_flap_detection_on(engine::service::ok);


### PR DESCRIPTION
# Pull Request Template

## Description

Check_results are faster now. Each time we need to access service or hosts attached to a check_result we have a direct access and don't have anymore to query to the global table.

**Fixes** # (issue)

## Type of change

- [X Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [X] 20.04.x (master)
