### PR TITLE
Mon 6538 Engine doesn't respect user's defined notification periods

### DIFF
--- a/src/notification.cc
+++ b/src/notification.cc
@@ -60,7 +60,6 @@ notification::notification(notifier* parent,
  * @return OK on success, ERROR otherwise.
  */
 int notification::execute(std::unordered_set<contact*> const& to_notify) {
-
   uint32_t contacts_notified{0};
 
   struct timeval start_time;
@@ -181,22 +180,17 @@ int notification::execute(std::unordered_set<contact*> const& to_notify) {
     /* clear summary macros (they are customized for each contact) */
     clear_summary_macros_r(mac);
 
-    /* check viability of notifying the user */
-    notifier::notification_category cat{notifier::get_category(_type)};
-    if (ctc->should_be_notified(cat, _type, *_parent)) {
-      /* notify this contact */
-      if (_parent->notify_contact(mac, ctc, _type, _author.c_str(),
-                                  _message.c_str(), _options,
-                                  _escalated) == OK) {
-        /* keep track of how many contacts were notified */
-        contacts_notified++;
-        _notified_contact.insert(ctc->get_name());
-        if (mac->x[MACRO_NOTIFICATIONRECIPIENTS].empty())
-          mac->x[MACRO_NOTIFICATIONRECIPIENTS] = ctc->get_name();
-        else {
-          mac->x[MACRO_NOTIFICATIONRECIPIENTS].append(",");
-          mac->x[MACRO_NOTIFICATIONRECIPIENTS].append(ctc->get_name());
-        }
+    /* notify this contact */
+    if (_parent->notify_contact(mac, ctc, _type, _author.c_str(),
+                                _message.c_str(), _options, _escalated) == OK) {
+      /* keep track of how many contacts were notified */
+      contacts_notified++;
+      _notified_contact.insert(ctc->get_name());
+      if (mac->x[MACRO_NOTIFICATIONRECIPIENTS].empty())
+        mac->x[MACRO_NOTIFICATIONRECIPIENTS] = ctc->get_name();
+      else {
+        mac->x[MACRO_NOTIFICATIONRECIPIENTS].append(",");
+        mac->x[MACRO_NOTIFICATIONRECIPIENTS].append(ctc->get_name());
       }
     }
   }

--- a/src/notifier.cc
+++ b/src/notifier.cc
@@ -219,9 +219,9 @@ bool notifier::_is_notification_viable_normal(reason_type type
 
   /* forced notifications bust through everything */
   uint32_t notification_interval =
-    !_notification[cat_normal]
-        ? _notification_interval
-        : _notification[cat_normal]->get_notification_interval();
+      !_notification[cat_normal]
+          ? _notification_interval
+          : _notification[cat_normal]->get_notification_interval();
 
   if (options & notification_option_forced) {
     logger(dbg_notifications, more)
@@ -270,7 +270,8 @@ bool notifier::_is_notification_viable_normal(reason_type type
     logger(dbg_notifications, more)
         << "This notifier shouldn't have notifications sent out "
            "at this time.";
-    if(notification_interval == 0 && config->postpone_notification_to_timeperiod()) {
+    if (notification_interval == 0 &&
+        config->postpone_notification_to_timeperiod()) {
       _notification_to_interval_on_timeperiod_in = true;
       logger(dbg_notifications, more)
           << "This notifier is save to send this notifications in "
@@ -335,9 +336,9 @@ bool notifier::_is_notification_viable_normal(reason_type type
     /* In the case of a state change, we don't care of the notification interval
      * and we notify as soon as we can */
     if (get_last_hard_state_change() <= _last_notification) {
-      if (notification_interval == 0 ) {
-        if (_notification_to_interval_on_timeperiod_in){
-          _notification_to_interval_on_timeperiod_in= false;
+      if (notification_interval == 0) {
+        if (_notification_to_interval_on_timeperiod_in) {
+          _notification_to_interval_on_timeperiod_in = false;
           return true;
         }
         logger(dbg_notifications, more)
@@ -721,7 +722,8 @@ std::unordered_set<contact*> notifier::get_contacts_to_notify(
          end{get_contacts().end()};
          it != end; ++it) {
       assert(it->second);
-      retval.insert(it->second);
+      if (it->second->should_be_notified(cat, type, *this))
+        retval.insert(it->second);
     }
 
     /* For each contact group, we also add its contacts. */
@@ -734,7 +736,8 @@ std::unordered_set<contact*> notifier::get_contacts_to_notify(
            cend{it->second->get_members().end()};
            cit != cend; ++cit) {
         assert(cit->second);
-        retval.insert(cit->second);
+        if (cit->second->should_be_notified(cat, type, *this))
+          retval.insert(cit->second);
       }
     }
   }

--- a/src/timeperiod.cc
+++ b/src/timeperiod.cc
@@ -1066,8 +1066,7 @@ void timeperiod::get_next_valid_time_per_timeperiod(time_t preferred_time,
           _add_round_days_to_midnight(ti.midnight, 24 * 60 * 60);
   }
 
-  // If we couldn't find a time period there must be none defined.
-
+  // If we couldn't find a time period there must be none defined and return -1.
   *valid_time = earliest_time;
 }
 

--- a/src/timeperiod.cc
+++ b/src/timeperiod.cc
@@ -1067,11 +1067,8 @@ void timeperiod::get_next_valid_time_per_timeperiod(time_t preferred_time,
   }
 
   // If we couldn't find a time period there must be none defined.
-  if (earliest_time == (time_t)-1)
-    *valid_time = original_preferred_time;
-  // Else use the calculated time.
-  else
-    *valid_time = earliest_time;
+
+  *valid_time = earliest_time;
 }
 
 /**

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -95,6 +95,7 @@ if (WITH_TESTING)
     "${TESTS_DIR}/notifications/host_normal_notification.cc"
     "${TESTS_DIR}/notifications/host_recovery_notification.cc"
     "${TESTS_DIR}/notifications/service_normal_notification.cc"
+    "${TESTS_DIR}/notifications/host_timeperiod_notification.cc"
     "${TESTS_DIR}/notifications/service_timeperiod_notification.cc"
     "${TESTS_DIR}/notifications/service_flapping_notification.cc"
     "${TESTS_DIR}/perfdata/perfdata.cc"

--- a/tests/macros/macro.cc
+++ b/tests/macros/macro.cc
@@ -884,7 +884,7 @@ TEST_F(Macro, IsValidTime) {
   std::string out;
   nagios_macros* mac(get_global_macros());
   process_macros_r(mac, "$ISVALIDTIME:test$", out, 1);
-  ASSERT_EQ(out, "0");
+  ASSERT_EQ(out, "1");
 }
 
 TEST_F(Macro, NextValidTime) {
@@ -893,6 +893,13 @@ TEST_F(Macro, NextValidTime) {
 
   time.parse("alias", "test");
   time.parse("timeperiod_name", "test");
+  time.parse("monday", "23:00-24:00");
+  time.parse("tuesday", "23:00-24:00");
+  time.parse("wednesday", "23:00-24:00");
+  time.parse("thursday", "23:00-24:00");
+  time.parse("friday", "23:00-24:00");
+  time.parse("saterday", "23:00-24:00");
+  time.parse("sunday", "23:00-24:00");
   time_aply.add_object(time);
 
   init_macros();
@@ -902,7 +909,7 @@ TEST_F(Macro, NextValidTime) {
   std::string out;
   nagios_macros* mac(get_global_macros());
   process_macros_r(mac, "$NEXTVALIDTIME:test$", out, 1);
-  ASSERT_EQ(out, "01:53:20");
+  ASSERT_EQ(out, "23:00:00");
 }
 
 TEST_F(Macro, ContactTimeZone) {

--- a/tests/notifications/service_timeperiod_notification.cc
+++ b/tests/notifications/service_timeperiod_notification.cc
@@ -464,7 +464,6 @@ TEST_F(ServiceTimePeriodNotification, TimePeriodUserOut) {
   configuration::applier::contact ct_aply;
   configuration::contact ctct;
   ctct.parse("contact_name", "test_contact");
-  ctct.parse("host_notification_period", "24x9");
   ctct.parse("service_notification_period", "24x9");
   ctct.parse("host_notification_commands", "cmd");
   ctct.parse("service_notification_commands", "cmd");
@@ -590,7 +589,6 @@ TEST_F(ServiceTimePeriodNotification, TimePeriodUserIn) {
   configuration::applier::contact ct_aply;
   configuration::contact ctct;
   ctct.parse("contact_name", "test_contact");
-  ctct.parse("host_notification_period", "24x9");
   ctct.parse("service_notification_period", "24x9");
   ctct.parse("host_notification_commands", "cmd");
   ctct.parse("service_notification_commands", "cmd");
@@ -716,7 +714,6 @@ TEST_F(ServiceTimePeriodNotification, TimePeriodUserAll) {
   configuration::applier::contact ct_aply;
   configuration::contact ctct;
   ctct.parse("contact_name", "test_contact");
-  ctct.parse("host_notification_period", "24x9");
   ctct.parse("service_notification_period", "24x9");
   ctct.parse("host_notification_commands", "cmd");
   ctct.parse("service_notification_commands", "cmd");
@@ -835,7 +832,6 @@ TEST_F(ServiceTimePeriodNotification, TimePeriodUserNone) {
   configuration::applier::contact ct_aply;
   configuration::contact ctct;
   ctct.parse("contact_name", "test_contact");
-  ctct.parse("host_notification_period", "24x9");
   ctct.parse("service_notification_period", "24x9");
   ctct.parse("host_notification_commands", "cmd");
   ctct.parse("service_notification_commands", "cmd");

--- a/tests/notifications/service_timeperiod_notification.cc
+++ b/tests/notifications/service_timeperiod_notification.cc
@@ -25,6 +25,7 @@
 #include <iostream>
 #include <memory>
 
+#include <com/centreon/engine/configuration/applier/timeperiod.hh>
 #include <com/centreon/engine/macros.hh>
 #include <com/centreon/engine/macros/grab_host.hh>
 #include <com/centreon/engine/macros/process.hh>
@@ -32,19 +33,18 @@
 #include "../timeperiod/utils.hh"
 #include "com/centreon/engine/checks/checker.hh"
 #include "com/centreon/engine/configuration/applier/contact.hh"
-#include "com/centreon/engine/configuration/applier/state.hh"
 #include "com/centreon/engine/configuration/applier/contactgroup.hh"
 #include "com/centreon/engine/configuration/applier/host.hh"
 #include "com/centreon/engine/configuration/applier/service.hh"
 #include "com/centreon/engine/configuration/applier/servicedependency.hh"
 #include "com/centreon/engine/configuration/applier/serviceescalation.hh"
+#include "com/centreon/engine/configuration/applier/state.hh"
 #include "com/centreon/engine/configuration/host.hh"
 #include "com/centreon/engine/configuration/service.hh"
 #include "com/centreon/engine/exceptions/error.hh"
 #include "com/centreon/engine/modules/external_commands/commands.hh"
 #include "com/centreon/engine/serviceescalation.hh"
 #include "com/centreon/engine/timeperiod.hh"
-#include <com/centreon/engine/configuration/applier/timeperiod.hh>
 #include "helper.hh"
 
 using namespace com::centreon;
@@ -52,7 +52,7 @@ using namespace com::centreon::engine;
 using namespace com::centreon::engine::configuration;
 using namespace com::centreon::engine::configuration::applier;
 
-//extern configuration::state* config;
+// extern configuration::state* config;
 
 class ServiceTimePeriodNotification : public TestEngine {
  public:
@@ -96,7 +96,8 @@ class ServiceTimePeriodNotification : public TestEngine {
     _svc->set_notify_on(static_cast<uint32_t>(-1));
 
     _tp = _creator.new_timeperiod();
-    for (int i(0); i < 7; ++i) _creator.new_timerange(0, 0, 24, 0, i);
+    for (int i(0); i < 7; ++i)
+      _creator.new_timerange(0, 0, 24, 0, i);
     _now = strtotimet("2016-11-24 08:00:00");
     set_time(_now);
   }
@@ -167,7 +168,6 @@ TEST_F(ServiceTimePeriodNotification, NoTimePeriodOk) {
   _svc->set_state_type(checkable::hard);
   _svc->set_accept_passive_checks(true);
   _svc->set_notification_period_ptr(tperiod.get());
-  nagios_macros* mac(get_global_macros());
 
   testing::internal::CaptureStdout();
   for (int i = 0; i < 12; i++) {
@@ -214,15 +214,15 @@ TEST_F(ServiceTimePeriodNotification, NoTimePeriodOk) {
   std::string out{testing::internal::GetCapturedStdout()};
   std::cout << out << std::endl;
   size_t step1{out.find("NOW = 32000")};
-  size_t step2{out.find(
-      "SERVICE NOTIFICATION: "
-      "test_contact;test_host;test_svc;CRITICAL;cmd;service critical",
-      step1 + 1)};
+  size_t step2{
+      out.find("SERVICE NOTIFICATION: "
+               "test_contact;test_host;test_svc;CRITICAL;cmd;service critical",
+               step1 + 1)};
   size_t step3{out.find("NOW = 70000", step2 + 1)};
-  size_t step4{out.find(
-      "SERVICE NOTIFICATION: test_contact;test_host;test_svc;RECOVERY "
-      "(OK);cmd;service ok",
-      step3 + 1)};
+  size_t step4{
+      out.find("SERVICE NOTIFICATION: test_contact;test_host;test_svc;RECOVERY "
+               "(OK);cmd;service ok",
+               step3 + 1)};
   ASSERT_NE(step4, std::string::npos);
 }
 
@@ -272,7 +272,6 @@ TEST_F(ServiceTimePeriodNotification, NoTimePeriodKo) {
   _svc->set_state_type(checkable::hard);
   _svc->set_accept_passive_checks(true);
   _svc->set_notification_period_ptr(tperiod.get());
-  nagios_macros* mac(get_global_macros());
 
   testing::internal::CaptureStdout();
 
@@ -320,22 +319,22 @@ TEST_F(ServiceTimePeriodNotification, NoTimePeriodKo) {
   std::string out{testing::internal::GetCapturedStdout()};
   std::cout << out << std::endl;
   size_t step1{out.find("NOW = 35000")};
-  size_t step2{out.find(
-      "SERVICE NOTIFICATION: "
-      "test_contact;test_host;test_svc;CRITICAL;cmd;service critical",
-      step1 + 1)};
+  size_t step2{
+      out.find("SERVICE NOTIFICATION: "
+               "test_contact;test_host;test_svc;CRITICAL;cmd;service critical",
+               step1 + 1)};
   size_t step3{out.find("NOW = 59000", step2 + 1)};
-  size_t step4{out.find(
-      "SERVICE NOTIFICATION: test_contact;test_host;test_svc;RECOVERY "
-      "(OK);cmd;service ok",
-      step3 + 1)};
+  size_t step4{
+      out.find("SERVICE NOTIFICATION: test_contact;test_host;test_svc;RECOVERY "
+               "(OK);cmd;service ok",
+               step3 + 1)};
   ASSERT_NE(step4, std::string::npos);
 
   size_t step5{out.find("NOW = 44000")};
-  size_t step6{out.find(
-      "SERVICE NOTIFICATION: "
-      "test_contact;test_host;test_svc;CRITICAL;cmd;service critical",
-      step5 + 1)};
+  size_t step6{
+      out.find("SERVICE NOTIFICATION: "
+               "test_contact;test_host;test_svc;CRITICAL;cmd;service critical",
+               step5 + 1)};
   ASSERT_EQ(step6, std::string::npos);
 }
 
@@ -385,7 +384,6 @@ TEST_F(ServiceTimePeriodNotification, TimePeriodOut) {
   _svc->set_state_type(checkable::hard);
   _svc->set_accept_passive_checks(true);
   _svc->set_notification_period_ptr(tperiod.get());
-  nagios_macros* mac(get_global_macros());
 
   testing::internal::CaptureStdout();
   for (int i = 0; i < 12; i++) {
@@ -432,14 +430,628 @@ TEST_F(ServiceTimePeriodNotification, TimePeriodOut) {
   std::string out{testing::internal::GetCapturedStdout()};
   std::cout << out << std::endl;
   size_t step1{out.find("NOW = 32000")};
-  size_t step2{out.find(
-      "SERVICE NOTIFICATION: "
-      "test_contact;test_host;test_svc;CRITICAL;cmd;service critical",
-      step1 + 1)};
+  size_t step2{
+      out.find("SERVICE NOTIFICATION: "
+               "test_contact;test_host;test_svc;CRITICAL;cmd;service critical",
+               step1 + 1)};
   size_t step3{out.find("NOW = 59000", step2 + 1)};
-  size_t step4{out.find(
-      "SERVICE NOTIFICATION: test_contact;test_host;test_svc;RECOVERY "
-      "(OK);cmd;service ok",
-      step3 + 1)};
+  size_t step4{
+      out.find("SERVICE NOTIFICATION: test_contact;test_host;test_svc;RECOVERY "
+               "(OK);cmd;service ok",
+               step3 + 1)};
   ASSERT_EQ(step4, std::string::npos);
+}
+
+TEST_F(ServiceTimePeriodNotification, TimePeriodUserOut) {
+  init_macros();
+  std::unique_ptr<engine::timeperiod> tiperiod{
+      new engine::timeperiod("tperiod", "alias")};
+  int now{20000};
+  set_time(now);
+  configuration::timeperiod tperiod;
+  tperiod.parse("timeperiod_name", "24x9");
+  tperiod.parse("alias", "24x9");
+  tperiod.parse("monday", "00:00-09:00");
+  tperiod.parse("tuesday", "00:00-09:00");
+  tperiod.parse("wednesday", "00:00-09:00");
+  tperiod.parse("thursday", "00:00-09:00");
+  tperiod.parse("friday", "00:00-09:00");
+  tperiod.parse("saterday", "00:00-09:00");
+  tperiod.parse("sunday", "00:00-09:00");
+  configuration::applier::timeperiod aplyr;
+  aplyr.add_object(tperiod);
+
+  configuration::applier::contact ct_aply;
+  configuration::contact ctct;
+  ctct.parse("contact_name", "test_contact");
+  ctct.parse("host_notification_period", "24x9");
+  ctct.parse("service_notification_period", "24x9");
+  ctct.parse("host_notification_commands", "cmd");
+  ctct.parse("service_notification_commands", "cmd");
+  ctct.parse("host_notification_options", "d,r,f,s");
+  ctct.parse("service_notification_options", "a");
+  ctct.parse("host_notifications_enabled", "1");
+  ctct.parse("service_notifications_enabled", "1");
+
+  ct_aply.add_object(ctct);
+  ct_aply.expand_objects(*config);
+  ct_aply.resolve_object(ctct);
+
+  configuration::applier::contactgroup cg_aply;
+  configuration::contactgroup cg{
+      new_configuration_contactgroup("test_cg", "test_contact")};
+  cg_aply.add_object(cg);
+  cg_aply.expand_objects(*config);
+  cg_aply.resolve_object(cg);
+
+  configuration::applier::serviceescalation se_aply;
+  configuration::serviceescalation se{
+      new_configuration_serviceescalation("test_host", "test_svc", "test_cg")};
+  se_aply.add_object(se);
+  se_aply.expand_objects(*config);
+  se_aply.resolve_object(se);
+
+  // uint64_t id{_svc->get_next_notification_id()};
+  for (int i = 0; i < 7; ++i) {
+    timerange_list list_time;
+    // list_time.push_back(std::make_shared<engine::timerange>(1000, 15000));
+    list_time.push_back(std::make_shared<engine::timerange>(8000, 85000));
+    tiperiod->days[i] = list_time;
+  }
+
+  _svc->set_current_state(engine::service::state_ok);
+  _svc->set_notification_interval(1);
+  _svc->set_last_hard_state(engine::service::state_ok);
+  _svc->set_last_hard_state_change(20000);
+  _svc->set_state_type(checkable::hard);
+  _svc->set_accept_passive_checks(true);
+  _svc->set_last_hard_state(engine::service::state_ok);
+  _svc->set_last_hard_state_change(now);
+  _svc->set_state_type(checkable::hard);
+  _svc->set_accept_passive_checks(true);
+  _svc->set_notification_period_ptr(tiperiod.get());
+
+  testing::internal::CaptureStdout();
+  for (int i = 0; i < 12; i++) {
+    // When i == 0, the state_critical is soft => no notification
+    // When i == 1, the state_critical is soft => no notification
+    // When i == 2, the state_critical is hard down => notification
+    now += 3000;
+    std::cout << "NOW = " << now << std::endl;
+    set_time(now);
+    _svc->set_last_state(_svc->get_current_state());
+    if (notifier::hard == _svc->get_state_type())
+      _svc->set_last_hard_state(_svc->get_current_state());
+
+    std::ostringstream oss;
+    std::time_t now{std::time(nullptr)};
+    oss << '[' << now << ']'
+        << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;service "
+           "critical";
+    std::string cmd{oss.str()};
+    process_external_command(cmd.c_str());
+    checks::checker::instance().reap();
+  }
+
+  now += 3000;
+  std::cout << "NOW = " << now << std::endl;
+  set_time(now);
+  std::ostringstream oss;
+  oss << '[' << now << ']'
+      << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;0;service ok";
+  std::string cmd{oss.str()};
+  process_external_command(cmd.c_str());
+  checks::checker::instance().reap();
+
+  now = 70000;
+  std::cout << "NOW = " << now << std::endl;
+  set_time(now);
+  oss.str("");
+  oss << '[' << now << ']'
+      << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;0;service ok";
+  cmd = oss.str();
+  process_external_command(cmd.c_str());
+  checks::checker::instance().reap();
+
+  std::string out{testing::internal::GetCapturedStdout()};
+  std::cout << out << std::endl;
+  size_t step1{out.find("NOW = 32000")};
+  size_t step2{
+      out.find("SERVICE NOTIFICATION: "
+               "test_contact;test_host;test_svc;CRITICAL;cmd;service critical",
+               step1 + 1)};
+  size_t step3{out.find("NOW = 59000", step2 + 1)};
+  size_t step4{
+      out.find("SERVICE NOTIFICATION: test_contact;test_host;test_svc;RECOVERY "
+               "(OK);cmd;service ok",
+               step3 + 1)};
+  ASSERT_EQ(step4, std::string::npos);
+}
+
+TEST_F(ServiceTimePeriodNotification, TimePeriodUserIn) {
+  init_macros();
+  std::unique_ptr<engine::timeperiod> tiperiod{
+      new engine::timeperiod("tperiod", "alias")};
+  int now{20000};
+  set_time(now);
+  configuration::timeperiod tperiod;
+  tperiod.parse("timeperiod_name", "24x9");
+  tperiod.parse("alias", "24x9");
+  tperiod.parse("monday", "09:00-20:00");
+  tperiod.parse("tuesday", "09:00-20:00");
+  tperiod.parse("wednesday", "09:00-20:00");
+  tperiod.parse("thursday", "09:00-20:00");
+  tperiod.parse("friday", "09:00-20:00");
+  tperiod.parse("saterday", "09:00-20:00");
+  tperiod.parse("sunday", "09:00-20:00");
+  configuration::applier::timeperiod aplyr;
+  aplyr.add_object(tperiod);
+
+  configuration::applier::contact ct_aply;
+  configuration::contact ctct;
+  ctct.parse("contact_name", "test_contact");
+  ctct.parse("host_notification_period", "24x9");
+  ctct.parse("service_notification_period", "24x9");
+  ctct.parse("host_notification_commands", "cmd");
+  ctct.parse("service_notification_commands", "cmd");
+  ctct.parse("host_notification_options", "d,r,f,s");
+  ctct.parse("service_notification_options", "a");
+  ctct.parse("host_notifications_enabled", "1");
+  ctct.parse("service_notifications_enabled", "1");
+
+  ct_aply.add_object(ctct);
+  ct_aply.expand_objects(*config);
+  ct_aply.resolve_object(ctct);
+
+  configuration::applier::contactgroup cg_aply;
+  configuration::contactgroup cg{
+      new_configuration_contactgroup("test_cg", "test_contact")};
+  cg_aply.add_object(cg);
+  cg_aply.expand_objects(*config);
+  cg_aply.resolve_object(cg);
+
+  configuration::applier::serviceescalation se_aply;
+  configuration::serviceescalation se{
+      new_configuration_serviceescalation("test_host", "test_svc", "test_cg")};
+  se_aply.add_object(se);
+  se_aply.expand_objects(*config);
+  se_aply.resolve_object(se);
+
+  // uint64_t id{_svc->get_next_notification_id()};
+  for (int i = 0; i < 7; ++i) {
+    timerange_list list_time;
+    // list_time.push_back(std::make_shared<engine::timerange>(1000, 15000));
+    list_time.push_back(std::make_shared<engine::timerange>(8000, 85000));
+    tiperiod->days[i] = list_time;
+  }
+
+  _svc->set_current_state(engine::service::state_ok);
+  _svc->set_notification_interval(1);
+  _svc->set_last_hard_state(engine::service::state_ok);
+  _svc->set_last_hard_state_change(20000);
+  _svc->set_state_type(checkable::hard);
+  _svc->set_accept_passive_checks(true);
+  _svc->set_last_hard_state(engine::service::state_ok);
+  _svc->set_last_hard_state_change(now);
+  _svc->set_state_type(checkable::hard);
+  _svc->set_accept_passive_checks(true);
+  _svc->set_notification_period_ptr(tiperiod.get());
+
+  testing::internal::CaptureStdout();
+  for (int i = 0; i < 12; i++) {
+    // When i == 0, the state_critical is soft => no notification
+    // When i == 1, the state_critical is soft => no notification
+    // When i == 2, the state_critical is hard down => notification
+    now += 3000;
+    std::cout << "NOW = " << now << std::endl;
+    set_time(now);
+    _svc->set_last_state(_svc->get_current_state());
+    if (notifier::hard == _svc->get_state_type())
+      _svc->set_last_hard_state(_svc->get_current_state());
+
+    std::ostringstream oss;
+    std::time_t now{std::time(nullptr)};
+    oss << '[' << now << ']'
+        << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;service "
+           "critical";
+    std::string cmd{oss.str()};
+    process_external_command(cmd.c_str());
+    checks::checker::instance().reap();
+  }
+
+  now += 3000;
+  std::cout << "NOW = " << now << std::endl;
+  set_time(now);
+  std::ostringstream oss;
+  oss << '[' << now << ']'
+      << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;0;service ok";
+  std::string cmd{oss.str()};
+  process_external_command(cmd.c_str());
+  checks::checker::instance().reap();
+
+  now = 70000;
+  std::cout << "NOW = " << now << std::endl;
+  set_time(now);
+  oss.str("");
+  oss << '[' << now << ']'
+      << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;0;service ok";
+  cmd = oss.str();
+  process_external_command(cmd.c_str());
+  checks::checker::instance().reap();
+
+  std::string out{testing::internal::GetCapturedStdout()};
+  std::cout << out << std::endl;
+  size_t step1{out.find("NOW = 32000")};
+  size_t step2{
+      out.find("SERVICE NOTIFICATION: "
+               "test_contact;test_host;test_svc;CRITICAL;cmd;service critical",
+               step1 + 1)};
+  size_t step3{out.find("NOW = 59000", step2 + 1)};
+  size_t step4{
+      out.find("SERVICE NOTIFICATION: test_contact;test_host;test_svc;RECOVERY "
+               "(OK);cmd;service ok",
+               step3 + 1)};
+  ASSERT_NE(step4, std::string::npos);
+}
+
+TEST_F(ServiceTimePeriodNotification, TimePeriodUserAll) {
+  init_macros();
+  std::unique_ptr<engine::timeperiod> tiperiod{
+      new engine::timeperiod("tperiod", "alias")};
+  int now{20000};
+  set_time(now);
+  configuration::timeperiod tperiod;
+  tperiod.parse("timeperiod_name", "24x9");
+  tperiod.parse("alias", "24x9");
+  tperiod.parse("monday", "00:00-24:00");
+  tperiod.parse("tuesday", "00:00-24:00");
+  tperiod.parse("wednesday", "00:00-24:00");
+  tperiod.parse("thursday", "00:00-24:00");
+  tperiod.parse("friday", "00:00-24:00");
+  tperiod.parse("saterday", "00:00-24:00");
+  tperiod.parse("sunday", "00:00-24:00");
+  configuration::applier::timeperiod aplyr;
+  aplyr.add_object(tperiod);
+
+  configuration::applier::contact ct_aply;
+  configuration::contact ctct;
+  ctct.parse("contact_name", "test_contact");
+  ctct.parse("host_notification_period", "24x9");
+  ctct.parse("service_notification_period", "24x9");
+  ctct.parse("host_notification_commands", "cmd");
+  ctct.parse("service_notification_commands", "cmd");
+  ctct.parse("host_notification_options", "d,r,f,s");
+  ctct.parse("service_notification_options", "a");
+  ctct.parse("host_notifications_enabled", "1");
+  ctct.parse("service_notifications_enabled", "1");
+
+  ct_aply.add_object(ctct);
+  ct_aply.expand_objects(*config);
+  ct_aply.resolve_object(ctct);
+
+  configuration::applier::contactgroup cg_aply;
+  configuration::contactgroup cg{
+      new_configuration_contactgroup("test_cg", "test_contact")};
+  cg_aply.add_object(cg);
+  cg_aply.expand_objects(*config);
+  cg_aply.resolve_object(cg);
+
+  configuration::applier::serviceescalation se_aply;
+  configuration::serviceescalation se{
+      new_configuration_serviceescalation("test_host", "test_svc", "test_cg")};
+  se_aply.add_object(se);
+  se_aply.expand_objects(*config);
+  se_aply.resolve_object(se);
+
+  // uint64_t id{_svc->get_next_notification_id()};
+  for (int i = 0; i < 7; ++i) {
+    timerange_list list_time;
+    // list_time.push_back(std::make_shared<engine::timerange>(1000, 15000));
+    list_time.push_back(std::make_shared<engine::timerange>(8000, 85000));
+    tiperiod->days[i] = list_time;
+  }
+
+  _svc->set_current_state(engine::service::state_ok);
+  _svc->set_notification_interval(1);
+  _svc->set_last_hard_state(engine::service::state_ok);
+  _svc->set_last_hard_state_change(20000);
+  _svc->set_state_type(checkable::hard);
+  _svc->set_accept_passive_checks(true);
+  _svc->set_last_hard_state(engine::service::state_ok);
+  _svc->set_last_hard_state_change(now);
+  _svc->set_state_type(checkable::hard);
+  _svc->set_accept_passive_checks(true);
+  _svc->set_notification_period_ptr(tiperiod.get());
+
+  testing::internal::CaptureStdout();
+  for (int i = 0; i < 12; i++) {
+    // When i == 0, the state_critical is soft => no notification
+    // When i == 1, the state_critical is soft => no notification
+    // When i == 2, the state_critical is hard down => notification
+    now += 3000;
+    std::cout << "NOW = " << now << std::endl;
+    set_time(now);
+    _svc->set_last_state(_svc->get_current_state());
+    if (notifier::hard == _svc->get_state_type())
+      _svc->set_last_hard_state(_svc->get_current_state());
+
+    std::ostringstream oss;
+    std::time_t now{std::time(nullptr)};
+    oss << '[' << now << ']'
+        << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;service "
+           "critical";
+    std::string cmd{oss.str()};
+    process_external_command(cmd.c_str());
+    checks::checker::instance().reap();
+  }
+
+  now += 3000;
+  std::cout << "NOW = " << now << std::endl;
+  set_time(now);
+  std::ostringstream oss;
+  oss << '[' << now << ']'
+      << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;0;service ok";
+  std::string cmd{oss.str()};
+  process_external_command(cmd.c_str());
+  checks::checker::instance().reap();
+
+  now = 70000;
+  std::cout << "NOW = " << now << std::endl;
+  set_time(now);
+  oss.str("");
+  oss << '[' << now << ']'
+      << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;0;service ok";
+  cmd = oss.str();
+  process_external_command(cmd.c_str());
+  checks::checker::instance().reap();
+
+  std::string out{testing::internal::GetCapturedStdout()};
+  std::cout << out << std::endl;
+  size_t step1{out.find("NOW = 32000")};
+  size_t step2{
+      out.find("SERVICE NOTIFICATION: "
+               "test_contact;test_host;test_svc;CRITICAL;cmd;service critical",
+               step1 + 1)};
+  size_t step3{out.find("NOW = 59000", step2 + 1)};
+  size_t step4{
+      out.find("SERVICE NOTIFICATION: test_contact;test_host;test_svc;RECOVERY "
+               "(OK);cmd;service ok",
+               step3 + 1)};
+  ASSERT_NE(step4, std::string::npos);
+}
+
+TEST_F(ServiceTimePeriodNotification, TimePeriodUserNone) {
+  init_macros();
+  std::unique_ptr<engine::timeperiod> tiperiod{
+      new engine::timeperiod("tperiod", "alias")};
+  int now{20000};
+  set_time(now);
+  configuration::timeperiod tperiod;
+  tperiod.parse("timeperiod_name", "24x9");
+  tperiod.parse("alias", "24x9");
+  configuration::applier::timeperiod aplyr;
+  aplyr.add_object(tperiod);
+
+  configuration::applier::contact ct_aply;
+  configuration::contact ctct;
+  ctct.parse("contact_name", "test_contact");
+  ctct.parse("host_notification_period", "24x9");
+  ctct.parse("service_notification_period", "24x9");
+  ctct.parse("host_notification_commands", "cmd");
+  ctct.parse("service_notification_commands", "cmd");
+  ctct.parse("host_notification_options", "d,r,f,s");
+  ctct.parse("service_notification_options", "a");
+  ctct.parse("host_notifications_enabled", "1");
+  ctct.parse("service_notifications_enabled", "1");
+
+  ct_aply.add_object(ctct);
+  ct_aply.expand_objects(*config);
+  ct_aply.resolve_object(ctct);
+
+  configuration::applier::contactgroup cg_aply;
+  configuration::contactgroup cg{
+      new_configuration_contactgroup("test_cg", "test_contact")};
+  cg_aply.add_object(cg);
+  cg_aply.expand_objects(*config);
+  cg_aply.resolve_object(cg);
+
+  configuration::applier::serviceescalation se_aply;
+  configuration::serviceescalation se{
+      new_configuration_serviceescalation("test_host", "test_svc", "test_cg")};
+  se_aply.add_object(se);
+  se_aply.expand_objects(*config);
+  se_aply.resolve_object(se);
+
+  // uint64_t id{_svc->get_next_notification_id()};
+  for (int i = 0; i < 7; ++i) {
+    timerange_list list_time;
+    // list_time.push_back(std::make_shared<engine::timerange>(1000, 15000));
+    list_time.push_back(std::make_shared<engine::timerange>(8000, 85000));
+    tiperiod->days[i] = list_time;
+  }
+
+  _svc->set_current_state(engine::service::state_ok);
+  _svc->set_notification_interval(1);
+  _svc->set_last_hard_state(engine::service::state_ok);
+  _svc->set_last_hard_state_change(20000);
+  _svc->set_state_type(checkable::hard);
+  _svc->set_accept_passive_checks(true);
+  _svc->set_last_hard_state(engine::service::state_ok);
+  _svc->set_last_hard_state_change(now);
+  _svc->set_state_type(checkable::hard);
+  _svc->set_accept_passive_checks(true);
+  _svc->set_notification_period_ptr(tiperiod.get());
+
+  testing::internal::CaptureStdout();
+  for (int i = 0; i < 12; i++) {
+    // When i == 0, the state_critical is soft => no notification
+    // When i == 1, the state_critical is soft => no notification
+    // When i == 2, the state_critical is hard down => notification
+    now += 3000;
+    std::cout << "NOW = " << now << std::endl;
+    set_time(now);
+    _svc->set_last_state(_svc->get_current_state());
+    if (notifier::hard == _svc->get_state_type())
+      _svc->set_last_hard_state(_svc->get_current_state());
+
+    std::ostringstream oss;
+    std::time_t now{std::time(nullptr)};
+    oss << '[' << now << ']'
+        << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;service "
+           "critical";
+    std::string cmd{oss.str()};
+    process_external_command(cmd.c_str());
+    checks::checker::instance().reap();
+  }
+
+  now += 3000;
+  std::cout << "NOW = " << now << std::endl;
+  set_time(now);
+  std::ostringstream oss;
+  oss << '[' << now << ']'
+      << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;0;service ok";
+  std::string cmd{oss.str()};
+  process_external_command(cmd.c_str());
+  checks::checker::instance().reap();
+
+  now = 70000;
+  std::cout << "NOW = " << now << std::endl;
+  set_time(now);
+  oss.str("");
+  oss << '[' << now << ']'
+      << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;0;service ok";
+  cmd = oss.str();
+  process_external_command(cmd.c_str());
+  checks::checker::instance().reap();
+
+  std::string out{testing::internal::GetCapturedStdout()};
+  std::cout << out << std::endl;
+  size_t step1{out.find("NOW = 32000")};
+  size_t step2{
+      out.find("SERVICE NOTIFICATION: "
+               "test_contact;test_host;test_svc;CRITICAL;cmd;service critical",
+               step1 + 1)};
+  size_t step3{out.find("NOW = 59000", step2 + 1)};
+  size_t step4{
+      out.find("SERVICE NOTIFICATION: test_contact;test_host;test_svc;RECOVERY "
+               "(OK);cmd;service ok",
+               step3 + 1)};
+  ASSERT_EQ(step4, std::string::npos);
+}
+
+TEST_F(ServiceTimePeriodNotification, NoTimePeriodUser) {
+  init_macros();
+  std::unique_ptr<engine::timeperiod> tiperiod{
+      new engine::timeperiod("tperiod", "alias")};
+  int now{20000};
+  set_time(now);
+  configuration::timeperiod tperiod;
+  tperiod.parse("timeperiod_name", "24x9");
+  tperiod.parse("alias", "24x9");
+  configuration::applier::timeperiod aplyr;
+  aplyr.add_object(tperiod);
+
+  configuration::applier::contact ct_aply;
+  configuration::contact ctct;
+  ctct.parse("contact_name", "test_contact");
+  ctct.parse("host_notification_commands", "cmd");
+  ctct.parse("service_notification_commands", "cmd");
+  ctct.parse("host_notification_options", "d,r,f,s");
+  ctct.parse("service_notification_options", "a");
+  ctct.parse("host_notifications_enabled", "1");
+  ctct.parse("service_notifications_enabled", "1");
+
+  ct_aply.add_object(ctct);
+  ct_aply.expand_objects(*config);
+  ct_aply.resolve_object(ctct);
+
+  configuration::applier::contactgroup cg_aply;
+  configuration::contactgroup cg{
+      new_configuration_contactgroup("test_cg", "test_contact")};
+  cg_aply.add_object(cg);
+  cg_aply.expand_objects(*config);
+  cg_aply.resolve_object(cg);
+
+  configuration::applier::serviceescalation se_aply;
+  configuration::serviceescalation se{
+      new_configuration_serviceescalation("test_host", "test_svc", "test_cg")};
+  se_aply.add_object(se);
+  se_aply.expand_objects(*config);
+  se_aply.resolve_object(se);
+
+  // uint64_t id{_svc->get_next_notification_id()};
+  for (int i = 0; i < 7; ++i) {
+    timerange_list list_time;
+    // list_time.push_back(std::make_shared<engine::timerange>(1000, 15000));
+    list_time.push_back(std::make_shared<engine::timerange>(8000, 85000));
+    tiperiod->days[i] = list_time;
+  }
+
+  _svc->set_current_state(engine::service::state_ok);
+  _svc->set_notification_interval(1);
+  _svc->set_last_hard_state(engine::service::state_ok);
+  _svc->set_last_hard_state_change(20000);
+  _svc->set_state_type(checkable::hard);
+  _svc->set_accept_passive_checks(true);
+  _svc->set_last_hard_state(engine::service::state_ok);
+  _svc->set_last_hard_state_change(now);
+  _svc->set_state_type(checkable::hard);
+  _svc->set_accept_passive_checks(true);
+  _svc->set_notification_period_ptr(tiperiod.get());
+
+  testing::internal::CaptureStdout();
+  for (int i = 0; i < 12; i++) {
+    // When i == 0, the state_critical is soft => no notification
+    // When i == 1, the state_critical is soft => no notification
+    // When i == 2, the state_critical is hard down => notification
+    now += 3000;
+    std::cout << "NOW = " << now << std::endl;
+    set_time(now);
+    _svc->set_last_state(_svc->get_current_state());
+    if (notifier::hard == _svc->get_state_type())
+      _svc->set_last_hard_state(_svc->get_current_state());
+
+    std::ostringstream oss;
+    std::time_t now{std::time(nullptr)};
+    oss << '[' << now << ']'
+        << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;service "
+           "critical";
+    std::string cmd{oss.str()};
+    process_external_command(cmd.c_str());
+    checks::checker::instance().reap();
+  }
+
+  now += 3000;
+  std::cout << "NOW = " << now << std::endl;
+  set_time(now);
+  std::ostringstream oss;
+  oss << '[' << now << ']'
+      << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;0;service ok";
+  std::string cmd{oss.str()};
+  process_external_command(cmd.c_str());
+  checks::checker::instance().reap();
+
+  now = 70000;
+  std::cout << "NOW = " << now << std::endl;
+  set_time(now);
+  oss.str("");
+  oss << '[' << now << ']'
+      << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;0;service ok";
+  cmd = oss.str();
+  process_external_command(cmd.c_str());
+  checks::checker::instance().reap();
+
+  std::string out{testing::internal::GetCapturedStdout()};
+  std::cout << out << std::endl;
+  size_t step1{out.find("NOW = 32000")};
+  size_t step2{
+      out.find("SERVICE NOTIFICATION: "
+               "test_contact;test_host;test_svc;CRITICAL;cmd;service critical",
+               step1 + 1)};
+  size_t step3{out.find("NOW = 59000", step2 + 1)};
+  size_t step4{
+      out.find("SERVICE NOTIFICATION: test_contact;test_host;test_svc;RECOVERY "
+               "(OK);cmd;service ok",
+               step3 + 1)};
+  ASSERT_NE(step4, std::string::npos);
 }

--- a/tests/timeperiod/get_next_valid_time/calendar_date.cc
+++ b/tests/timeperiod/get_next_valid_time/calendar_date.cc
@@ -89,10 +89,21 @@ TEST_F(GetNextValidTimeCalendarDateTest, WithinCalendarDate) {
 // When get_next_valid_time() is called
 // Then the next valid time is now
 TEST_F(GetNextValidTimeCalendarDateTest, AfterCalendarDates) {
+  std::unique_ptr<engine::timeperiod> tiperiod{
+      new engine::timeperiod("tperiod", "alias")};
+
+  for (int i = 0; i < 7; ++i) {
+    timerange_list list_time;
+    // list_time.push_back(std::make_shared<engine::timerange>(1000, 15000));
+    list_time.push_back(std::make_shared<engine::timerange>(8000, 85000));
+    tiperiod->days[i] = list_time;
+  }
+
   default_data_set();
+
   time_t now(strtotimet("2016-10-30 12:00:00"));
   set_time(now);
   time_t computed((time_t)-1);
-  get_next_valid_time(now, &computed, _creator.get_timeperiods());
+  get_next_valid_time(now, &computed, tiperiod.get());
   ASSERT_EQ(computed, now);
 }


### PR DESCRIPTION
    * fix(notification) the timeperiod are now filtered for the contact

    REFS: MON-6538

## Description

Please include a short resume of the changes and what is the purpose of PR. Any relevant information should be added to help:
* **QA Team** (Quality Assurance) with tests.
* **reviewers** to understand what are the stakes of the pull request.

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

