### PR TITLE
Mon 6916 last time in the future 20.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Bugfixes
 
+*Retention*
+
+Last time changes are checked when they are read from the retention files. So
+if they have no meaning, they are replaced by a default value.
+
 *Host/service status*
 
 They could be sent twice. This new version fixes that.
@@ -16,9 +21,13 @@ $HOSTGROUPACTIONURL*$, $SERVICEGROUPNOTESURL*$, $SERVICEGROUPACTIONURL*$.
 
 *Notification Period*
 
-the timeperiod are now filtered for the contact 
-and now don't push the notification with time period empty.
-these macro are now available without parameters ($HOSTGROUPNAME$, $CONTACTGROUPNAME$, $SERVICEGROUPNAME$)
+Timeperiods are now filtered for contacts
+and notifications are not pushed with an empty one.
+
+*Macros*
+
+These macros are now available without parameters
+($HOSTGROUPNAME$, $CONTACTGROUPNAME$, $SERVICEGROUPNAME$)
 
 *Connectors*
 

--- a/src/retention/host.cc
+++ b/src/retention/host.cc
@@ -20,9 +20,13 @@
 #include "com/centreon/engine/retention/host.hh"
 #include <array>
 #include "com/centreon/engine/common.hh"
+#include "com/centreon/engine/logging.hh"
+#include "com/centreon/engine/logging/logger.hh"
 #include "com/centreon/engine/string.hh"
 
-using namespace com::centreon::engine;
+using com::centreon::engine::map_customvar;
+using com::centreon::engine::opt;
+using namespace com::centreon::engine::logging;
 using namespace com::centreon::engine::retention;
 
 #define SETTER(type, method) &object::setter<host, type, &host::method>::generic
