### PR TITLE
chore(build): remove centos6 support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,21 +13,7 @@ stage('Source') {
 
 try {
   stage('Unit tests') {
-    parallel 'centos6': {
-      node {
-        sh 'setup_centreon_build.sh'
-        sh './centreon-build/jobs/engine/3.4/mon-engine-unittest.sh centos6'
-        step([
-          $class: 'XUnitBuilder',
-          thresholds: [
-            [$class: 'FailedThreshold', failureThreshold: '0'],
-            [$class: 'SkippedThreshold', failureThreshold: '0']
-          ],
-          tools: [[$class: 'GoogleTestType', pattern: 'ut.xml']]
-        ])
-      }
-    },
-    'centos7': {
+    parallel 'centos7': {
       node {
         sh 'setup_centreon_build.sh'
         sh './centreon-build/jobs/engine/3.4/mon-engine-unittest.sh centos7'
@@ -52,13 +38,7 @@ try {
   }
 
   stage('Package') {
-    parallel 'centos6': {
-      node {
-        sh 'setup_centreon_build.sh'
-        sh './centreon-build/jobs/engine/3.4/mon-engine-package.sh centos6'
-      }
-    },
-    'centos7': {
+    parallel 'centos7': {
       node {
         sh 'setup_centreon_build.sh'
         sh './centreon-build/jobs/engine/3.4/mon-engine-package.sh centos7'


### PR DESCRIPTION
## Description

remove centos6 support

**Fixes** DEVOPS-121

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 2.8.x
- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x (master)