### PR TITLE
enh(anomalydetection): min/max are kept for upper and lower thresholds.

### DIFF
--- a/src/anomalydetection.cc
+++ b/src/anomalydetection.cc
@@ -657,10 +657,10 @@ int anomalydetection::run_async_check(int check_options,
   check_result_info->set_return_code(std::get<0>(pd));
   oss << perfdata;
   if (!std::isnan(std::get<3>(pd))) {
-    oss << ' ' << _metric_name << "_lower_thresholds=" << std::get<3>(pd) << without_thresholds;
+    oss << ' ' << _metric_name << "_lower_thresholds=" << std::get<3>(pd) << std::get<2>(pd) << without_thresholds;
   }
   if (!std::isnan(std::get<4>(pd))) {
-    oss << ' ' << _metric_name << "_upper_thresholds=" << std::get<4>(pd) << without_thresholds;
+    oss << ' ' << _metric_name << "_upper_thresholds=" << std::get<4>(pd) << std::get<2>(pd) << without_thresholds;
   }
   check_result_info->set_output(oss.str());
 

--- a/src/anomalydetection.cc
+++ b/src/anomalydetection.cc
@@ -607,8 +607,15 @@ int anomalydetection::run_async_check(int check_options,
 
   std::string perfdata = string::extract_perfdata(
       _dependent_service->get_perf_data(), _metric_name);
+
+  std::string without_thresholds(string::remove_thresholds(perfdata));
   std::tuple<service::service_state, double, std::string, double, double> pd =
-      parse_perfdata(string::remove_thresholds(perfdata), start_time.tv_sec);
+      parse_perfdata(without_thresholds, start_time.tv_sec);
+  size_t pos = without_thresholds.find(';');
+  if (pos != std::string::npos)
+    without_thresholds = without_thresholds.substr(pos);
+  else
+    without_thresholds = "";
 
   // Init check result info.
   std::unique_ptr<check_result> check_result_info(
@@ -650,10 +657,10 @@ int anomalydetection::run_async_check(int check_options,
   check_result_info->set_return_code(std::get<0>(pd));
   oss << perfdata;
   if (!std::isnan(std::get<3>(pd))) {
-    oss << ' ' << _metric_name << "_lower_thresholds=" << std::get<3>(pd);
+    oss << ' ' << _metric_name << "_lower_thresholds=" << std::get<3>(pd) << without_thresholds;
   }
   if (!std::isnan(std::get<4>(pd))) {
-    oss << ' ' << _metric_name << "_upper_thresholds=" << std::get<4>(pd);
+    oss << ' ' << _metric_name << "_upper_thresholds=" << std::get<4>(pd) << without_thresholds;
   }
   check_result_info->set_output(oss.str());
 

--- a/src/string.cc
+++ b/src/string.cc
@@ -319,7 +319,7 @@ std::string& string::remove_thresholds(std::string& perfdata) noexcept {
     perfdata.resize(pos1);
     return perfdata;
   }
-  
+
   perfdata.replace(pos1, pos3 - pos1, ";;");
   return perfdata;
 }

--- a/tests/checks/anomalydetection.cc
+++ b/tests/checks/anomalydetection.cc
@@ -474,7 +474,7 @@ TEST_F(AnomalydetectionCheck, MetricWithQuotes) {
   std::time_t now{std::time(nullptr)};
   oss << '[' << now << ']'
       << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;service critical| "
-         "'metric'=90;25;60";
+         "'metric'=90;25;60;0;100";
   std::string cmd{oss.str()};
   process_external_command(cmd.c_str());
   checks::checker::instance().reap();
@@ -483,7 +483,7 @@ TEST_F(AnomalydetectionCheck, MetricWithQuotes) {
   ASSERT_EQ(_svc->get_last_state_change(), now);
   ASSERT_EQ(_svc->get_current_attempt(), 1);
   ASSERT_EQ(_svc->get_plugin_output(), "service critical");
-  ASSERT_EQ(_svc->get_perf_data(), "'metric'=90;25;60");
+  ASSERT_EQ(_svc->get_perf_data(), "'metric'=90;25;60;0;100");
   int check_options = 0;
   int latency = 0;
   bool time_is_valid;
@@ -499,6 +499,6 @@ TEST_F(AnomalydetectionCheck, MetricWithQuotes) {
             "NON-OK: Unusual activity, the actual value of metric is 90.00 "
             "which is outside the forecasting range [73.31 : 83.26]");
   ASSERT_EQ(_ad->get_perf_data(),
-            "'metric'=90 metric_lower_thresholds=73.31 "
-            "metric_upper_thresholds=83.26");
+            "'metric'=90;;;0;100 metric_lower_thresholds=73.31;;;0;100 "
+            "metric_upper_thresholds=83.26;;;0;100");
 }

--- a/tests/checks/anomalydetection.cc
+++ b/tests/checks/anomalydetection.cc
@@ -242,8 +242,8 @@ TEST_F(AnomalydetectionCheck, StatusChanges) {
             "NON-OK: Unusual activity, the actual value of metric is 110.00foo "
             "which is outside the forecasting range [71.93 : 81.78]");
   ASSERT_EQ(_ad->get_perf_data(),
-            "metric=110foo metric_lower_thresholds=71.93 "
-            "metric_upper_thresholds=81.78");
+            "metric=110foo metric_lower_thresholds=71.93foo "
+            "metric_upper_thresholds=81.78foo");
   ASSERT_EQ(_ad->get_current_attempt(), 3);
 
   set_time(52000);
@@ -270,8 +270,8 @@ TEST_F(AnomalydetectionCheck, StatusChanges) {
             "NON-OK: Unusual activity, the actual value of metric is 30.00% "
             "which is outside the forecasting range [71.24 : 81.04]");
   ASSERT_EQ(_ad->get_perf_data(),
-            "metric=30% metric_lower_thresholds=71.24 "
-            "metric_upper_thresholds=81.04");
+            "metric=30% metric_lower_thresholds=71.24% "
+            "metric_upper_thresholds=81.04%");
   ASSERT_EQ(_ad->get_current_attempt(), 3);
 
   set_time(52500);
@@ -300,8 +300,8 @@ TEST_F(AnomalydetectionCheck, StatusChanges) {
             "NON-OK: Unusual activity, the actual value of metric is 35.00% "
             "which is outside the forecasting range [70.55 : 80.30]");
   ASSERT_EQ(_ad->get_perf_data(),
-            "metric=35% metric_lower_thresholds=70.55 "
-            "metric_upper_thresholds=80.30");
+            "metric=35% metric_lower_thresholds=70.55% "
+            "metric_upper_thresholds=80.30%");
   ASSERT_EQ(_ad->get_current_attempt(), 3);
 
   set_time(53000);