@@ -190,63 +194,64 @@ host& host::operator=(host const& right) {
  *
  *  @return True if is the same object, otherwise false.
  */
-bool host::operator==(host const& right) const throw() {
-  return (
-      object::operator==(right) &&
-      _acknowledgement_type == right._acknowledgement_type &&
-      _active_checks_enabled == right._active_checks_enabled &&
-      _check_command == right._check_command &&
-      _check_execution_time == right._check_execution_time &&
-      _check_flapping_recovery_notification ==
-          right._check_flapping_recovery_notification &&
-      _check_latency == right._check_latency &&
-      _check_options == right._check_options &&
-      _check_period == right._check_period &&
-      _check_type == right._check_type &&
-      _current_attempt == right._current_attempt &&
-      _current_event_id == right._current_event_id &&
-      _current_notification_id == right._current_notification_id &&
-      _current_notification_number == right._current_notification_number &&
-      _current_problem_id == right._current_problem_id &&
-      _current_state == right._current_state &&
-      std::operator==(_customvariables, right._customvariables) &&
-      _event_handler == right._event_handler &&
-      _event_handler_enabled == right._event_handler_enabled &&
-      _flap_detection_enabled == right._flap_detection_enabled &&
-      _has_been_checked == right._has_been_checked &&
-      _host_id == right._host_id && _host_name == right._host_name &&
-      _is_flapping == right._is_flapping &&
-      _last_acknowledgement == right._last_acknowledgement &&
-      _last_check == right._last_check &&
-      _last_event_id == right._last_event_id &&
-      _last_hard_state == right._last_hard_state &&
-      _last_hard_state_change == right._last_hard_state_change &&
-      _last_notification == right._last_notification &&
-      _last_problem_id == right._last_problem_id &&
-      _last_state == right._last_state &&
-      _last_state_change == right._last_state_change &&
-      _last_time_down == right._last_time_down &&
-      _last_time_unreachable == right._last_time_unreachable &&
-      _last_time_up == right._last_time_up &&
-      _long_plugin_output == right._long_plugin_output &&
-      _max_attempts == right._max_attempts &&
-      _modified_attributes == right._modified_attributes &&
-      _next_check == right._next_check &&
-      _normal_check_interval == right._normal_check_interval &&
-      _notification_period == right._notification_period &&
-      _notifications_enabled == right._notifications_enabled &&
-      _notified_on_down == right._notified_on_down &&
-      _notified_on_unreachable == right._notified_on_unreachable &&
-      _obsess_over_host == right._obsess_over_host &&
-      _passive_checks_enabled == right._passive_checks_enabled &&
-      _percent_state_change == right._percent_state_change &&
-      _performance_data == right._performance_data &&
-      _plugin_output == right._plugin_output &&
-      _problem_has_been_acknowledged == right._problem_has_been_acknowledged &&
-      _process_performance_data == right._process_performance_data &&
-      _retry_check_interval == right._retry_check_interval &&
-      _state_history == right._state_history &&
-      _state_type == right._state_type && _notification == right._notification);
+bool host::operator==(host const& right) const noexcept {
+  return object::operator==(right) &&
+         _acknowledgement_type == right._acknowledgement_type &&
+         _active_checks_enabled == right._active_checks_enabled &&
+         _check_command == right._check_command &&
+         _check_execution_time == right._check_execution_time &&
+         _check_flapping_recovery_notification ==
+             right._check_flapping_recovery_notification &&
+         _check_latency == right._check_latency &&
+         _check_options == right._check_options &&
+         _check_period == right._check_period &&
+         _check_type == right._check_type &&
+         _current_attempt == right._current_attempt &&
+         _current_event_id == right._current_event_id &&
+         _current_notification_id == right._current_notification_id &&
+         _current_notification_number == right._current_notification_number &&
+         _current_problem_id == right._current_problem_id &&
+         _current_state == right._current_state &&
+         std::operator==(_customvariables, right._customvariables) &&
+         _event_handler == right._event_handler &&
+         _event_handler_enabled == right._event_handler_enabled &&
+         _flap_detection_enabled == right._flap_detection_enabled &&
+         _has_been_checked == right._has_been_checked &&
+         _host_id == right._host_id && _host_name == right._host_name &&
+         _is_flapping == right._is_flapping &&
+         _last_acknowledgement == right._last_acknowledgement &&
+         _last_check == right._last_check &&
+         _last_event_id == right._last_event_id &&
+         _last_hard_state == right._last_hard_state &&
+         _last_hard_state_change == right._last_hard_state_change &&
+         _last_notification == right._last_notification &&
+         _last_problem_id == right._last_problem_id &&
+         _last_state == right._last_state &&
+         _last_state_change == right._last_state_change &&
+         _last_time_down == right._last_time_down &&
+         _last_time_unreachable == right._last_time_unreachable &&
+         _last_time_up == right._last_time_up &&
+         _long_plugin_output == right._long_plugin_output &&
+         _max_attempts == right._max_attempts &&
+         _modified_attributes == right._modified_attributes &&
+         _next_check == right._next_check &&
+         _normal_check_interval == right._normal_check_interval &&
+         _notification_period == right._notification_period &&
+         _notifications_enabled == right._notifications_enabled &&
+         _notified_on_down == right._notified_on_down &&
+         _notified_on_unreachable == right._notified_on_unreachable &&
+         _obsess_over_host == right._obsess_over_host &&
+         _passive_checks_enabled == right._passive_checks_enabled &&
+         _percent_state_change == right._percent_state_change &&
+         _performance_data == right._performance_data &&
+         _plugin_output == right._plugin_output &&
+         _problem_has_been_acknowledged ==
+             right._problem_has_been_acknowledged &&
+         _process_performance_data == right._process_performance_data &&
+         _retry_check_interval == right._retry_check_interval &&
+         _state_history == right._state_history &&
+         _state_type == right._state_type &&
+         _notification == right._notification;
 }
 
 /**
@@ -1091,6 +1096,13 @@ bool host::_set_last_state_change(time_t value) {
  *  @param[in] value The new last_time_down.
  */
 bool host::_set_last_time_down(time_t value) {
+  time_t now = time(nullptr);
+  if (value > now) {
+    logger(log_verification_error, basic)
+        << "Warning: Host last time down cannot be in the future (bad value: "
+        << value << ")";
+    value = now;
+  }
   _last_time_down = value;
   return true;
 }
@@ -1101,6 +1113,14 @@ bool host::_set_last_time_down(time_t value) {
  *  @param[in] value The new last_time_unreachable.
  */
 bool host::_set_last_time_unreachable(time_t value) {
+  time_t now = time(nullptr);
+  if (value > now) {
+    logger(log_verification_error, basic)
+        << "Warning: Host last time unreachable cannot be in the future (bad "
+           "value: "
+        << value << ")";
+    value = now;
+  }
   _last_time_unreachable = value;
   return true;
 }
@@ -1111,6 +1131,13 @@ bool host::_set_last_time_unreachable(time_t value) {
  *  @param[in] value The new last_time_up.
  */
 bool host::_set_last_time_up(time_t value) {
+  time_t now = time(nullptr);
+  if (value > now) {
+    logger(log_verification_error, basic)
+        << "Warning: Host last time up cannot be in the future (bad value: "
+        << value << ")";
+    value = now;
+  }
   _last_time_up = value;
   return true;
 }

--- a/src/retention/service.cc
+++ b/src/retention/service.cc
@@ -20,9 +20,13 @@
 #include "com/centreon/engine/retention/service.hh"
 #include <array>
 #include "com/centreon/engine/common.hh"
+#include "com/centreon/engine/logging.hh"
+#include "com/centreon/engine/logging/logger.hh"
 #include "com/centreon/engine/string.hh"
 
-using namespace com::centreon::engine;
+using com::centreon::engine::map_customvar;
+using com::centreon::engine::opt;
+using namespace com::centreon::engine::logging;
 using namespace com::centreon::engine::retention;
 
 #define SETTER(type, method) \
@@ -1165,6 +1169,14 @@ bool service::_set_last_state_change(time_t value) {
  *  @param[in] value The new last_time_critical.
  */
 bool service::_set_last_time_critical(time_t value) {
+  time_t now = time(nullptr);
+  if (value > now) {
+    logger(log_verification_error, basic) << "Warning: Service last time "
+                                             "critical cannot be in the future "
+                                             "(bad value: "
+                                          << value << ")";
+    value = now;
+  }
   _last_time_critical = value;
   return true;
 }
@@ -1175,6 +1187,13 @@ bool service::_set_last_time_critical(time_t value) {
  *  @param[in] value The new last_time_ok.
  */
 bool service::_set_last_time_ok(time_t value) {
+  time_t now = time(nullptr);
+  if (value > now) {
+    logger(log_verification_error, basic)
+        << "Warning: Service last time ok cannot be in the future (bad value: "
+        << value << ")";
+    value = now;
+  }
   _last_time_ok = value;
   return true;
 }
@@ -1185,6 +1204,14 @@ bool service::_set_last_time_ok(time_t value) {
  *  @param[in] value The new last_time_unknown.
  */
 bool service::_set_last_time_unknown(time_t value) {
+  time_t now = time(nullptr);
+  if (value > now) {
+    logger(log_verification_error, basic) << "Warning: Service last time "
+                                             "unknown cannot be in the future "
+                                             "(bad value: "
+                                          << value << ")";
+    value = now;
+  }
   _last_time_unknown = value;
   return true;
 }
@@ -1195,6 +1222,14 @@ bool service::_set_last_time_unknown(time_t value) {
  *  @param[in] value The new last_time_warning.
  */
 bool service::_set_last_time_warning(time_t value) {
+  time_t now = time(nullptr);
+  if (value > now) {
+    logger(log_verification_error, basic) << "Warning: Service last time "
+                                             "warning cannot be in the future "
+                                             "(bad value: "
+                                          << value << ")";
+    value = now;
+  }
   _last_time_warning = value;
   return true;
 }


### PR DESCRIPTION
## Description

If the retention.dat file contains date in the future for last_time_... values, they are replaced by the current time which has more
sense. This avoids also to send broker too big timestamps impossible to insert in database.

REFS: MON-6916

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [X] 20.10.x
- [ ] 21.04.x (master)
