### PR TITLE
Let's use the new c++ abi when available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ if (WITH_ASAN)
   set (CMAKE_LINKER_FLAGS_DEBUG "${CMAKE_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
 endif ()
 
-add_definitions("-D_GLIBCXX_USE_CXX11_ABI=0")
+add_definitions("-D_GLIBCXX_USE_CXX11_ABI=1")
 set(INC_DIR "${PROJECT_SOURCE_DIR}/inc")
 set(SCRIPT_DIR "${PROJECT_SOURCE_DIR}/scripts")
 set(SRC_DIR "${PROJECT_SOURCE_DIR}/src")

--- a/cmake.sh
+++ b/cmake.sh
@@ -19,6 +19,9 @@ if [ -r /etc/centos-release ] ; then
     elif [ $maj = "centos7" ] ; then
       yum -y install epel-release cmake3
       cmake='cmake3'
+    else
+      dnf -y install cmake
+      cmake='cmake'
     fi
   fi
   if [[ ! -x /usr/bin/python3 ]] ; then

--- a/cmake.sh
+++ b/cmake.sh
@@ -17,7 +17,8 @@ if [ -r /etc/centos-release ] ; then
     if rpm -q cmake3 ; then
       cmake='cmake3'
     elif [ $maj = "centos7" ] ; then
-      yum -y install epel-release cmake3
+      yum -y install epel-release
+      yum -y install cmake3
       cmake='cmake3'
     else
       dnf -y install cmake

--- a/cmake.sh
+++ b/cmake.sh
@@ -1,24 +1,104 @@
 #!/bin/bash
 
-v=$(cmake --version)
-if [[ $v =~ "version 3" ]] ; then
-  cmake='cmake'
-else
-  if rpm -q cmake3 ; then
-    cmake='cmake3'
+if [ "$1" = "-f" ] ; then
+  force=1
+  shift
+fi
+
+# Am I root?
+my_id=$(id -u)
+
+if [ -r /etc/centos-release ] ; then
+  maj="centos$(cat /etc/centos-release | awk '{print $4}' | cut -f1 -d'.')"
+  v=$(cmake --version)
+  if [[ $v =~ "version 3" ]] ; then
+    cmake='cmake'
   else
-    yum -y install epel-release cmake3
-    cmake='cmake3'
+    if rpm -q cmake3 ; then
+      cmake='cmake3'
+    elif [ $maj = "centos7" ] ; then
+      yum -y install epel-release cmake3
+      cmake='cmake3'
+    fi
+  fi
+  if [[ ! -x /usr/bin/python3 ]] ; then
+    yum -y install python3
+  else
+    echo "python3 already installed"
+  fi
+  if ! rpm -q python3-pip ; then
+    yum -y install python3-pip
+  else
+    echo "pip3 already installed"
+  fi
+
+  if ! rpm -q gcc-c++ ; then
+    yum -y install gcc-c++
+  fi
+
+  pkgs=(
+  )
+  for i in "${pkgs[@]}"; do
+    if ! rpm -q $i ; then
+      if [ $maj = 'centos7' ] ; then
+        yum install -y $i
+      else
+        dnf -y --enablerepo=PowerTools install $i
+      fi
+    fi
+  done
+elif [ -r /etc/issue ] ; then
+  maj=$(cat /etc/issue | awk '{print $1}')
+  v=$(cmake --version)
+  if [[ $v =~ "version 3" ]] ; then
+    cmake='cmake'
+  elif [ $maj = "Debian" ] ; then
+    if dpkg -l --no-pager cmake ; then
+      echo "Bad version of cmake..."
+      exit 1
+    else
+      if [ $my_id -eq 0 ] ; then
+        apt install -y cmake
+        cmake='cmake'
+      else
+        echo -e "cmake is not installed, you could enter, as root:\n\tapt install -y cmake\n\n"
+        exit 1
+      fi
+    fi
+    pkgs=(
+      gcc
+      ninja-build
+      python3
+      python3-pip
+    )
+    for i in "${pkgs[@]}"; do
+      if ! dpkg -l --no-pager $i | grep "^ii" ; then
+        if [ $my_id -eq 0 ] ; then
+          apt install -y $i
+        else
+          echo -e "The package \"$i\" is not installed, you can install it, as root, with the command:\n\tapt install -y $i\n\n"
+          exit 1
+        fi
+      fi
+    done
+  else
+    echo "Bad version of cmake..."
+    exit 1
   fi
 fi
 
-if ! rpm -qa | grep "python3-pip" ; then
-  yum -y install python3-pip
+pip3 install conan --upgrade
+
+if [ $my_id -eq 0 ] ; then
+  conan='conan'
 else
-  echo "pip3 already installed"
+  conan="$HOME/.local/bin/conan"
+fi
+if ! $conan remote list | grep ^centreon ; then
+  $conan remote add centreon https://api.bintray.com/conan/centreon/centreon
 fi
 
-pip3 install conan
+good=$(gcc --version | awk '/gcc/ && ($3+0)>5.0{print 1}')
 
 if [ ! -d build ] ; then
   mkdir build
@@ -26,11 +106,25 @@ else
   echo "'build' directory already there"
 fi
 
-cd build
-conan remote add centreon https://api.bintray.com/conan/centreon/centreon
-conan install --remote centreon ..
+if [ ! -d build ] ; then
+  mkdir build
+else
+  echo "'build' directory already there"
+fi
 
-CXXFLAGS="-Wall -Wextra" "$cmake" -DWITH_PREFIX=/usr -DWITH_PREFIX_BIN=/usr/sbin -DWITH_USER=centreon-engine -DWITH_GROUP=centreon-engine -DCMAKE_BUILD_TYPE=Debug -DWITH_RW_DIR=/var/lib/centreon-engine/rw -DWITH_PREFIX_CONF=/etc/centreon-engine -DWITH_VAR_DIR=/var/log/centreon-engine -DWITH_PREFIX_LIB=/usr/lib64/centreon-engine -DWITH_TESTING=On -DWITH_SIMU=On $* -DWITH_CREATE_FILES=OFF -DWITH_BENCH=On ..
+if [ "$force" = "1" ] ; then
+  rm -rf build
+  mkdir build
+fi
+cd build
+
+if [ $good -eq 1 ] ; then
+  $conan install .. --remote centreon -s compiler.libcxx=libstdc++11
+else
+  $conan install .. --remote centreon -s compiler.libcxx=libstdc++
+fi
+
+CXXFLAGS="-Wall -Wextra" $cmake -DWITH_PREFIX=/usr -DWITH_PREFIX_BIN=/usr/sbin -DWITH_USER=centreon-engine -DWITH_GROUP=centreon-engine -DCMAKE_BUILD_TYPE=Debug -DWITH_RW_DIR=/var/lib/centreon-engine/rw -DWITH_PREFIX_CONF=/etc/centreon-engine -DWITH_VAR_DIR=/var/log/centreon-engine -DWITH_PREFIX_LIB=/usr/lib64/centreon-engine -DWITH_TESTING=On -DWITH_SIMU=On $* -DWITH_CREATE_FILES=OFF -DWITH_BENCH=On ..
 
 #CXX=/usr/bin/clang++ CC=/usr/bin/clang cmake -DWITH_PREFIX=/usr -DWITH_PREFIX_BIN=/usr/sbin -DWITH_USER=centreon-engine -DWITH_GROUP=centreon-engine -DCMAKE_BUILD_TYPE=Debug -DWITH_RW_DIR=/var/lib/centreon-engine/rw -DWITH_PREFIX_CONF=/etc/centreon-engine -DWITH_VAR_DIR=/var/log/centreon-engine -DWITH_PREFIX_LIB=/usr/lib64/centreon-engine -DWITH_TESTING=On -DWITH_SIMU=On .
 

--- a/cmake.sh
+++ b/cmake.sh
@@ -37,6 +37,7 @@ if [ -r /etc/centos-release ] ; then
   fi
 
   pkgs=(
+    ninja-build
   )
   for i in "${pkgs[@]}"; do
     if ! rpm -q $i ; then

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,7 +1,7 @@
 [requires]
 gtest/1.8.1@bincrafters/stable
 json11/e2e3a11@centreon/stable
-fmt/7.1.0
+fmt/7.1.2
 grpc/1.27.3@inexorgame/stable
 
 [generators]


### PR DESCRIPTION
## Description

Since gcc 5, we can use the new c++ abi. This patch allows use to do so.
The cmake.sh then compiles engine on Debian and Centos8 with this new abi, whereas it does not for Centos8 (gcc 4.8).

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)