@@ -327,8 +327,8 @@ TEST_F(AnomalydetectionCheck, StatusChanges) {
   ASSERT_EQ(_ad->get_last_hard_state_change(), now);
   ASSERT_EQ(_ad->get_plugin_output(), "OK: Regular activity, metric=70.00%");
   ASSERT_EQ(_ad->get_perf_data(),
-            "metric=70% metric_lower_thresholds=69.86 "
-            "metric_upper_thresholds=79.56");
+            "metric=70% metric_lower_thresholds=69.86% "
+            "metric_upper_thresholds=79.56%");
   ASSERT_EQ(_ad->get_current_attempt(), 1);
 
   set_time(53500);
@@ -354,8 +354,8 @@ TEST_F(AnomalydetectionCheck, StatusChanges) {
   ASSERT_EQ(_ad->get_last_hard_state_change(), previous);
   ASSERT_EQ(_ad->get_plugin_output(), "OK: Regular activity, metric=71.00%");
   ASSERT_EQ(_ad->get_perf_data(),
-            "metric=71% metric_lower_thresholds=69.17 "
-            "metric_upper_thresholds=78.82");
+            "metric=71% metric_lower_thresholds=69.17% "
+            "metric_upper_thresholds=78.82%");
   ASSERT_EQ(_ad->get_current_attempt(), 1);
 
   set_time(54000);
