### PR TITLE
MON 6507 $TIMET$ macro displays time instead of epoch

### DIFF
--- a/src/macros.cc
+++ b/src/macros.cc
@@ -316,9 +316,7 @@ int grab_datetime_macro_r(nagios_macros* mac,
       break;
 
     case MACRO_TIMET:
-      get_datetime_string(&current_time, tmp_date, MAX_DATETIME_LENGTH,
-                          SHORT_TIME);
-      output = tmp_date;
+      output = std::to_string(current_time);
       break;
 
     case MACRO_ISVALIDTIME:

--- a/tests/macros/macro.cc
+++ b/tests/macros/macro.cc
@@ -209,7 +209,7 @@ TEST_F(Macro, TimeT) {
   std::string out;
   nagios_macros* mac(get_global_macros());
   process_macros_r(mac, "$TIMET:test_host$", out, 0);
-  ASSERT_EQ(out, "01:53:20");
+  ASSERT_EQ(out, "500000000");
 }
 
 TEST_F(Macro, ContactName) {


### PR DESCRIPTION
  fix(macro): the standard macro $TIMET$ now return time in a unix epoch format.

## Description

Please include a short resume of the changes and what is the purpose of PR. Any relevant information should be added to help:
* **QA Team** (Quality Assurance) with tests.
* **reviewers** to understand what are the stakes of the pull request.

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

