### PR TITLE
Ad id not integers

### DIFF
--- a/tests/checks/anomalydetection.cc
+++ b/tests/checks/anomalydetection.cc
@@ -130,7 +130,7 @@ class AnomalydetectionCheck : public TestEngine {
 TEST_F(AnomalydetectionCheck, StatusChanges) {
   CreateFile(
       "/tmp/thresholds_status_change.json",
-      "[{\n \"host_id\": 12,\n \"service_id\": 9,\n \"metric_name\": "
+      "[{\n \"host_id\": \"12\",\n \"service_id\": \"9\",\n \"metric_name\": "
       "\"metric\",\n \"predict\": [{\n \"timestamp\": 50000,\n \"upper\": "
       "84,\n \"lower\": 74,\n \"fit\": 79\n }, {\n \"timestamp\": 100000,\n "
       "\"upper\": 10,\n \"lower\": 5,\n \"fit\": 51.5\n }, {\n \"timestamp\": "
@@ -442,7 +442,7 @@ TEST_F(AnomalydetectionCheck, StatusChanges) {
 TEST_F(AnomalydetectionCheck, MetricWithQuotes) {
   CreateFile(
       "/tmp/thresholds_status_change.json",
-      "[{\n \"host_id\": 12,\n \"service_id\": 9,\n \"metric_name\": "
+      "[{\n \"host_id\": \"12\",\n \"service_id\": \"9\",\n \"metric_name\": "
       "\"metric\",\n \"predict\": [{\n \"timestamp\": 50000,\n \"upper\": "
       "84,\n \"lower\": 74,\n \"fit\": 79\n }, {\n \"timestamp\": 100000,\n "
       "\"upper\": 10,\n \"lower\": 5,\n \"fit\": 51.5\n }, {\n \"timestamp\": "

--- a/tests/enginerpc/enginerpc.cc
+++ b/tests/enginerpc/enginerpc.cc
@@ -182,7 +182,7 @@ TEST_F(EngineRpc, ProcessHostCheckResultBadHost) {
 TEST_F(EngineRpc, NewThresholdsFile) {
   CreateFile(
       "/tmp/thresholds_file.json",
-      "[{\n \"host_id\": 12,\n \"service_id\": 12,\n \"metric_name\": "
+      "[{\n \"host_id\": \"12\",\n \"service_id\": \"12\",\n \"metric_name\": "
       "\"metric\",\n \"predict\": [{\n \"timestamp\": 50000,\n \"upper\": "
       "84,\n \"lower\": 74,\n \"fit\": 79\n }, {\n \"timestamp\": 100000,\n "
       "\"upper\": 10,\n \"lower\": 5,\n \"fit\": 51.5\n }, {\n \"timestamp\": "

--- a/tests/external_commands/anomalydetection.cc
+++ b/tests/external_commands/anomalydetection.cc
@@ -125,7 +125,7 @@ class ADExtCmd : public TestEngine {
 TEST_F(ADExtCmd, NewThresholdsFile) {
   CreateFile(
       "/tmp/thresholds_file.json",
-      "[{\n \"host_id\": 12,\n \"service_id\": 12,\n \"metric_name\": "
+      "[{\n \"host_id\": \"12\",\n \"service_id\": \"12\",\n \"metric_name\": "
       "\"metric\",\n \"predict\": [{\n \"timestamp\": 50000,\n \"upper\": "
       "84,\n \"lower\": 74,\n \"fit\": 79\n }, {\n \"timestamp\": 100000,\n "
       "\"upper\": 10,\n \"lower\": 5,\n \"fit\": 51.5\n }, {\n \"timestamp\": "


### PR DESCRIPTION
# Pull Request Template

## Description

In centreon engine and broker, service_id and host_id are integers. But thresholds files we get for anomalydetections do not respect this logic. So here is a patch to read strings and convert them to uint.

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [X] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Let's hope we will understand thresholds files now.