@@ -406,8 +406,8 @@ TEST_F(AnomalydetectionCheck, StatusChanges) {
   ASSERT_EQ(_ad->get_last_state_change(), now);
   ASSERT_EQ(_ad->get_plugin_output(), "OK: Regular activity, metric=72.00%");
   ASSERT_EQ(_ad->get_perf_data(),
-            "metric=72% metric_lower_thresholds=67.79 "
-            "metric_upper_thresholds=77.34");
+            "metric=72% metric_lower_thresholds=67.79% "
+            "metric_upper_thresholds=77.34%");
   ASSERT_EQ(_ad->get_current_attempt(), 2);
 
   set_time(55000);
@@ -417,7 +417,7 @@ TEST_F(AnomalydetectionCheck, StatusChanges) {
   oss.str("");
   oss << '[' << now << ']'
       << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;0;service ok| "
-         "metric=71.7%;80;90";
+         "metric=71.7%;80;90;10;100";
   cmd = oss.str();
   process_external_command(cmd.c_str());
   checks::checker::instance().reap();
@@ -433,8 +433,8 @@ TEST_F(AnomalydetectionCheck, StatusChanges) {
   ASSERT_EQ(_ad->get_last_hard_state_change(), now);
   ASSERT_EQ(_ad->get_plugin_output(), "OK: Regular activity, metric=71.70%");
   ASSERT_EQ(_ad->get_perf_data(),
-            "metric=71.7% metric_lower_thresholds=67.10 "
-            "metric_upper_thresholds=76.60");
+            "metric=71.7%;;;10;100 metric_lower_thresholds=67.10%;;;10;100 "
+            "metric_upper_thresholds=76.60%;;;10;100");
   ASSERT_EQ(_ad->get_current_attempt(), 1);
   ::unlink("/tmp/thresholds_status_change.json");
 }
@@ -474,7 +474,7 @@ TEST_F(AnomalydetectionCheck, MetricWithQuotes) {
   std::time_t now{std::time(nullptr)};
   oss << '[' << now << ']'
       << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;service critical| "
-         "'metric'=90;25;60;0;100";
+         "'metric'=90MT;25;60;0;100";
   std::string cmd{oss.str()};
   process_external_command(cmd.c_str());
   checks::checker::instance().reap();
@@ -483,7 +483,7 @@ TEST_F(AnomalydetectionCheck, MetricWithQuotes) {
   ASSERT_EQ(_svc->get_last_state_change(), now);
   ASSERT_EQ(_svc->get_current_attempt(), 1);
   ASSERT_EQ(_svc->get_plugin_output(), "service critical");
-  ASSERT_EQ(_svc->get_perf_data(), "'metric'=90;25;60;0;100");
+  ASSERT_EQ(_svc->get_perf_data(), "'metric'=90MT;25;60;0;100");
   int check_options = 0;
   int latency = 0;
   bool time_is_valid;
@@ -496,9 +496,9 @@ TEST_F(AnomalydetectionCheck, MetricWithQuotes) {
   ASSERT_EQ(_ad->get_last_state_change(), now);
   ASSERT_EQ(_ad->get_current_attempt(), 1);
   ASSERT_EQ(_ad->get_plugin_output(),
-            "NON-OK: Unusual activity, the actual value of metric is 90.00 "
+            "NON-OK: Unusual activity, the actual value of metric is 90.00MT "
             "which is outside the forecasting range [73.31 : 83.26]");
   ASSERT_EQ(_ad->get_perf_data(),
-            "'metric'=90;;;0;100 metric_lower_thresholds=73.31;;;0;100 "
-            "metric_upper_thresholds=83.26;;;0;100");
+            "'metric'=90MT;;;0;100 metric_lower_thresholds=73.31MT;;;0;100 "
+            "metric_upper_thresholds=83.26MT;;;0;100");
 }


### PR DESCRIPTION
# Pull Request Template

## Description

For an anomalydetection, in case of a metric with min/max. New upper and lower thresholds did not contain them. The impact was that their curves were not aligned in centreon-web. Now if min/max are given for the metric, they are kept into their thresholds.

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [X] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Create an anomalydetection from a metric with min/max.
And take care to the lower and upper thresholds of the anomalydetection. They should contain min/max values.
