### PR TITLE
enh(anomalydetection): If a thresholds file is missing, no error mess…

### DIFF
--- a/src/anomalydetection.cc
+++ b/src/anomalydetection.cc
@@ -789,15 +789,11 @@ anomalydetection::parse_perfdata(std::string const& perfdata,
 void anomalydetection::init_thresholds() {
   std::lock_guard<std::mutex> lock(_thresholds_m);
 
-  logger(log_info_message, most) << "Reading thresholds file '"
-                                 << _thresholds_file << "'...";
+  logger(log_info_message, basic) << "Trying to read thresholds file '"
+                                 << _thresholds_file << "'";
   std::ifstream t(_thresholds_file);
-  if (!t) {
-    logger(log_config_error, basic)
-        << "Error: Unable to read the thresholds file '" << _thresholds_file
-        << "'.";
+  if (!t)
     return;
-  }
 
   std::stringstream buffer;
   buffer << t.rdbuf();


### PR DESCRIPTION
…age is sent.

# Pull Request Template

## Description

No error message if a thresholds file is missing. This situation is classical.

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [X] 20.04.x (master)

