### PR TITLE
Schedule ad

### DIFF
--- a/src/configuration/applier/scheduler.cc
+++ b/src/configuration/applier/scheduler.cc
@@ -156,7 +156,7 @@ void applier::scheduler::apply(
     _unschedule_service_events(old_anomalydetections);
   }
   // Check if we need to add or modify objects into the scheduler.
-  if (!hst_to_schedule.empty() || !svc_to_schedule.empty()) {
+  if (!hst_to_schedule.empty() || !svc_to_schedule.empty() || !ad_to_schedule.empty()) {
     // Reset scheduling info.
     // Keep data that has been set manually by the user
     // (service interleave and intercheck delays).
@@ -188,18 +188,16 @@ void applier::scheduler::apply(
       _schedule_host_events(new_hosts);
     }
 
-    // Get and schedule new services.
+    // Get and schedule new services and anomalydetections.
     {
       std::vector<engine::service*> new_services =
           _get_services(svc_to_schedule, true);
-      _schedule_service_events(new_services);
-    }
-
-    // Get and schedule new anomalydetections.
-    {
       std::vector<engine::service*> new_anomalydetections =
           _get_anomalydetections(ad_to_schedule, true);
-      _schedule_service_events(new_anomalydetections);
+      new_services.insert(new_services.end(),
+          std::make_move_iterator(new_anomalydetections.begin()),
+          std::make_move_iterator(new_anomalydetections.end()));
+      _schedule_service_events(new_services);
     }
   }
 }

--- a/src/configuration/applier/scheduler.cc
+++ b/src/configuration/applier/scheduler.cc
@@ -46,6 +46,8 @@ using namespace com::centreon::logging;
  *                           new host configuration.
  *  @param[in] diff_services The difference between old and the
  *                           new service configuration.
+ *  @param[in] diff_anomalydetections The difference between old and the
+ *                           new cwanomalydetectionservice configuration.
  */
 void applier::scheduler::apply(
     configuration::state& config,
@@ -791,9 +793,10 @@ std::vector<com::centreon::engine::host*> applier::scheduler::_get_hosts(
  *                                  found.
  *  @return a vector of services.
  */
-std::vector<com::centreon::engine::service*> applier::scheduler::_get_services(set_service const& svc_cfg,
-                                       bool throw_if_not_found) {
-  std::vector<engine::service*> retval;
+std::vector<com::centreon::engine::service*> applier::scheduler::_get_services(
+    set_service const& svc_cfg,
+    bool throw_if_not_found) {
+  std::vector<com::centreon::engine::service*> retval;
   service_id_map const& services(engine::service::services_by_id);
   for (auto it = svc_cfg.rbegin(), end = svc_cfg.rend(); it != end; ++it) {
     uint64_t host_id(it->host_id());
@@ -803,11 +806,11 @@ std::vector<com::centreon::engine::service*> applier::scheduler::_get_services(s
     service_id_map::const_iterator svc(services.find({host_id, service_id}));
     if (svc == services.end()) {
       if (throw_if_not_found)
-        throw(engine_error()
+        throw engine_error()
               << "Cannot schedule non-existing service '" << service_description
-              << "' on host '" << host_name << "'");
+              << "' on host '" << host_name << "'";
     } else
-      retval.push_back(&*svc->second);
+      retval.push_back(svc->second.get());
   }
   return retval;
 }
@@ -821,11 +824,11 @@ std::vector<com::centreon::engine::service*> applier::scheduler::_get_services(s
  *  @return a vector of services.
  */
 std::vector<com::centreon::engine::service*>
-applier::scheduler::_get_anomalydetections(set_anomalydetection const& svc_cfg,
+applier::scheduler::_get_anomalydetections(set_anomalydetection const& ad_cfg,
                                            bool throw_if_not_found) {
   std::vector<engine::service*> retval;
   service_id_map const& services(engine::service::services_by_id);
-  for (auto it = svc_cfg.rbegin(), end = svc_cfg.rend(); it != end; ++it) {
+  for (auto it = ad_cfg.rbegin(), end = ad_cfg.rend(); it != end; ++it) {
     uint64_t host_id(it->host_id());
     uint64_t service_id(it->service_id());
     std::string const& host_name(it->host_name());
@@ -834,10 +837,10 @@ applier::scheduler::_get_anomalydetections(set_anomalydetection const& svc_cfg,
     if (svc == services.end()) {
       if (throw_if_not_found)
         throw engine_error()
-              << "Cannot schedule non-existing service '" << service_description
-              << "' on host '" << host_name << "'";
+            << "Cannot schedule non-existing anomalydetection '"
+            << service_description << "' on host '" << host_name << "'";
     } else
-      retval.push_back(&*svc->second);
+      retval.push_back(svc->second.get());
   }
   return retval;
 }

--- a/src/configuration/applier/state.cc
+++ b/src/configuration/applier/state.cc
@@ -1082,6 +1082,9 @@ void applier::state::_processing(configuration::state& new_cfg,
   // Expand services.
   _expand<configuration::service, applier::service>(new_cfg);
 
+  // Expand anomalydetections.
+  _expand<configuration::anomalydetection, applier::anomalydetection>(new_cfg);
+
   // Expand servicegroups.
   _expand<configuration::servicegroup, applier::servicegroup>(new_cfg);
 
@@ -1238,16 +1241,20 @@ void applier::state::_processing(configuration::state& new_cfg,
     _apply<configuration::servicegroup, applier::servicegroup>(
         diff_servicegroups);
 
-    // Resolve hosts, services, host groups and service groups.
+    // Resolve hosts, services, host groups.
     _resolve<configuration::host, applier::host>(config->hosts());
     _resolve<configuration::hostgroup, applier::hostgroup>(
         config->hostgroups());
+
+    // Resolve services.
     _resolve<configuration::service, applier::service>(config->services());
+
+    // Resolve anomalydetections.
+    _resolve<configuration::anomalydetection, applier::anomalydetection>(config->anomalydetections());
+
+    // Resolve service groups.
     _resolve<configuration::servicegroup, applier::servicegroup>(
         config->servicegroups());
-
-    // Resolve anomalydetections
-    _resolve<configuration::anomalydetection, applier::anomalydetection>(config->anomalydetections());
 
     // Apply host dependencies.
     _apply<configuration::hostdependency, applier::hostdependency>(


### PR DESCRIPTION
# Pull Request Template

## Description

When a new anomalydetection is created and the configuration is just *reloaded*, the new anomalydetection was not loaded by the scheduler.

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [X] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Centreon-engine / Centreon-broker are running correctly.

Create a new anomalydetection.

Reload Centreon-Engine and the new anomalydetection should be loaded.