### PR TITLE
fix(string): utf-8 validator had a bug

### DIFF
--- a/src/string.cc
+++ b/src/string.cc
@@ -342,13 +342,13 @@ std::string string::check_string_utf8(std::string const& str) noexcept {
   for (auto it = str.begin(); it != str.end();) {
     if ((*it & ~127) == 0)
       ++it;
-    else if ((*it & 192) == 192 && (*(it + 1) & 128) == 128)
+    else if ((*it & 192) == 192 && (*(it + 1) & 0xc0) == 0x80)
       it += 2;
-    else if ((*it & 224) == 224 && (*(it + 1) & 128) == 128 &&
-             (*(it + 2) & 128) == 128)
+    else if ((*it & 224) == 224 && (*(it + 1) & 0xc0) == 0x80 &&
+             (*(it + 2) & 0xc0) == 0x80)
       it += 3;
-    else if ((*it & 240) == 240 && (*(it + 1) & 128) == 128 &&
-             (*(it + 2) & 128) == 128 && (*(it + 3) & 128) == 128)
+    else if ((*it & 240) == 240 && (*(it + 1) & 0xc0) == 0x80 &&
+             (*(it + 2) & 0xc0) == 0x80 && (*(it + 3) & 0xc0) == 0x80)
       it += 4;
     else {
       /* Not an UTF-8 string */
@@ -362,7 +362,7 @@ std::string string::check_string_utf8(std::string const& str) noexcept {
         out.reserve(d + 2 * (str.size() - d));
         out = str.substr(0, d);
         while (it != str.end()) {
-          unsigned char c = static_cast<unsigned char>(*it);
+          uint8_t c = static_cast<uint8_t>(*it);
           if (c < 128)
             out.push_back(c);
           else if (c >= 128 && c <= 160)
@@ -404,7 +404,7 @@ std::string string::check_string_utf8(std::string const& str) noexcept {
         return out;
       };
       do {
-        unsigned char c = *itt;
+        uint8_t c = *itt;
         /* not ISO-8859-15 */
         if (c > 126 && c < 160)
           is_iso8859 = false;

--- a/tests/string/string.cc
+++ b/tests/string/string.cc
@@ -215,3 +215,16 @@ TEST(string_check_utf8, whatever_as_iso8859) {
       "éêëìíîïðñòóôõö÷øùúûüýþ");
   ASSERT_EQ(string::check_string_utf8(txt), result);
 }
+
+/*
+ * In case of a string containing multiple encoding, the resulting string should
+ * be an UTF-8 string. Here we have a string beginning with UTF-8 and finishing
+ * with cp1252. The resulting string is good and is UTF-8 only encoded.
+ */
+TEST(string_check_utf8, utf8_and_cp1252) {
+  std::string txt(
+      "\xc3\xa9\xc3\xa7\xc3\xa8\xc3\xa0\xc3\xb9\xc3\xaf\xc3\xab\x7e\x23\x0a\xe9"
+      "\xe7\xe8\xe0\xf9\xef\xeb\x7e\x23\x0a");
+  std::string result("éçèàùïë~#\néçèàùïë~#\n");
+  ASSERT_EQ(string::check_string_utf8(txt), result);
+}


### PR DESCRIPTION
The utf-8 validation was not sufficiently strict.

# Pull Request Template

## Description

An error was present in the utf-8 checker. So when a string was not utf-8 encoded, it could be seen as an UTF-8 string.
A new unit test has been added to check this new algorithm.

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [X] 20.04.x (master)

