### PR TITLE
enh(statusdata): There is a minimal delay now between two instance updates

### DIFF
--- a/inc/com/centreon/engine/configuration/state.hh
+++ b/inc/com/centreon/engine/configuration/state.hh
@@ -383,6 +383,8 @@ class state {
   void use_aggressive_host_checking(bool value);
   bool use_large_installation_tweaks() const noexcept;
   void use_large_installation_tweaks(bool value);
+  uint32_t instance_heartbeat_interval() const noexcept;
+  void instance_heartbeat_interval(uint32_t value);
   bool use_regexp_matches() const noexcept;
   void use_regexp_matches(bool value);
   bool use_retained_program_state() const noexcept;
@@ -598,6 +600,7 @@ class state {
   std::unordered_map<std::string, std::string> _users;
   bool _use_aggressive_host_checking;
   bool _use_large_installation_tweaks;
+  uint32_t _instance_heartbeat_interval;
   bool _use_regexp_matches;
   bool _use_retained_program_state;
   bool _use_retained_scheduling_info;

--- a/inc/com/centreon/engine/globals.hh
+++ b/inc/com/centreon/engine/globals.hh
@@ -127,6 +127,7 @@ extern char* use_timezone;
 extern char* illegal_object_chars;
 extern char* illegal_output_chars;
 extern unsigned int use_large_installation_tweaks;
+extern uint32_t instance_heartbeat_interval;
 
 #ifdef __cplusplus
 }

--- a/src/configuration/applier/globals.cc
+++ b/src/configuration/applier/globals.cc
@@ -18,7 +18,9 @@
 */
 
 #include "com/centreon/engine/configuration/applier/globals.hh"
+
 #include <cassert>
+
 #include "com/centreon/engine/globals.hh"
 #include "com/centreon/engine/string.hh"
 
@@ -67,6 +69,7 @@ void applier::globals::apply(state& config) {
   ::soft_state_dependencies = config.soft_state_dependencies();
   ::use_aggressive_host_checking = config.use_aggressive_host_checking();
   ::use_large_installation_tweaks = config.use_large_installation_tweaks();
+  ::instance_heartbeat_interval = config.instance_heartbeat_interval();
 }
 
 /**

--- a/src/configuration/applier/state.cc
+++ b/src/configuration/applier/state.cc
@@ -76,8 +76,7 @@ void applier::state::apply(configuration::state& new_cfg) {
   try {
     _processing_state = state_ready;
     _processing(new_cfg);
-  }
-  catch (std::exception const& e) {
+  } catch (std::exception const& e) {
     // If is the first time to load configuration, we don't
     // have a valid configuration to restore.
     if (!has_already_been_loaded)
@@ -108,16 +107,15 @@ void applier::state::apply(configuration::state& new_cfg,
   try {
     _processing_state = state_ready;
     _processing(new_cfg, &state);
-  }
-  catch (std::exception const& e) {
+  } catch (std::exception const& e) {
     // If is the first time to load configuration, we don't
     // have a valid configuration to restore.
     if (!has_already_been_loaded)
       throw;
 
     // If is not the first time, we can restore the old one.
-    logger(log_config_error, basic) << "Cannot apply new configuration: "
-                                    << e.what();
+    logger(log_config_error, basic)
+        << "Cannot apply new configuration: " << e.what();
 
     // Check if we need to restore old configuration.
     if (_processing_state == state_error) {
@@ -223,13 +221,17 @@ applier::state::user_macros_find(std::string const& key) const {
  *  Lock state
  *
  */
-void applier::state::lock() { _apply_lock.lock(); }
+void applier::state::lock() {
+  _apply_lock.lock();
+}
 
 /**
  *  Unlock state
  *
  */
-void applier::state::unlock() { _apply_lock.unlock(); }
+void applier::state::unlock() {
+  _apply_lock.unlock();
+}
 
 /*
  *  Update all new globals.
@@ -427,6 +429,7 @@ void applier::state::_apply(configuration::state const& new_cfg) {
   config->use_aggressive_host_checking(new_cfg.use_aggressive_host_checking());
   config->use_large_installation_tweaks(
       new_cfg.use_large_installation_tweaks());
+  config->instance_heartbeat_interval(new_cfg.instance_heartbeat_interval());
   config->use_regexp_matches(new_cfg.use_regexp_matches());
   config->use_retained_program_state(new_cfg.use_retained_program_state());
   config->use_retained_scheduling_info(new_cfg.use_retained_scheduling_info());
@@ -546,15 +549,13 @@ void applier::state::_apply(
   // Erase objects.
   for (typename cfg_set::const_iterator it_delete(diff.deleted().begin()),
        end_delete(diff.deleted().end());
-       it_delete != end_delete;
-       ++it_delete) {
+       it_delete != end_delete; ++it_delete) {
     if (!verify_config)
       aplyr.remove_object(*it_delete);
     else {
       try {
         aplyr.remove_object(*it_delete);
-      }
-      catch (std::exception const& e) {
+      } catch (std::exception const& e) {
         ++config_errors;
         logger(log_info_message, basic) << e.what();
       }
@@ -564,15 +565,13 @@ void applier::state::_apply(
   // Add objects.
   for (typename cfg_set::const_iterator it_create(diff.added().begin()),
        end_create(diff.added().end());
-       it_create != end_create;
-       ++it_create) {
+       it_create != end_create; ++it_create) {
     if (!verify_config)
       aplyr.add_object(*it_create);
     else {
       try {
         aplyr.add_object(*it_create);
-      }
-      catch (std::exception const& e) {
+      } catch (std::exception const& e) {
         ++config_errors;
         logger(log_info_message, basic) << e.what();
       }
@@ -582,15 +581,13 @@ void applier::state::_apply(
   // Modify objects.
   for (typename cfg_set::const_iterator it_modify(diff.modified().begin()),
        end_modify(diff.modified().end());
-       it_modify != end_modify;
-       ++it_modify) {
+       it_modify != end_modify; ++it_modify) {
     if (!verify_config)
       aplyr.modify_object(*it_modify);
     else {
       try {
         aplyr.modify_object(*it_modify);
-      }
-      catch (std::exception const& e) {
+      } catch (std::exception const& e) {
         ++config_errors;
         logger(log_info_message, basic) << e.what();
       }
@@ -630,8 +627,9 @@ void applier::state::_check_serviceescalations() const {
     if (s.size() != srv->get_escalations().size()) {
       logger(log_config_error, basic)
           << "Error on serviceescalation !!! Some escalations are stored "
-             "several times in service " << srv->get_hostname() << "/"
-          << srv->get_description() << "set size: " << s.size()
+             "several times in service "
+          << srv->get_hostname() << "/" << srv->get_description()
+          << "set size: " << s.size()
           << " ; list size: " << srv->get_escalations().size();
       throw engine_error() << "This is a bug";
     }
@@ -747,10 +745,10 @@ void applier::state::_check_contacts() const {
       contact_map::iterator found{engine::contact::contacts.find(pp.first)};
       if (found == engine::contact::contacts.end() ||
           found->second.get() != pp.second) {
-        logger(log_config_error, basic) << "Error on contact !!! The contact "
-                                        << pp.first << " used in contactgroup "
-                                        << p.first
-                                        << " is not or badly defined";
+        logger(log_config_error, basic)
+            << "Error on contact !!! The contact " << pp.first
+            << " used in contactgroup " << p.first
+            << " is not or badly defined";
         throw engine_error() << "This is a bug";
       }
     }
@@ -761,11 +759,10 @@ void applier::state::_check_contacts() const {
       contact_map::iterator found{engine::contact::contacts.find(pp.first)};
       if (found == engine::contact::contacts.end() ||
           found->second.get() != pp.second) {
-        logger(log_config_error, basic) << "Error on contact !!! The contact "
-                                        << pp.first << " used in service "
-                                        << p.second->get_hostname() << '/'
-                                        << p.second->get_description()
-                                        << " is not or badly defined";
+        logger(log_config_error, basic)
+            << "Error on contact !!! The contact " << pp.first
+            << " used in service " << p.second->get_hostname() << '/'
+            << p.second->get_description() << " is not or badly defined";
         throw engine_error() << "This is a bug";
       }
     }
@@ -776,10 +773,10 @@ void applier::state::_check_contacts() const {
       contact_map::iterator found{engine::contact::contacts.find(pp.first)};
       if (found == engine::contact::contacts.end() ||
           found->second.get() != pp.second) {
-        logger(log_config_error, basic) << "Error on contact !!! The contact "
-                                        << pp.first << " used in service "
-                                        << p.second->get_name()
-                                        << " is not or badly defined";
+        logger(log_config_error, basic)
+            << "Error on contact !!! The contact " << pp.first
+            << " used in service " << p.second->get_name()
+            << " is not or badly defined";
         throw engine_error() << "This is a bug";
       }
     }
@@ -870,13 +867,10 @@ void applier::state::_check_services() const {
           {svc->get_host_id(), svc->get_service_id()})};
       if (found == engine::service::services_by_id.end() ||
           found->second.get() != svc) {
-        logger(log_config_error, basic) << "Error on service !!! The service "
-                                        << p.first.first << '/'
-                                        << p.first.second
-                                        << " used in service dependency "
-                                        << p.first.first << '/'
-                                        << p.first.second
-                                        << " is not or badly defined";
+        logger(log_config_error, basic)
+            << "Error on service !!! The service " << p.first.first << '/'
+            << p.first.second << " used in service dependency " << p.first.first
+            << '/' << p.first.second << " is not or badly defined";
         throw engine_error() << "This is a bug";
       }
     }
@@ -896,8 +890,10 @@ void applier::state::_check_services() const {
   }
 
   for (auto const& p : engine::service::services) {
-    std::array<commands::command*, 2> arr{p.second->get_check_command_ptr(),
-                                          p.second->get_event_handler_ptr(), };
+    std::array<commands::command*, 2> arr{
+        p.second->get_check_command_ptr(),
+        p.second->get_event_handler_ptr(),
+    };
     for (auto cc : arr) {
       if (cc) {
         bool found = false;
@@ -959,8 +955,10 @@ void applier::state::_check_hosts() const {
   }
 
   for (auto const& p : engine::host::hosts) {
-    std::array<commands::command*, 2> arr{p.second->get_check_command_ptr(),
-                                          p.second->get_event_handler_ptr(), };
+    std::array<commands::command*, 2> arr{
+        p.second->get_check_command_ptr(),
+        p.second->get_event_handler_ptr(),
+    };
     for (auto cc : arr) {
       if (cc) {
         bool found = false;
@@ -983,8 +981,9 @@ void applier::state::_check_hosts() const {
   if (engine::host::hosts_by_id.size() != engine::host::hosts.size()) {
     logger(log_config_error, basic)
         << "Error on host !!! hosts_by_id contains hosts that are not in "
-           "hosts. The first one size is " << engine::service::services.size()
-        << " whereas the second size is " << engine::service::services.size();
+           "hosts. The first one size is "
+        << engine::service::services.size() << " whereas the second size is "
+        << engine::service::services.size();
     throw engine_error() << "This is a bug";
   }
 
@@ -1008,8 +1007,7 @@ void applier::state::_apply(configuration::state& new_cfg,
   else {
     try {
       app_state.apply(new_cfg, state);
-    }
-    catch (std::exception const& e) {
+    } catch (std::exception const& e) {
       ++config_errors;
       logger(log_info_message, basic) << e.what();
     }
@@ -1027,8 +1025,7 @@ void applier::state::_expand(configuration::state& new_state) {
   ApplierType aplyr;
   try {
     aplyr.expand_objects(new_state);
-  }
-  catch (std::exception const& e) {
+  } catch (std::exception const& e) {
     if (verify_config) {
       ++config_errors;
       logger(log_info_message, basic) << e.what();
@@ -1050,8 +1047,8 @@ void applier::state::_processing(configuration::state& new_cfg,
 
   // Call prelauch broker event the first time to run applier state.
   if (!has_already_been_loaded)
-    broker_program_state(
-        NEBTYPE_PROCESS_PRELAUNCH, NEBFLAG_NONE, NEBATTR_NONE, nullptr);
+    broker_program_state(NEBTYPE_PROCESS_PRELAUNCH, NEBFLAG_NONE, NEBATTR_NONE,
+                         nullptr);
 
   //
   // Expand all objects.
@@ -1188,16 +1185,15 @@ void applier::state::_processing(configuration::state& new_cfg,
     if (!has_already_been_loaded && !verify_config && !test_scheduling) {
       // This must be logged after we read config data,
       // as user may have changed location of main log file.
-      logger(log_process_info, basic) << "Centreon Engine "
-                                      << CENTREON_ENGINE_VERSION_STRING
-                                      << " starting ... (PID=" << getpid()
-                                      << ")";
+      logger(log_process_info, basic)
+          << "Centreon Engine " << CENTREON_ENGINE_VERSION_STRING
+          << " starting ... (PID=" << getpid() << ")";
 
       // Log the local time - may be different than clock
       // time due to timezone offset.
-      logger(log_process_info, basic) << "Local time is "
-                                      << string::ctime(program_start) << "\n"
-                                      << "LOG VERSION: " << LOG_VERSION_2;
+      logger(log_process_info, basic)
+          << "Local time is " << string::ctime(program_start) << "\n"
+          << "LOG VERSION: " << LOG_VERSION_2;
     }
 
     //
@@ -1250,7 +1246,8 @@ void applier::state::_processing(configuration::state& new_cfg,
     _resolve<configuration::service, applier::service>(config->services());
 
     // Resolve anomalydetections.
-    _resolve<configuration::anomalydetection, applier::anomalydetection>(config->anomalydetections());
+    _resolve<configuration::anomalydetection, applier::anomalydetection>(
+        config->anomalydetections());
 
     // Resolve service groups.
     _resolve<configuration::servicegroup, applier::servicegroup>(
@@ -1299,8 +1296,8 @@ void applier::state::_processing(configuration::state& new_cfg,
 
     // Apply scheduler.
     if (!verify_config)
-      applier::scheduler::instance().apply(
-          new_cfg, diff_hosts, diff_services, diff_anomalydetections);
+      applier::scheduler::instance().apply(new_cfg, diff_hosts, diff_services,
+                                           diff_anomalydetections);
 
     // Apply new global on the current state.
     if (!verify_config)
@@ -1308,8 +1305,7 @@ void applier::state::_processing(configuration::state& new_cfg,
     else {
       try {
         _apply(new_cfg);
-      }
-      catch (std::exception const& e) {
+      } catch (std::exception const& e) {
         ++config_errors;
         logger(log_info_message, basic) << e.what();
       }
@@ -1325,8 +1321,8 @@ void applier::state::_processing(configuration::state& new_cfg,
     if (!has_already_been_loaded) {
       neb_load_all_modules();
 
-      broker_program_state(
-          NEBTYPE_PROCESS_START, NEBFLAG_NONE, NEBATTR_NONE, nullptr);
+      broker_program_state(NEBTYPE_PROCESS_START, NEBFLAG_NONE, NEBATTR_NONE,
+                           nullptr);
     } else
       neb_reload_all_modules();
 
@@ -1334,8 +1330,7 @@ void applier::state::_processing(configuration::state& new_cfg,
     if (!verify_config && !test_scheduling) {
       for (set_host::iterator it(diff_hosts.added().begin()),
            end(diff_hosts.added().end());
-           it != end;
-           ++it) {
+           it != end; ++it) {
         host_id_map::const_iterator hst(
             engine::host::hosts_by_id.find(it->host_id()));
         if (hst != engine::host::hosts_by_id.end())
@@ -1343,8 +1338,7 @@ void applier::state::_processing(configuration::state& new_cfg,
       }
       for (set_service::iterator it(diff_services.added().begin()),
            end(diff_services.added().end());
-           it != end;
-           ++it) {
+           it != end; ++it) {
         service_id_map::const_iterator svc(engine::service::services_by_id.find(
             {it->host_id(), it->service_id()}));
         if (svc != engine::service::services_by_id.end())
@@ -1378,8 +1372,7 @@ void applier::state::_processing(configuration::state& new_cfg,
           << " sec  * = " << runtimes[3] << " sec ("
           << (runtimes[3] * 100.0 / runtimes[4]) << "%) estimated savings\n";
     }
-  }
-  catch (...) {
+  } catch (...) {
     _processing_state = state_error;
     throw;
   }
@@ -1398,12 +1391,10 @@ void applier::state::_resolve(std::set<ConfigurationType>& cfg) {
   ApplierType aplyr;
   for (typename std::set<ConfigurationType>::const_iterator it(cfg.begin()),
        end(cfg.end());
-       it != end;
-       ++it) {
+       it != end; ++it) {
     try {
       aplyr.resolve_object(*it);
-    }
-    catch (std::exception const& e) {
+    } catch (std::exception const& e) {
       if (verify_config) {
         ++config_errors;
         logger(log_info_message, basic) << e.what();

--- a/src/configuration/state.cc
+++ b/src/configuration/state.cc
@@ -18,7 +18,9 @@
 */
 
 #include "com/centreon/engine/configuration/state.hh"
+
 #include <limits>
+
 #include "com/centreon/engine/broker.hh"
 #include "com/centreon/engine/exceptions/error.hh"
 #include "com/centreon/engine/globals.hh"
@@ -168,9 +170,9 @@ std::unordered_map<std::string, state::setter_func> const state::_setters{
     {"passive_host_checks_are_soft",
      SETTER(bool, passive_host_checks_are_soft)},
     {"perfdata_timeout", SETTER(int, perfdata_timeout)},
-    { "poller_name", SETTER(std::string const&, poller_name)},
-    { "poller_id", SETTER(uint32_t, poller_id)},
-    { "rpc_port", SETTER(uint16_t, rpc_port)},
+    {"poller_name", SETTER(std::string const&, poller_name)},
+    {"poller_id", SETTER(uint32_t, poller_id)},
+    {"rpc_port", SETTER(uint16_t, rpc_port)},
     {"precached_object_file",
      SETTER(std::string const&, _set_precached_object_file)},
     {"process_performance_data", SETTER(bool, process_performance_data)},
@@ -229,6 +231,8 @@ std::unordered_map<std::string, state::setter_func> const state::_setters{
      SETTER(std::string const&, _set_use_embedded_perl_implicitly)},
     {"use_large_installation_tweaks",
      SETTER(bool, use_large_installation_tweaks)},
+    {"instance_heartbeat_interval",
+     SETTER(uint32_t, instance_heartbeat_interval)},
     {"use_regexp_matching", SETTER(bool, use_regexp_matches)},
     {"use_retained_program_state", SETTER(bool, use_retained_program_state)},
     {"use_retained_scheduling_info",
@@ -351,6 +355,7 @@ static unsigned int const default_time_change_threshold(900);
 static bool const default_translate_passive_host_checks(false);
 static bool const default_use_aggressive_host_checking(false);
 static bool const default_use_large_installation_tweaks(false);
+static uint32_t const default_instance_heartbeat_interval(30);
 static bool const default_use_regexp_matches(false);
 static bool const default_use_retained_program_state(true);
 static bool const default_use_retained_scheduling_info(false);
@@ -475,6 +480,7 @@ state::state()
       _translate_passive_host_checks(default_translate_passive_host_checks),
       _use_aggressive_host_checking(default_use_aggressive_host_checking),
       _use_large_installation_tweaks(default_use_large_installation_tweaks),
+      _instance_heartbeat_interval(default_instance_heartbeat_interval),
       _use_regexp_matches(default_use_regexp_matches),
       _use_retained_program_state(default_use_retained_program_state),
       _use_retained_scheduling_info(default_use_retained_scheduling_info),
@@ -749,8 +755,7 @@ bool state::operator==(state const& right) const noexcept {
       _ocsp_timeout == right._ocsp_timeout &&
       _passive_host_checks_are_soft == right._passive_host_checks_are_soft &&
       _perfdata_timeout == right._perfdata_timeout &&
-      _poller_name == right._poller_name &&
-      _poller_id == right._poller_id &&
+      _poller_name == right._poller_name && _poller_id == right._poller_id &&
       _rpc_port == right._rpc_port &&
       _process_performance_data == right._process_performance_data &&
       _retained_contact_host_attribute_mask ==
@@ -3010,7 +3015,7 @@ set_servicegroup::iterator state::servicegroups_find(
 // *
 // *  @return All engine anomalydetections.
 // */
-//set_anomalydetection const& state::anomalydetections() const noexcept {
+// set_anomalydetection const& state::anomalydetections() const noexcept {
 //  return _anomalydetections;
 //}
 
@@ -3574,12 +3579,31 @@ bool state::use_large_installation_tweaks() const noexcept {
 }
 
 /**
+ * @brief Get instance_heartbeat_interval value. This is the minimal delay in
+ * seconds between two instance status sent to broker.
+ *
+ * @return this value in seconds.
+ */
+uint32_t state::instance_heartbeat_interval() const noexcept {
+  return _instance_heartbeat_interval;
+}
+
+/**
  *  Set use_large_installation_tweaks value.
  *
  *  @param[in] value The new use_large_installation_tweaks value.
  */
 void state::use_large_installation_tweaks(bool value) {
   _use_large_installation_tweaks = value;
+}
+
+/**
+ *  Set instance_heartbeat_interval value.
+ *
+ *  @param[in] value The new instance_heartbeat_interval value.
+ */
+void state::instance_heartbeat_interval(uint32_t value) {
+  _instance_heartbeat_interval = value;
 }
 
 /**

--- a/src/globals.cc
+++ b/src/globals.cc
@@ -21,7 +21,9 @@
 */
 
 #include "com/centreon/engine/globals.hh"
+
 #include <map>
+
 #include "com/centreon/engine/logging/logger.hh"
 #include "nagios.h"
 
@@ -98,6 +100,7 @@ unsigned int process_performance_data(false);
 unsigned int soft_state_dependencies(false);
 unsigned int use_aggressive_host_checking(false);
 unsigned int use_large_installation_tweaks(false);
+uint32_t instance_heartbeat_interval(30);
 unsigned long cached_host_check_horizon(15);
 unsigned long logging_options(
     logging::log_runtime_error | logging::log_runtime_warning |

--- a/src/statusdata.cc
+++ b/src/statusdata.cc
@@ -60,10 +60,14 @@ int cleanup_status_data(int delete_status_data) {
 /* updates program status info */
 int update_program_status(int aggregated_dump) {
   /* send data to event broker (non-aggregated dumps only) */
-  // FIXME DBR: -> instances update
-  // static time_t now = time(nullptr);
-  if (aggregated_dump == false)
-    broker_program_status(NEBTYPE_PROGRAMSTATUS_UPDATE, NEBFLAG_NONE,
-                          NEBATTR_NONE, NULL);
+  static time_t next_program_status =
+      time(nullptr) + instance_heartbeat_interval;
+  time_t now = time(nullptr);
+  if (now >= next_program_status) {
+    next_program_status += instance_heartbeat_interval;
+    if (!aggregated_dump)
+      broker_program_status(NEBTYPE_PROGRAMSTATUS_UPDATE, NEBFLAG_NONE,
+                            NEBATTR_NONE, NULL);
+  }
   return OK;
 }


### PR DESCRIPTION
## Description

There is a minimal delay now between two instance updates. This delay is instance_heartbeat_interval, it is an integer value representing seconds.
It may be configured in centengine.cfg. Its default value is 30.

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [X] 21.04.x (master)
