### PR TITLE
Mon 6916 last time in the future

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -603,7 +603,7 @@ set(
 # Subdirectories with core features.
 add_subdirectory(src/broker)
 add_subdirectory(src/checks)
-add_subdirectory(conf)
+#add_subdirectory(conf)
 add_subdirectory(src/downtimes)
 add_subdirectory(src/configuration)
 add_subdirectory(src/commands)
@@ -627,6 +627,7 @@ target_link_libraries(cce_core ${json11_LIBS}
   ${PTHREAD_LIBRARIES}
   ${SOCKET_LIBRARIES}
   ${CLIB_LIBRARIES}
+  ${fmt_LIBRARIES}
 )
 
 # centengine target.

--- a/cmake.sh
+++ b/cmake.sh
@@ -21,6 +21,7 @@ do
       ;;
     -r|--release)
       BUILD_TYPE="Release"
+      shift
       ;;
     -h|--help)
       show_help
@@ -203,8 +204,3 @@ elif [ $maj = "Debian" ] ; then
 else
   CXXFLAGS="-Wall -Wextra" $cmake -DWITH_PREFIX=/usr -DWITH_CENTREON_CLIB_LIBRARY_DIR=/usr/lib64 -DWITH_PREFIX_BIN=/usr/sbin -DWITH_USER=centreon-engine -DWITH_GROUP=centreon-engine -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_RW_DIR=/var/lib/centreon-engine/rw -DWITH_PREFIX_CONF=/etc/centreon-engine -DWITH_VAR_DIR=/var/log/centreon-engine -DWITH_PREFIX_LIB=/usr/lib64/centreon-engine -DWITH_TESTING=On -DWITH_SIMU=On $* -DWITH_CREATE_FILES=OFF -DWITH_BENCH=On ..
 fi
-#CXX=/usr/bin/clang++ CC=/usr/bin/clang cmake -DWITH_PREFIX=/usr -DWITH_PREFIX_BIN=/usr/sbin -DWITH_USER=centreon-engine -DWITH_GROUP=centreon-engine -DCMAKE_BUILD_TYPE=Debug -DWITH_RW_DIR=/var/lib/centreon-engine/rw -DWITH_PREFIX_CONF=/etc/centreon-engine -DWITH_VAR_DIR=/var/log/centreon-engine -DWITH_PREFIX_LIB=/usr/lib64/centreon-engine -DWITH_TESTING=On -DWITH_SIMU=On .
-
-#CXX=/usr/lib64/ccache/g++ CC=/usr/lib64/ccache/gcc cmake -DWITH_PREFIX=/usr -DWITH_PREFIX_BIN=/usr/sbin -DWITH_USER=centreon-engine -DWITH_GROUP=centreon-engine -DCMAKE_BUILD_TYPE=Debug -DWITH_RW_DIR=/var/lib/centreon-engine/rw -DWITH_PREFIX_CONF=/etc/centreon-engine -DWITH_VAR_DIR=/var/log/centreon-engine -DWITH_PREFIX_LIB=/usr/lib64/centreon-engine -DWITH_TESTING=On -DWITH_SIMU=On .
-
-#CXXFLAGS="-O1 -fsanitize=address -fno-omit-frame-pointer" cmake -DWITH_PREFIX=/usr -DWITH_PREFIX_BIN=/usr/sbin -DWITH_USER=centreon-engine -DWITH_GROUP=centreon-engine -DCMAKE_BUILD_TYPE=Debug -DWITH_RW_DIR=/var/lib/centreon-engine/rw -DWITH_PREFIX_CONF=/etc/centreon-engine -DWITH_VAR_DIR=/var/log/centreon-engine -DWITH_PREFIX_LIB=/usr/lib64/centreon-engine -DWITH_TESTING=On -DWITH_SIMU=On .

--- a/inc/com/centreon/engine/command_manager.hh
+++ b/inc/com/centreon/engine/command_manager.hh
@@ -40,8 +40,7 @@
 CCE_BEGIN()
 class command_manager {
   std::mutex _queue_m;
-  std::condition_variable _queue_cv;
-  std::deque<std::packaged_task<int()>> _queue;
+  std::deque<std::packaged_task<int()> > _queue;
   command_manager();
 
  public:

--- a/inc/com/centreon/engine/nebmods.hh
+++ b/inc/com/centreon/engine/nebmods.hh
@@ -21,6 +21,7 @@
 #ifndef CCE_NEBMODS_HH
 #define CCE_NEBMODS_HH
 
+#include "com/centreon/engine/broker/handle.hh"
 #include "com/centreon/engine/nebcallbacks.hh"
 
 // Module Structures
@@ -47,7 +48,9 @@ int neb_load_module(void* mod);
 int neb_reload_all_modules();
 int neb_reload_module(void* mod);
 int neb_unload_all_modules(int flags, int reason);
-int neb_unload_module(void* mod, int flags, int reason);
+int neb_unload_module(com::centreon::engine::broker::handle* mod,
+                      int flags,
+                      int reason);
 
 // Callback Functions
 int neb_make_callbacks(int callback_type, void* data);

--- a/inc/com/centreon/engine/notifier.hh
+++ b/inc/com/centreon/engine/notifier.hh
@@ -238,8 +238,8 @@ class notifier : public checkable {
   int get_notification_number() const noexcept;
   void set_notification_number(int number);
 
-  virtual bool authorized_by_dependencies(
-      dependency::types dependency_type) const = 0;
+  virtual bool authorized_by_dependencies(dependency::types dependency_type)
+      const = 0;
   static uint64_t get_next_notification_id();
   virtual timeperiod* get_notification_timeperiod() const = 0;
   static notification_category get_category(reason_type type);
@@ -253,15 +253,15 @@ class notifier : public checkable {
       bool& escalated);
   notifier_type get_notifier_type() const noexcept;
   std::unordered_map<std::string, contact*>& get_contacts() noexcept;
-  std::unordered_map<std::string, contact*> const& get_contacts()
-      const noexcept;
+  std::unordered_map<std::string, contact*> const& get_contacts() const
+      noexcept;
   contactgroup_map_unsafe& get_contactgroups() noexcept;
   contactgroup_map_unsafe const& get_contactgroups() const noexcept;
   void resolve(int& w, int& e);
   std::array<int, MAX_STATE_HISTORY_ENTRIES> const& get_state_history() const;
   std::array<int, MAX_STATE_HISTORY_ENTRIES>& get_state_history();
-  std::array<std::shared_ptr<notification>, 6> const&
-  get_current_notifications() const;
+  std::array<std::unique_ptr<notification>, 6> const&
+      get_current_notifications() const;
   int get_pending_flex_downtime() const;
   void inc_pending_flex_downtime() noexcept;
   void dec_pending_flex_downtime() noexcept;
@@ -327,12 +327,16 @@ class notifier : public checkable {
 
   bool _is_volatile;
 
+  /*if notification_interval at 0 and is on time period off.
+  is set as true to send the notification on the next starting time period*/
+  bool _notification_to_interval_on_timeperiod_in;
+
   /* New ones */
   int _notification_number;
   // reason_type _type;
   std::unordered_map<std::string, contact*> _contacts;
   contactgroup_map_unsafe _contact_groups;
-  std::array<std::shared_ptr<notification>, 6> _notification;
+  std::array<std::unique_ptr<notification>, 6> _notification;
   std::array<int, MAX_STATE_HISTORY_ENTRIES> _state_history;
   int _pending_flex_downtime;
 };

--- a/inc/com/centreon/engine/notifier.hh
+++ b/inc/com/centreon/engine/notifier.hh
@@ -238,8 +238,8 @@ class notifier : public checkable {
   int get_notification_number() const noexcept;
   void set_notification_number(int number);
 
-  virtual bool authorized_by_dependencies(dependency::types dependency_type)
-      const = 0;
+  virtual bool authorized_by_dependencies(
+      dependency::types dependency_type) const = 0;
   static uint64_t get_next_notification_id();
   virtual timeperiod* get_notification_timeperiod() const = 0;
   static notification_category get_category(reason_type type);
@@ -253,15 +253,15 @@ class notifier : public checkable {
       bool& escalated);
   notifier_type get_notifier_type() const noexcept;
   std::unordered_map<std::string, contact*>& get_contacts() noexcept;
-  std::unordered_map<std::string, contact*> const& get_contacts() const
-      noexcept;
+  std::unordered_map<std::string, contact*> const& get_contacts()
+      const noexcept;
   contactgroup_map_unsafe& get_contactgroups() noexcept;
   contactgroup_map_unsafe const& get_contactgroups() const noexcept;
   void resolve(int& w, int& e);
   std::array<int, MAX_STATE_HISTORY_ENTRIES> const& get_state_history() const;
   std::array<int, MAX_STATE_HISTORY_ENTRIES>& get_state_history();
   std::array<std::unique_ptr<notification>, 6> const&
-      get_current_notifications() const;
+  get_current_notifications() const;
   int get_pending_flex_downtime() const;
   void inc_pending_flex_downtime() noexcept;
   void dec_pending_flex_downtime() noexcept;

--- a/inc/com/centreon/engine/retention/dump.hh
+++ b/inc/com/centreon/engine/retention/dump.hh
@@ -48,7 +48,7 @@ std::ostream& customvariables(std::ostream& os,
                               com::centreon::engine::map_customvar const& obj);
 std::ostream& notifications(
     std::ostream& os,
-    std::array<std::shared_ptr<com::centreon::engine::notification>, 6> const&
+    std::array<std::unique_ptr<com::centreon::engine::notification>, 6> const&
         obj);
 std::ostream& scheduled_downtime(std::ostream& os,
                                  downtimes::downtime const& obj);

--- a/inc/compatibility/mmap.h
+++ b/inc/compatibility/mmap.h
@@ -38,7 +38,6 @@ extern "C" {
 mmapfile* mmap_fopen(char const* filename);
 int mmap_fclose(mmapfile* temp_mmapfile);
 char* mmap_fgets(mmapfile* temp_mmapfile);
-char* mmap_fgets_multiline(mmapfile* temp_mmapfile);
 
 #ifdef __cplusplus
 }

--- a/modules/external_commands/src/commands.cc
+++ b/modules/external_commands/src/commands.cc
@@ -124,10 +124,9 @@ int process_external_commands_from_file(char const* file, int delete_file) {
   if (!file)
     return ERROR;
 
-  logger(dbg_external_command, more) << "Processing commands from file '"
-                                     << file << "'.  File will "
-                                     << (delete_file ? "be" : "NOT be")
-                                     << " deleted after processing.";
+  logger(dbg_external_command, more)
+      << "Processing commands from file '" << file << "'.  File will "
+      << (delete_file ? "be" : "NOT be") << " deleted after processing.";
 
   /* open the config file for reading */
   mmapfile* thefile(nullptr);
@@ -227,23 +226,15 @@ int cmd_add_comment(int cmd, time_t entry_time, char* args) {
   /* add the comment */
   std::shared_ptr<comment> com{new comment(
       (cmd == CMD_ADD_HOST_COMMENT) ? comment::host : comment::service,
-      comment::user,
-      temp_host->get_host_id(),
-      service_id,
-      entry_time,
-      user,
-      comment_data,
-      persistent,
-      comment::external,
-      false,
-      (time_t)0)};
+      comment::user, temp_host->get_host_id(), service_id, entry_time, user,
+      comment_data, persistent, comment::external, false, (time_t)0)};
   comment::comments.insert({com->get_comment_id(), com});
 
   return OK;
 }
 
 /* removes a host or service comment from the status log */
-int cmd_delete_comment(int cmd[[maybe_unused]], char* args) {
+int cmd_delete_comment(int cmd [[maybe_unused]], char* args) {
   uint64_t comment_id{0};
 
   /* get the comment id we should delete */
@@ -398,8 +389,7 @@ int cmd_schedule_check(int cmd, char* args) {
            cmd == CMD_SCHEDULE_FORCED_HOST_SVC_CHECKS) {
     for (service_map_unsafe::iterator it(temp_host->services.begin()),
          end(temp_host->services.end());
-         it != end;
-         ++it) {
+         it != end; ++it) {
       if (!it->second)
         continue;
       it->second->schedule_check(delay_time,
@@ -445,8 +435,7 @@ int cmd_schedule_host_service_checks(int cmd, char* args, int force) {
   /* reschedule all services on the specified host */
   for (service_map_unsafe::iterator it(temp_host->services.begin()),
        end(temp_host->services.end());
-       it != end;
-       ++it) {
+       it != end; ++it) {
     if (!it->second)
       continue;
     it->second->schedule_check(
@@ -468,17 +457,10 @@ void cmd_signal_process(int cmd, char* args) {
     scheduled_time = strtoul(temp_ptr, nullptr, 10);
 
   /* add a scheduled program shutdown or restart to the event list */
-  timed_event* evt = new timed_event((cmd == CMD_SHUTDOWN_PROCESS)
-                                         ? timed_event::EVENT_PROGRAM_SHUTDOWN
-                                         : timed_event::EVENT_PROGRAM_RESTART,
-                                     scheduled_time,
-                                     false,
-                                     0,
-                                     nullptr,
-                                     false,
-                                     nullptr,
-                                     nullptr,
-                                     0);
+  timed_event* evt = new timed_event(
+      (cmd == CMD_SHUTDOWN_PROCESS) ? timed_event::EVENT_PROGRAM_SHUTDOWN
+                                    : timed_event::EVENT_PROGRAM_RESTART,
+      scheduled_time, false, 0, nullptr, false, nullptr, nullptr, 0);
   events::loop::instance().schedule(evt, true);
 }
 
@@ -524,8 +506,8 @@ int cmd_process_service_check_result(int cmd, time_t check_time, char* args) {
   int return_code(strtol(delimiter, nullptr, 0));
 
   // Submit the passive check result.
-  return process_passive_service_check(
-      check_time, host_name, svc_description, return_code, output);
+  return process_passive_service_check(check_time, host_name, svc_description,
+                                       return_code, output);
 }
 
 /* submits a passive service check result for later processing */
@@ -551,8 +533,7 @@ int process_passive_service_check(time_t check_time,
     real_host_name = host_name;
   else {
     for (host_map::iterator itt(host::hosts.begin()), end(host::hosts.end());
-         itt != end;
-         ++itt) {
+         itt != end; ++itt) {
       if (itt->second && itt->second->get_address() == host_name) {
         real_host_name = itt->first.c_str();
         it = itt;
@@ -591,19 +572,11 @@ int process_passive_service_check(time_t check_time,
   timeval set_tv = {.tv_sec = check_time, .tv_usec = 0};
 
   check_result* result =
-      new check_result(service_check,
-                       found->second.get(),
-                       checkable::check_passive,
-                       CHECK_OPTION_NONE,
-                       false,
+      new check_result(service_check, found->second.get(),
+                       checkable::check_passive, CHECK_OPTION_NONE, false,
                        static_cast<double>(tv.tv_sec - check_time) +
                            static_cast<double>(tv.tv_usec / 1000000.0),
-                       set_tv,
-                       set_tv,
-                       false,
-                       true,
-                       return_code,
-                       output);
+                       set_tv, set_tv, false, true, return_code, output);
 
   /* make sure the return code is within bounds */
   if (result->get_return_code() < 0 || result->get_return_code() > 3) {
@@ -680,8 +653,7 @@ int process_passive_host_check(time_t check_time,
     real_host_name = host_name;
   else {
     for (host_map::iterator itt(host::hosts.begin()), end(host::hosts.end());
-         itt != end;
-         ++itt) {
+         itt != end; ++itt) {
       if (itt->second && itt->second->get_address() == host_name) {
         real_host_name = itt->first.c_str();
         it = itt;
@@ -707,19 +679,11 @@ int process_passive_host_check(time_t check_time,
   timeval tv_start = {.tv_sec = check_time, .tv_usec = 0};
 
   check_result* result =
-      new check_result(host_check,
-                       it->second.get(),
-                       checkable::check_passive,
-                       CHECK_OPTION_NONE,
-                       false,
+      new check_result(host_check, it->second.get(), checkable::check_passive,
+                       CHECK_OPTION_NONE, false,
                        static_cast<double>(tv.tv_sec - check_time) +
                            static_cast<double>(tv.tv_usec / 1000000.0),
-                       tv_start,
-                       tv_start,
-                       false,
-                       true,
-                       return_code,
-                       output);
+                       tv_start, tv_start, false, true, return_code, output);
 
   /* make sure the return code is within bounds */
   if (result->get_return_code() < 0 || result->get_return_code() > 3)
@@ -796,12 +760,12 @@ int cmd_acknowledge_problem(int cmd, char* args) {
 
   /* acknowledge the host problem */
   if (cmd == CMD_ACKNOWLEDGE_HOST_PROBLEM)
-    acknowledge_host_problem(
-        it->second.get(), ack_author, ack_data, type, notify, persistent);
+    acknowledge_host_problem(it->second.get(), ack_author, ack_data, type,
+                             notify, persistent);
   /* acknowledge the service problem */
   else
-    acknowledge_service_problem(
-        found->second.get(), ack_author, ack_data, type, notify, persistent);
+    acknowledge_service_problem(found->second.get(), ack_author, ack_data, type,
+                                notify, persistent);
 
   /* free memory */
   delete[] ack_author;
@@ -966,102 +930,57 @@ int cmd_schedule_downtime(int cmd, time_t entry_time, char* args) {
   /* schedule downtime */
   switch (cmd) {
     case CMD_SCHEDULE_HOST_DOWNTIME:
-      downtime_manager::instance().schedule_downtime(downtime::host_downtime,
-                                                     host_name,
-                                                     "",
-                                                     entry_time,
-                                                     author,
-                                                     comment_data,
-                                                     start_time,
-                                                     end_time,
-                                                     fixed,
-                                                     triggered_by,
-                                                     duration,
-                                                     &downtime_id);
+      downtime_manager::instance().schedule_downtime(
+          downtime::host_downtime, host_name, "", entry_time, author,
+          comment_data, start_time, end_time, fixed, triggered_by, duration,
+          &downtime_id);
       break;
 
     case CMD_SCHEDULE_SVC_DOWNTIME:
-      downtime_manager::instance().schedule_downtime(downtime::service_downtime,
-                                                     host_name,
-                                                     svc_description,
-                                                     entry_time,
-                                                     author,
-                                                     comment_data,
-                                                     start_time,
-                                                     end_time,
-                                                     fixed,
-                                                     triggered_by,
-                                                     duration,
-                                                     &downtime_id);
+      downtime_manager::instance().schedule_downtime(
+          downtime::service_downtime, host_name, svc_description, entry_time,
+          author, comment_data, start_time, end_time, fixed, triggered_by,
+          duration, &downtime_id);
       break;
 
     case CMD_SCHEDULE_HOST_SVC_DOWNTIME:
       for (service_map_unsafe::iterator it(temp_host->services.begin()),
            end(temp_host->services.end());
-           it != end;
-           ++it) {
+           it != end; ++it) {
         if (!it->second)
           continue;
         downtime_manager::instance().schedule_downtime(
-            downtime::service_downtime,
-            host_name,
-            it->second->get_description(),
-            entry_time,
-            author,
-            comment_data,
-            start_time,
-            end_time,
-            fixed,
-            triggered_by,
-            duration,
-            &downtime_id);
+            downtime::service_downtime, host_name,
+            it->second->get_description(), entry_time, author, comment_data,
+            start_time, end_time, fixed, triggered_by, duration, &downtime_id);
       }
       break;
 
     case CMD_SCHEDULE_HOSTGROUP_HOST_DOWNTIME:
       for (host_map_unsafe::iterator it(hg->members.begin()),
            end(hg->members.end());
-           it != end;
-           ++it)
-        downtime_manager::instance().schedule_downtime(downtime::host_downtime,
-                                                       it->first,
-                                                       "",
-                                                       entry_time,
-                                                       author,
-                                                       comment_data,
-                                                       start_time,
-                                                       end_time,
-                                                       fixed,
-                                                       triggered_by,
-                                                       duration,
-                                                       &downtime_id);
+           it != end; ++it)
+        downtime_manager::instance().schedule_downtime(
+            downtime::host_downtime, it->first, "", entry_time, author,
+            comment_data, start_time, end_time, fixed, triggered_by, duration,
+            &downtime_id);
       break;
 
     case CMD_SCHEDULE_HOSTGROUP_SVC_DOWNTIME:
       for (host_map_unsafe::iterator it(hg->members.begin()),
            end(hg->members.end());
-           it != end;
-           ++it) {
+           it != end; ++it) {
         if (!it->second)
           continue;
         for (service_map_unsafe::iterator it2(it->second->services.begin()),
              end2(it->second->services.end());
-             it2 != end2;
-             ++it2) {
+             it2 != end2; ++it2) {
           if (!it2->second)
             continue;
           downtime_manager::instance().schedule_downtime(
-              downtime::service_downtime,
-              it2->second->get_hostname(),
-              it2->second->get_description(),
-              entry_time,
-              author,
-              comment_data,
-              start_time,
-              end_time,
-              fixed,
-              triggered_by,
-              duration,
+              downtime::service_downtime, it2->second->get_hostname(),
+              it2->second->get_description(), entry_time, author, comment_data,
+              start_time, end_time, fixed, triggered_by, duration,
               &downtime_id);
         }
       }
@@ -1071,8 +990,7 @@ int cmd_schedule_downtime(int cmd, time_t entry_time, char* args) {
       last_host = nullptr;
       for (service_map_unsafe::iterator it(sg_it->second->members.begin()),
            end(sg_it->second->members.end());
-           it != end;
-           ++it) {
+           it != end; ++it) {
         temp_host = nullptr;
         host_map::const_iterator found(host::hosts.find(it->first.first));
         if (found == host::hosts.end() || !found->second)
@@ -1080,18 +998,10 @@ int cmd_schedule_downtime(int cmd, time_t entry_time, char* args) {
         temp_host = found->second.get();
         if (last_host == temp_host)
           continue;
-        downtime_manager::instance().schedule_downtime(downtime::host_downtime,
-                                                       it->first.first,
-                                                       "",
-                                                       entry_time,
-                                                       author,
-                                                       comment_data,
-                                                       start_time,
-                                                       end_time,
-                                                       fixed,
-                                                       triggered_by,
-                                                       duration,
-                                                       &downtime_id);
+        downtime_manager::instance().schedule_downtime(
+            downtime::host_downtime, it->first.first, "", entry_time, author,
+            comment_data, start_time, end_time, fixed, triggered_by, duration,
+            &downtime_id);
         last_host = temp_host;
       }
       break;
@@ -1099,75 +1009,37 @@ int cmd_schedule_downtime(int cmd, time_t entry_time, char* args) {
     case CMD_SCHEDULE_SERVICEGROUP_SVC_DOWNTIME:
       for (service_map_unsafe::iterator it(sg_it->second->members.begin()),
            end(sg_it->second->members.end());
-           it != end;
-           ++it)
+           it != end; ++it)
         downtime_manager::instance().schedule_downtime(
-            downtime::service_downtime,
-            it->first.first,
-            it->first.second,
-            entry_time,
-            author,
-            comment_data,
-            start_time,
-            end_time,
-            fixed,
-            triggered_by,
-            duration,
-            &downtime_id);
+            downtime::service_downtime, it->first.first, it->first.second,
+            entry_time, author, comment_data, start_time, end_time, fixed,
+            triggered_by, duration, &downtime_id);
       break;
 
     case CMD_SCHEDULE_AND_PROPAGATE_HOST_DOWNTIME:
       /* schedule downtime for "parent" host */
-      downtime_manager::instance().schedule_downtime(downtime::host_downtime,
-                                                     host_name,
-                                                     "",
-                                                     entry_time,
-                                                     author,
-                                                     comment_data,
-                                                     start_time,
-                                                     end_time,
-                                                     fixed,
-                                                     triggered_by,
-                                                     duration,
-                                                     &downtime_id);
+      downtime_manager::instance().schedule_downtime(
+          downtime::host_downtime, host_name, "", entry_time, author,
+          comment_data, start_time, end_time, fixed, triggered_by, duration,
+          &downtime_id);
 
       /* schedule (non-triggered) downtime for all child hosts */
-      schedule_and_propagate_downtime(temp_host,
-                                      entry_time,
-                                      author,
-                                      comment_data,
-                                      start_time,
-                                      end_time,
-                                      fixed,
-                                      0,
-                                      duration);
+      schedule_and_propagate_downtime(temp_host, entry_time, author,
+                                      comment_data, start_time, end_time, fixed,
+                                      0, duration);
       break;
 
     case CMD_SCHEDULE_AND_PROPAGATE_TRIGGERED_HOST_DOWNTIME:
       /* schedule downtime for "parent" host */
-      downtime_manager::instance().schedule_downtime(downtime::host_downtime,
-                                                     host_name,
-                                                     "",
-                                                     entry_time,
-                                                     author,
-                                                     comment_data,
-                                                     start_time,
-                                                     end_time,
-                                                     fixed,
-                                                     triggered_by,
-                                                     duration,
-                                                     &downtime_id);
+      downtime_manager::instance().schedule_downtime(
+          downtime::host_downtime, host_name, "", entry_time, author,
+          comment_data, start_time, end_time, fixed, triggered_by, duration,
+          &downtime_id);
 
       /* schedule triggered downtime for all child hosts */
-      schedule_and_propagate_downtime(temp_host,
-                                      entry_time,
-                                      author,
-                                      comment_data,
-                                      start_time,
-                                      end_time,
-                                      fixed,
-                                      downtime_id,
-                                      duration);
+      schedule_and_propagate_downtime(temp_host, entry_time, author,
+                                      comment_data, start_time, end_time, fixed,
+                                      downtime_id, duration);
       break;
 
     default:
@@ -1259,8 +1131,7 @@ int cmd_delete_downtime_full(int cmd, char* args) {
   downtime_finder::result_set result(dtf.find_matching_all(criterias));
   for (downtime_finder::result_set::const_iterator it(result.begin()),
        end(result.end());
-       it != end;
-       ++it) {
+       it != end; ++it) {
     downtime_manager::instance().unschedule_downtime(*it);
   }
 
@@ -1313,7 +1184,7 @@ int cmd_delete_downtime_by_host_name(int cmd, char* args) {
   deleted =
       downtime_manager::instance()
           .delete_downtime_by_hostname_service_description_start_time_comment(
-               hostname, service_description, start_time, downtime_comment);
+              hostname, service_description, start_time, downtime_comment);
   if (0 == deleted)
     return ERROR;
   return OK;
@@ -1392,8 +1263,7 @@ int cmd_delete_downtime_by_hostgroup_name(int cmd, char* args) {
 
   for (host_map_unsafe::iterator it_h(it->second->members.begin()),
        end_h(it->second->members.end());
-       it_h != end_h;
-       ++it_h) {
+       it_h != end_h; ++it_h) {
     if (!it_h->second)
       continue;
     if (host_name != nullptr && it_h->first != host_name)
@@ -1401,7 +1271,7 @@ int cmd_delete_downtime_by_hostgroup_name(int cmd, char* args) {
     deleted =
         downtime_manager::instance()
             .delete_downtime_by_hostname_service_description_start_time_comment(
-                 host_name, service_description, start_time, downtime_comment);
+                host_name, service_description, start_time, downtime_comment);
   }
 
   if (0 == deleted)
@@ -1436,7 +1306,7 @@ int cmd_delete_downtime_by_start_time_comment(int cmd, char* args) {
   deleted =
       downtime_manager::instance()
           .delete_downtime_by_hostname_service_description_start_time_comment(
-               "", "", start_time, downtime_comment);
+              "", "", start_time, downtime_comment);
 
   if (0 == deleted)
     return ERROR;
@@ -1547,8 +1417,8 @@ int cmd_change_object_int_var(int cmd, char* args) {
         time(&preferred_time);
         if (!check_time_against_period(preferred_time,
                                        temp_host->check_period_ptr)) {
-          get_next_valid_time(
-              preferred_time, &next_valid_time, temp_host->check_period_ptr);
+          get_next_valid_time(preferred_time, &next_valid_time,
+                              temp_host->check_period_ptr);
           temp_host->set_next_check(next_valid_time);
         } else
           temp_host->set_next_check(preferred_time);
@@ -1595,8 +1465,7 @@ int cmd_change_object_int_var(int cmd, char* args) {
         time(&preferred_time);
         if (!check_time_against_period(preferred_time,
                                        found_svc->second->check_period_ptr)) {
-          get_next_valid_time(preferred_time,
-                              &next_valid_time,
+          get_next_valid_time(preferred_time, &next_valid_time,
                               found_svc->second->check_period_ptr);
           found_svc->second->set_next_check(next_valid_time);
         } else
@@ -1659,14 +1528,10 @@ int cmd_change_object_int_var(int cmd, char* args) {
             found_svc->second->get_modified_attributes() | attr);
 
       /* send data to event broker */
-      broker_adaptive_service_data(NEBTYPE_ADAPTIVESERVICE_UPDATE,
-                                   NEBFLAG_NONE,
-                                   NEBATTR_NONE,
-                                   found_svc->second.get(),
-                                   cmd,
-                                   attr,
-                                   found_svc->second->get_modified_attributes(),
-                                   nullptr);
+      broker_adaptive_service_data(
+          NEBTYPE_ADAPTIVESERVICE_UPDATE, NEBFLAG_NONE, NEBATTR_NONE,
+          found_svc->second.get(), cmd, attr,
+          found_svc->second->get_modified_attributes(), nullptr);
 
       /* update the status log with the service info */
       found_svc->second->update_status();
@@ -1684,14 +1549,9 @@ int cmd_change_object_int_var(int cmd, char* args) {
             temp_host->get_modified_attributes() | attr);
 
       /* send data to event broker */
-      broker_adaptive_host_data(NEBTYPE_ADAPTIVEHOST_UPDATE,
-                                NEBFLAG_NONE,
-                                NEBATTR_NONE,
-                                temp_host,
-                                cmd,
-                                attr,
-                                temp_host->get_modified_attributes(),
-                                nullptr);
+      broker_adaptive_host_data(NEBTYPE_ADAPTIVEHOST_UPDATE, NEBFLAG_NONE,
+                                NEBATTR_NONE, temp_host, cmd, attr,
+                                temp_host->get_modified_attributes(), nullptr);
 
       /* update the status log with the host info */
       temp_host->update_status();
@@ -1720,18 +1580,11 @@ int cmd_change_object_int_var(int cmd, char* args) {
 
       /* send data to event broker */
       broker_adaptive_contact_data(
-          NEBTYPE_ADAPTIVECONTACT_UPDATE,
-          NEBFLAG_NONE,
-          NEBATTR_NONE,
-          cnct->second.get(),
-          cmd,
-          attr,
-          cnct->second->get_modified_attributes(),
-          hattr,
-          cnct->second->get_modified_host_attributes(),
-          sattr,
-          cnct->second->get_modified_service_attributes(),
-          nullptr);
+          NEBTYPE_ADAPTIVECONTACT_UPDATE, NEBFLAG_NONE, NEBATTR_NONE,
+          cnct->second.get(), cmd, attr,
+          cnct->second->get_modified_attributes(), hattr,
+          cnct->second->get_modified_host_attributes(), sattr,
+          cnct->second->get_modified_service_attributes(), nullptr);
 
       /* update the status log with the contact info */
       cnct->second->update_status_info(false);
@@ -1980,15 +1833,10 @@ int cmd_change_object_char_var(int cmd, char* args) {
       modified_host_process_attributes |= attr;
 
       /* send data to event broker */
-      broker_adaptive_program_data(NEBTYPE_ADAPTIVEPROGRAM_UPDATE,
-                                   NEBFLAG_NONE,
-                                   NEBATTR_NONE,
-                                   cmd,
-                                   attr,
-                                   modified_host_process_attributes,
-                                   MODATTR_NONE,
-                                   modified_service_process_attributes,
-                                   nullptr);
+      broker_adaptive_program_data(
+          NEBTYPE_ADAPTIVEPROGRAM_UPDATE, NEBFLAG_NONE, NEBATTR_NONE, cmd, attr,
+          modified_host_process_attributes, MODATTR_NONE,
+          modified_service_process_attributes, nullptr);
       /* update program status */
       update_program_status(false);
       break;
@@ -1998,15 +1846,10 @@ int cmd_change_object_char_var(int cmd, char* args) {
       modified_service_process_attributes |= attr;
 
       /* send data to event broker */
-      broker_adaptive_program_data(NEBTYPE_ADAPTIVEPROGRAM_UPDATE,
-                                   NEBFLAG_NONE,
-                                   NEBATTR_NONE,
-                                   cmd,
-                                   MODATTR_NONE,
-                                   modified_host_process_attributes,
-                                   attr,
-                                   modified_service_process_attributes,
-                                   nullptr);
+      broker_adaptive_program_data(
+          NEBTYPE_ADAPTIVEPROGRAM_UPDATE, NEBFLAG_NONE, NEBATTR_NONE, cmd,
+          MODATTR_NONE, modified_host_process_attributes, attr,
+          modified_service_process_attributes, nullptr);
 
       /* update program status */
       update_program_status(false);
@@ -2021,14 +1864,10 @@ int cmd_change_object_char_var(int cmd, char* args) {
       found_svc->second->add_modified_attributes(attr);
 
       /* send data to event broker */
-      broker_adaptive_service_data(NEBTYPE_ADAPTIVESERVICE_UPDATE,
-                                   NEBFLAG_NONE,
-                                   NEBATTR_NONE,
-                                   found_svc->second.get(),
-                                   cmd,
-                                   attr,
-                                   found_svc->second->get_modified_attributes(),
-                                   nullptr);
+      broker_adaptive_service_data(
+          NEBTYPE_ADAPTIVESERVICE_UPDATE, NEBFLAG_NONE, NEBATTR_NONE,
+          found_svc->second.get(), cmd, attr,
+          found_svc->second->get_modified_attributes(), nullptr);
 
       /* update the status log with the service info */
       found_svc->second->update_status();
@@ -2042,14 +1881,9 @@ int cmd_change_object_char_var(int cmd, char* args) {
       temp_host->add_modified_attributes(attr);
 
       /* send data to event broker */
-      broker_adaptive_host_data(NEBTYPE_ADAPTIVEHOST_UPDATE,
-                                NEBFLAG_NONE,
-                                NEBATTR_NONE,
-                                temp_host,
-                                cmd,
-                                attr,
-                                temp_host->get_modified_attributes(),
-                                nullptr);
+      broker_adaptive_host_data(NEBTYPE_ADAPTIVEHOST_UPDATE, NEBFLAG_NONE,
+                                NEBATTR_NONE, temp_host, cmd, attr,
+                                temp_host->get_modified_attributes(), nullptr);
 
       /* update the status log with the host info */
       temp_host->update_status();
@@ -2065,18 +1899,11 @@ int cmd_change_object_char_var(int cmd, char* args) {
 
       /* send data to event broker */
       broker_adaptive_contact_data(
-          NEBTYPE_ADAPTIVECONTACT_UPDATE,
-          NEBFLAG_NONE,
-          NEBATTR_NONE,
-          cnct->second.get(),
-          cmd,
-          attr,
-          cnct->second->get_modified_attributes(),
-          hattr,
-          cnct->second->get_modified_host_attributes(),
-          sattr,
-          cnct->second->get_modified_service_attributes(),
-          nullptr);
+          NEBTYPE_ADAPTIVECONTACT_UPDATE, NEBFLAG_NONE, NEBATTR_NONE,
+          cnct->second.get(), cmd, attr,
+          cnct->second->get_modified_attributes(), hattr,
+          cnct->second->get_modified_host_attributes(), sattr,
+          cnct->second->get_modified_service_attributes(), nullptr);
 
       /* update the status log with the contact info */
       cnct->second->update_status_info(false);
@@ -2231,14 +2058,9 @@ void disable_service_checks(service* svc) {
   svc->set_should_be_scheduled(false);
 
   /* send data to event broker */
-  broker_adaptive_service_data(NEBTYPE_ADAPTIVESERVICE_UPDATE,
-                               NEBFLAG_NONE,
-                               NEBATTR_NONE,
-                               svc,
-                               CMD_NONE,
-                               attr,
-                               svc->get_modified_attributes(),
-                               nullptr);
+  broker_adaptive_service_data(NEBTYPE_ADAPTIVESERVICE_UPDATE, NEBFLAG_NONE,
+                               NEBATTR_NONE, svc, CMD_NONE, attr,
+                               svc->get_modified_attributes(), nullptr);
 
   /* update the status log to reflect the new service state */
   svc->update_status();
@@ -2268,8 +2090,8 @@ void enable_service_checks(service* svc) {
   /* schedule a check for right now (or as soon as possible) */
   time(&preferred_time);
   if (!check_time_against_period(preferred_time, svc->check_period_ptr)) {
-    get_next_valid_time(
-        preferred_time, &next_valid_time, svc->check_period_ptr);
+    get_next_valid_time(preferred_time, &next_valid_time,
+                        svc->check_period_ptr);
     svc->set_next_check(next_valid_time);
   } else
     svc->set_next_check(preferred_time);
@@ -2279,14 +2101,9 @@ void enable_service_checks(service* svc) {
     svc->schedule_check(svc->get_next_check(), CHECK_OPTION_NONE);
 
   /* send data to event broker */
-  broker_adaptive_service_data(NEBTYPE_ADAPTIVESERVICE_UPDATE,
-                               NEBFLAG_NONE,
-                               NEBATTR_NONE,
-                               svc,
-                               CMD_NONE,
-                               attr,
-                               svc->get_modified_attributes(),
-                               nullptr);
+  broker_adaptive_service_data(NEBTYPE_ADAPTIVESERVICE_UPDATE, NEBFLAG_NONE,
+                               NEBATTR_NONE, svc, CMD_NONE, attr,
+                               svc->get_modified_attributes(), nullptr);
 
   /* update the status log to reflect the new service state */
   svc->update_status();
@@ -2308,15 +2125,10 @@ void enable_all_notifications(void) {
   config->enable_notifications(true);
 
   /* send data to event broker */
-  broker_adaptive_program_data(NEBTYPE_ADAPTIVEPROGRAM_UPDATE,
-                               NEBFLAG_NONE,
-                               NEBATTR_NONE,
-                               CMD_NONE,
-                               attr,
-                               modified_host_process_attributes,
-                               attr,
-                               modified_service_process_attributes,
-                               nullptr);
+  broker_adaptive_program_data(NEBTYPE_ADAPTIVEPROGRAM_UPDATE, NEBFLAG_NONE,
+                               NEBATTR_NONE, CMD_NONE, attr,
+                               modified_host_process_attributes, attr,
+                               modified_service_process_attributes, nullptr);
 
   /* update the status log */
   update_program_status(false);
@@ -2338,15 +2150,10 @@ void disable_all_notifications(void) {
   config->enable_notifications(false);
 
   /* send data to event broker */
-  broker_adaptive_program_data(NEBTYPE_ADAPTIVEPROGRAM_UPDATE,
-                               NEBFLAG_NONE,
-                               NEBATTR_NONE,
-                               CMD_NONE,
-                               attr,
-                               modified_host_process_attributes,
-                               attr,
-                               modified_service_process_attributes,
-                               nullptr);
+  broker_adaptive_program_data(NEBTYPE_ADAPTIVEPROGRAM_UPDATE, NEBFLAG_NONE,
+                               NEBATTR_NONE, CMD_NONE, attr,
+                               modified_host_process_attributes, attr,
+                               modified_service_process_attributes, nullptr);
 
   /* update the status log */
   update_program_status(false);
@@ -2367,14 +2174,9 @@ void enable_service_notifications(service* svc) {
   svc->set_notifications_enabled(true);
 
   /* send data to event broker */
-  broker_adaptive_service_data(NEBTYPE_ADAPTIVESERVICE_UPDATE,
-                               NEBFLAG_NONE,
-                               NEBATTR_NONE,
-                               svc,
-                               CMD_NONE,
-                               attr,
-                               svc->get_modified_attributes(),
-                               nullptr);
+  broker_adaptive_service_data(NEBTYPE_ADAPTIVESERVICE_UPDATE, NEBFLAG_NONE,
+                               NEBATTR_NONE, svc, CMD_NONE, attr,
+                               svc->get_modified_attributes(), nullptr);
 
   /* update the status log to reflect the new service state */
   svc->update_status();
@@ -2395,14 +2197,9 @@ void disable_service_notifications(service* svc) {
   svc->set_notifications_enabled(false);
 
   /* send data to event broker */
-  broker_adaptive_service_data(NEBTYPE_ADAPTIVESERVICE_UPDATE,
-                               NEBFLAG_NONE,
-                               NEBATTR_NONE,
-                               svc,
-                               CMD_NONE,
-                               attr,
-                               svc->get_modified_attributes(),
-                               nullptr);
+  broker_adaptive_service_data(NEBTYPE_ADAPTIVESERVICE_UPDATE, NEBFLAG_NONE,
+                               NEBATTR_NONE, svc, CMD_NONE, attr,
+                               svc->get_modified_attributes(), nullptr);
 
   /* update the status log to reflect the new service state */
   svc->update_status();
@@ -2423,14 +2220,9 @@ void enable_host_notifications(host* hst) {
   hst->set_notifications_enabled(true);
 
   /* send data to event broker */
-  broker_adaptive_host_data(NEBTYPE_ADAPTIVEHOST_UPDATE,
-                            NEBFLAG_NONE,
-                            NEBATTR_NONE,
-                            hst,
-                            CMD_NONE,
-                            attr,
-                            hst->get_modified_attributes(),
-                            nullptr);
+  broker_adaptive_host_data(NEBTYPE_ADAPTIVEHOST_UPDATE, NEBFLAG_NONE,
+                            NEBATTR_NONE, hst, CMD_NONE, attr,
+                            hst->get_modified_attributes(), nullptr);
 
   /* update the status log to reflect the new host state */
   hst->update_status();
@@ -2451,14 +2243,9 @@ void disable_host_notifications(host* hst) {
   hst->set_notifications_enabled(false);
 
   /* send data to event broker */
-  broker_adaptive_host_data(NEBTYPE_ADAPTIVEHOST_UPDATE,
-                            NEBFLAG_NONE,
-                            NEBATTR_NONE,
-                            hst,
-                            CMD_NONE,
-                            attr,
-                            hst->get_modified_attributes(),
-                            nullptr);
+  broker_adaptive_host_data(NEBTYPE_ADAPTIVEHOST_UPDATE, NEBFLAG_NONE,
+                            NEBATTR_NONE, hst, CMD_NONE, attr,
+                            hst->get_modified_attributes(), nullptr);
 
   /* update the status log to reflect the new host state */
   hst->update_status();
@@ -2477,14 +2264,13 @@ void enable_and_propagate_notifications(host* hst,
   /* check all child hosts... */
   for (host_map_unsafe::iterator it(hst->child_hosts.begin()),
        end(hst->child_hosts.end());
-       it != end;
-       ++it) {
+       it != end; ++it) {
     if (it->second == nullptr)
       continue;
 
     /* recurse... */
-    enable_and_propagate_notifications(
-        it->second, level + 1, affect_top_host, affect_hosts, affect_services);
+    enable_and_propagate_notifications(it->second, level + 1, affect_top_host,
+                                       affect_hosts, affect_services);
 
     /* enable notifications for this host */
     if (affect_hosts)
@@ -2494,8 +2280,7 @@ void enable_and_propagate_notifications(host* hst,
     if (affect_services) {
       for (service_map_unsafe::iterator it2(it->second->services.begin()),
            end2(it->second->services.end());
-           it2 != end2;
-           ++it2) {
+           it2 != end2; ++it2) {
         if (!it2->second)
           continue;
         enable_service_notifications(it2->second);
@@ -2520,14 +2305,13 @@ void disable_and_propagate_notifications(host* hst,
   /* check all child hosts... */
   for (host_map_unsafe::iterator it(hst->child_hosts.begin()),
        end(hst->child_hosts.begin());
-       it != end;
-       ++it) {
+       it != end; ++it) {
     if (!it->second)
       continue;
 
     /* recurse... */
-    disable_and_propagate_notifications(
-        it->second, level + 1, affect_top_host, affect_hosts, affect_services);
+    disable_and_propagate_notifications(it->second, level + 1, affect_top_host,
+                                        affect_hosts, affect_services);
 
     /* disable notifications for this host */
     if (affect_hosts)
@@ -2537,8 +2321,7 @@ void disable_and_propagate_notifications(host* hst,
     if (affect_services) {
       for (service_map_unsafe::iterator it2(it->second->services.begin()),
            end2(it->second->services.end());
-           it2 != end2;
-           ++it2) {
+           it2 != end2; ++it2) {
         if (!it2->second)
           continue;
         disable_service_notifications(it2->second);
@@ -2563,18 +2346,11 @@ void enable_contact_host_notifications(contact* cntct) {
   cntct->set_host_notifications_enabled(true);
 
   /* send data to event broker */
-  broker_adaptive_contact_data(NEBTYPE_ADAPTIVECONTACT_UPDATE,
-                               NEBFLAG_NONE,
-                               NEBATTR_NONE,
-                               cntct,
-                               CMD_NONE,
-                               MODATTR_NONE,
-                               cntct->get_modified_attributes(),
-                               attr,
-                               cntct->get_modified_host_attributes(),
-                               MODATTR_NONE,
-                               cntct->get_modified_service_attributes(),
-                               nullptr);
+  broker_adaptive_contact_data(
+      NEBTYPE_ADAPTIVECONTACT_UPDATE, NEBFLAG_NONE, NEBATTR_NONE, cntct,
+      CMD_NONE, MODATTR_NONE, cntct->get_modified_attributes(), attr,
+      cntct->get_modified_host_attributes(), MODATTR_NONE,
+      cntct->get_modified_service_attributes(), nullptr);
 
   /* update the status log to reflect the new contact state */
   cntct->update_status_info(false);
@@ -2596,18 +2372,11 @@ void disable_contact_host_notifications(contact* cntct) {
   cntct->set_host_notifications_enabled(false);
 
   /* send data to event broker */
-  broker_adaptive_contact_data(NEBTYPE_ADAPTIVECONTACT_UPDATE,
-                               NEBFLAG_NONE,
-                               NEBATTR_NONE,
-                               cntct,
-                               CMD_NONE,
-                               MODATTR_NONE,
-                               cntct->get_modified_attributes(),
-                               attr,
-                               cntct->get_modified_host_attributes(),
-                               MODATTR_NONE,
-                               cntct->get_modified_service_attributes(),
-                               nullptr);
+  broker_adaptive_contact_data(
+      NEBTYPE_ADAPTIVECONTACT_UPDATE, NEBFLAG_NONE, NEBATTR_NONE, cntct,
+      CMD_NONE, MODATTR_NONE, cntct->get_modified_attributes(), attr,
+      cntct->get_modified_host_attributes(), MODATTR_NONE,
+      cntct->get_modified_service_attributes(), nullptr);
 
   /* update the status log to reflect the new contact state */
   cntct->update_status_info(false);
@@ -2629,18 +2398,11 @@ void enable_contact_service_notifications(contact* cntct) {
   cntct->set_service_notifications_enabled(true);
 
   /* send data to event broker */
-  broker_adaptive_contact_data(NEBTYPE_ADAPTIVECONTACT_UPDATE,
-                               NEBFLAG_NONE,
-                               NEBATTR_NONE,
-                               cntct,
-                               CMD_NONE,
-                               MODATTR_NONE,
-                               cntct->get_modified_attributes(),
-                               MODATTR_NONE,
-                               cntct->get_modified_host_attributes(),
-                               attr,
-                               cntct->get_modified_service_attributes(),
-                               nullptr);
+  broker_adaptive_contact_data(
+      NEBTYPE_ADAPTIVECONTACT_UPDATE, NEBFLAG_NONE, NEBATTR_NONE, cntct,
+      CMD_NONE, MODATTR_NONE, cntct->get_modified_attributes(), MODATTR_NONE,
+      cntct->get_modified_host_attributes(), attr,
+      cntct->get_modified_service_attributes(), nullptr);
 
   /* update the status log to reflect the new contact state */
   cntct->update_status_info(false);
@@ -2662,18 +2424,11 @@ void disable_contact_service_notifications(contact* cntct) {
   cntct->set_service_notifications_enabled(false);
 
   /* send data to event broker */
-  broker_adaptive_contact_data(NEBTYPE_ADAPTIVECONTACT_UPDATE,
-                               NEBFLAG_NONE,
-                               NEBATTR_NONE,
-                               cntct,
-                               CMD_NONE,
-                               MODATTR_NONE,
-                               cntct->get_modified_attributes(),
-                               MODATTR_NONE,
-                               cntct->get_modified_host_attributes(),
-                               attr,
-                               cntct->get_modified_service_attributes(),
-                               nullptr);
+  broker_adaptive_contact_data(
+      NEBTYPE_ADAPTIVECONTACT_UPDATE, NEBFLAG_NONE, NEBATTR_NONE, cntct,
+      CMD_NONE, MODATTR_NONE, cntct->get_modified_attributes(), MODATTR_NONE,
+      cntct->get_modified_host_attributes(), attr,
+      cntct->get_modified_service_attributes(), nullptr);
 
   /* update the status log to reflect the new contact state */
   cntct->update_status_info(false);
@@ -2692,35 +2447,20 @@ void schedule_and_propagate_downtime(host* temp_host,
   /* check all child hosts... */
   for (host_map_unsafe::iterator it(temp_host->child_hosts.begin()),
        end(temp_host->child_hosts.end());
-       it != end;
-       ++it) {
+       it != end; ++it) {
     if (it->second == nullptr)
       continue;
 
     /* recurse... */
-    schedule_and_propagate_downtime(it->second,
-                                    entry_time,
-                                    author,
-                                    comment_data,
-                                    start_time,
-                                    end_time,
-                                    fixed,
-                                    triggered_by,
-                                    duration);
+    schedule_and_propagate_downtime(it->second, entry_time, author,
+                                    comment_data, start_time, end_time, fixed,
+                                    triggered_by, duration);
 
     /* schedule downtime for this host */
-    downtime_manager::instance().schedule_downtime(downtime::host_downtime,
-                                                   it->first,
-                                                   "",
-                                                   entry_time,
-                                                   author,
-                                                   comment_data,
-                                                   start_time,
-                                                   end_time,
-                                                   fixed,
-                                                   triggered_by,
-                                                   duration,
-                                                   nullptr);
+    downtime_manager::instance().schedule_downtime(
+        downtime::host_downtime, it->first, "", entry_time, author,
+        comment_data, start_time, end_time, fixed, triggered_by, duration,
+        nullptr);
   }
 }
 
@@ -2749,40 +2489,24 @@ void acknowledge_host_problem(host* hst,
   hst->schedule_acknowledgement_expiration();
 
   /* send data to event broker */
-  broker_acknowledgement_data(NEBTYPE_ACKNOWLEDGEMENT_ADD,
-                              NEBFLAG_NONE,
-                              NEBATTR_NONE,
-                              HOST_ACKNOWLEDGEMENT,
-                              (void*)hst,
-                              ack_author,
-                              ack_data,
-                              type,
-                              notify,
-                              persistent,
+  broker_acknowledgement_data(NEBTYPE_ACKNOWLEDGEMENT_ADD, NEBFLAG_NONE,
+                              NEBATTR_NONE, HOST_ACKNOWLEDGEMENT, (void*)hst,
+                              ack_author, ack_data, type, notify, persistent,
                               nullptr);
 
   /* send out an acknowledgement notification */
   if (notify)
-    hst->notify(notifier::reason_acknowledgement,
-                ack_author,
-                ack_data,
+    hst->notify(notifier::reason_acknowledgement, ack_author, ack_data,
                 notifier::notification_option_none);
 
   /* update the status log with the host info */
   hst->update_status();
 
   /* add a comment for the acknowledgement */
-  std::shared_ptr<comment> com{new comment(comment::host,
-                                           comment::acknowledgment,
-                                           hst->get_host_id(),
-                                           0,
-                                           current_time,
-                                           ack_author,
-                                           ack_data,
-                                           persistent,
-                                           comment::internal,
-                                           false,
-                                           (time_t)0)};
+  std::shared_ptr<comment> com{
+      new comment(comment::host, comment::acknowledgment, hst->get_host_id(), 0,
+                  current_time, ack_author, ack_data, persistent,
+                  comment::internal, false, (time_t)0)};
   comment::comments.insert({com->get_comment_id(), com});
 }
 
@@ -2811,40 +2535,24 @@ void acknowledge_service_problem(service* svc,
   svc->schedule_acknowledgement_expiration();
 
   /* send data to event broker */
-  broker_acknowledgement_data(NEBTYPE_ACKNOWLEDGEMENT_ADD,
-                              NEBFLAG_NONE,
-                              NEBATTR_NONE,
-                              SERVICE_ACKNOWLEDGEMENT,
-                              (void*)svc,
-                              ack_author,
-                              ack_data,
-                              type,
-                              notify,
-                              persistent,
+  broker_acknowledgement_data(NEBTYPE_ACKNOWLEDGEMENT_ADD, NEBFLAG_NONE,
+                              NEBATTR_NONE, SERVICE_ACKNOWLEDGEMENT, (void*)svc,
+                              ack_author, ack_data, type, notify, persistent,
                               nullptr);
 
   /* send out an acknowledgement notification */
   if (notify)
-    svc->notify(notifier::reason_acknowledgement,
-                ack_author,
-                ack_data,
+    svc->notify(notifier::reason_acknowledgement, ack_author, ack_data,
                 notifier::notification_option_none);
 
   /* update the status log with the service info */
   svc->update_status();
 
   /* add a comment for the acknowledgement */
-  std::shared_ptr<comment> com{new comment(comment::service,
-                                           comment::acknowledgment,
-                                           svc->get_host_id(),
-                                           svc->get_service_id(),
-                                           current_time,
-                                           ack_author,
-                                           ack_data,
-                                           persistent,
-                                           comment::internal,
-                                           false,
-                                           (time_t)0)};
+  std::shared_ptr<comment> com{
+      new comment(comment::service, comment::acknowledgment, svc->get_host_id(),
+                  svc->get_service_id(), current_time, ack_author, ack_data,
+                  persistent, comment::internal, false, (time_t)0)};
   comment::comments.insert({com->get_comment_id(), com});
 }
 
@@ -2887,15 +2595,10 @@ void start_executing_service_checks(void) {
   config->execute_service_checks(true);
 
   /* send data to event broker */
-  broker_adaptive_program_data(NEBTYPE_ADAPTIVEPROGRAM_UPDATE,
-                               NEBFLAG_NONE,
-                               NEBATTR_NONE,
-                               CMD_NONE,
-                               MODATTR_NONE,
-                               modified_host_process_attributes,
-                               attr,
-                               modified_service_process_attributes,
-                               nullptr);
+  broker_adaptive_program_data(NEBTYPE_ADAPTIVEPROGRAM_UPDATE, NEBFLAG_NONE,
+                               NEBATTR_NONE, CMD_NONE, MODATTR_NONE,
+                               modified_host_process_attributes, attr,
+                               modified_service_process_attributes, nullptr);
 
   /* update the status log with the program info */
   update_program_status(false);
@@ -2916,15 +2619,10 @@ void stop_executing_service_checks(void) {
   config->execute_service_checks(false);
 
   /* send data to event broker */
-  broker_adaptive_program_data(NEBTYPE_ADAPTIVEPROGRAM_UPDATE,
-                               NEBFLAG_NONE,
-                               NEBATTR_NONE,
-                               CMD_NONE,
-                               MODATTR_NONE,
-                               modified_host_process_attributes,
-                               attr,
-                               modified_service_process_attributes,
-                               nullptr);
+  broker_adaptive_program_data(NEBTYPE_ADAPTIVEPROGRAM_UPDATE, NEBFLAG_NONE,
+                               NEBATTR_NONE, CMD_NONE, MODATTR_NONE,
+                               modified_host_process_attributes, attr,
+                               modified_service_process_attributes, nullptr);
 
   /* update the status log with the program info */
   update_program_status(false);
@@ -2945,15 +2643,10 @@ void start_accepting_passive_service_checks(void) {
   config->accept_passive_service_checks(true);
 
   /* send data to event broker */
-  broker_adaptive_program_data(NEBTYPE_ADAPTIVEPROGRAM_UPDATE,
-                               NEBFLAG_NONE,
-                               NEBATTR_NONE,
-                               CMD_NONE,
-                               MODATTR_NONE,
-                               modified_host_process_attributes,
-                               attr,
-                               modified_service_process_attributes,
-                               nullptr);
+  broker_adaptive_program_data(NEBTYPE_ADAPTIVEPROGRAM_UPDATE, NEBFLAG_NONE,
+                               NEBATTR_NONE, CMD_NONE, MODATTR_NONE,
+                               modified_host_process_attributes, attr,
+                               modified_service_process_attributes, nullptr);
 
   /* update the status log with the program info */
   update_program_status(false);
@@ -2974,15 +2667,10 @@ void stop_accepting_passive_service_checks(void) {
   config->accept_passive_service_checks(false);
 
   /* send data to event broker */
-  broker_adaptive_program_data(NEBTYPE_ADAPTIVEPROGRAM_UPDATE,
-                               NEBFLAG_NONE,
-                               NEBATTR_NONE,
-                               CMD_NONE,
-                               MODATTR_NONE,
-                               modified_host_process_attributes,
-                               attr,
-                               modified_service_process_attributes,
-                               nullptr);
+  broker_adaptive_program_data(NEBTYPE_ADAPTIVEPROGRAM_UPDATE, NEBFLAG_NONE,
+                               NEBATTR_NONE, CMD_NONE, MODATTR_NONE,
+                               modified_host_process_attributes, attr,
+                               modified_service_process_attributes, nullptr);
 
   /* update the status log with the program info */
   update_program_status(false);
@@ -3003,14 +2691,9 @@ void enable_passive_service_checks(service* svc) {
   svc->set_accept_passive_checks(true);
 
   /* send data to event broker */
-  broker_adaptive_service_data(NEBTYPE_ADAPTIVESERVICE_UPDATE,
-                               NEBFLAG_NONE,
-                               NEBATTR_NONE,
-                               svc,
-                               CMD_NONE,
-                               attr,
-                               svc->get_modified_attributes(),
-                               nullptr);
+  broker_adaptive_service_data(NEBTYPE_ADAPTIVESERVICE_UPDATE, NEBFLAG_NONE,
+                               NEBATTR_NONE, svc, CMD_NONE, attr,
+                               svc->get_modified_attributes(), nullptr);
 
   /* update the status log with the service info */
   svc->update_status();
@@ -3031,14 +2714,9 @@ void disable_passive_service_checks(service* svc) {
   svc->set_accept_passive_checks(false);
 
   /* send data to event broker */
-  broker_adaptive_service_data(NEBTYPE_ADAPTIVESERVICE_UPDATE,
-                               NEBFLAG_NONE,
-                               NEBATTR_NONE,
-                               svc,
-                               CMD_NONE,
-                               attr,
-                               svc->get_modified_attributes(),
-                               nullptr);
+  broker_adaptive_service_data(NEBTYPE_ADAPTIVESERVICE_UPDATE, NEBFLAG_NONE,
+                               NEBATTR_NONE, svc, CMD_NONE, attr,
+                               svc->get_modified_attributes(), nullptr);
 
   /* update the status log with the service info */
   svc->update_status();
@@ -3059,15 +2737,10 @@ void start_executing_host_checks(void) {
   config->execute_host_checks(true);
 
   /* send data to event broker */
-  broker_adaptive_program_data(NEBTYPE_ADAPTIVEPROGRAM_UPDATE,
-                               NEBFLAG_NONE,
-                               NEBATTR_NONE,
-                               CMD_NONE,
-                               attr,
-                               modified_host_process_attributes,
-                               MODATTR_NONE,
-                               modified_service_process_attributes,
-                               nullptr);
+  broker_adaptive_program_data(NEBTYPE_ADAPTIVEPROGRAM_UPDATE, NEBFLAG_NONE,
+                               NEBATTR_NONE, CMD_NONE, attr,
+                               modified_host_process_attributes, MODATTR_NONE,
+                               modified_service_process_attributes, nullptr);
 
   /* update the status log with the program info */
   update_program_status(false);
@@ -3088,15 +2761,10 @@ void stop_executing_host_checks(void) {
   config->execute_host_checks(false);
 
   /* send data to event broker */
-  broker_adaptive_program_data(NEBTYPE_ADAPTIVEPROGRAM_UPDATE,
-                               NEBFLAG_NONE,
-                               NEBATTR_NONE,
-                               CMD_NONE,
-                               attr,
-                               modified_host_process_attributes,
-                               MODATTR_NONE,
-                               modified_service_process_attributes,
-                               nullptr);
+  broker_adaptive_program_data(NEBTYPE_ADAPTIVEPROGRAM_UPDATE, NEBFLAG_NONE,
+                               NEBATTR_NONE, CMD_NONE, attr,
+                               modified_host_process_attributes, MODATTR_NONE,
+                               modified_service_process_attributes, nullptr);
 
   /* update the status log with the program info */
   update_program_status(false);
@@ -3117,15 +2785,10 @@ void start_accepting_passive_host_checks(void) {
   config->accept_passive_host_checks(true);
 
   /* send data to event broker */
-  broker_adaptive_program_data(NEBTYPE_ADAPTIVEPROGRAM_UPDATE,
-                               NEBFLAG_NONE,
-                               NEBATTR_NONE,
-                               CMD_NONE,
-                               attr,
-                               modified_host_process_attributes,
-                               MODATTR_NONE,
-                               modified_service_process_attributes,
-                               nullptr);
+  broker_adaptive_program_data(NEBTYPE_ADAPTIVEPROGRAM_UPDATE, NEBFLAG_NONE,
+                               NEBATTR_NONE, CMD_NONE, attr,
+                               modified_host_process_attributes, MODATTR_NONE,
+                               modified_service_process_attributes, nullptr);
 
   /* update the status log with the program info */
   update_program_status(false);
@@ -3146,15 +2809,10 @@ void stop_accepting_passive_host_checks(void) {
   config->accept_passive_host_checks(false);
 
   /* send data to event broker */
-  broker_adaptive_program_data(NEBTYPE_ADAPTIVEPROGRAM_UPDATE,
-                               NEBFLAG_NONE,
-                               NEBATTR_NONE,
-                               CMD_NONE,
-                               attr,
-                               modified_host_process_attributes,
-                               MODATTR_NONE,
-                               modified_service_process_attributes,
-                               nullptr);
+  broker_adaptive_program_data(NEBTYPE_ADAPTIVEPROGRAM_UPDATE, NEBFLAG_NONE,
+                               NEBATTR_NONE, CMD_NONE, attr,
+                               modified_host_process_attributes, MODATTR_NONE,
+                               modified_service_process_attributes, nullptr);
   /* update the status log with the program info */
   update_program_status(false);
 }
@@ -3174,14 +2832,9 @@ void enable_passive_host_checks(host* hst) {
   hst->set_accept_passive_checks(true);
 
   /* send data to event broker */
-  broker_adaptive_host_data(NEBTYPE_ADAPTIVEHOST_UPDATE,
-                            NEBFLAG_NONE,
-                            NEBATTR_NONE,
-                            hst,
-                            CMD_NONE,
-                            attr,
-                            hst->get_modified_attributes(),
-                            nullptr);
+  broker_adaptive_host_data(NEBTYPE_ADAPTIVEHOST_UPDATE, NEBFLAG_NONE,
+                            NEBATTR_NONE, hst, CMD_NONE, attr,
+                            hst->get_modified_attributes(), nullptr);
 
   /* update the status log with the host info */
   hst->update_status();
@@ -3202,14 +2855,9 @@ void disable_passive_host_checks(host* hst) {
   hst->set_accept_passive_checks(false);
 
   /* send data to event broker */
-  broker_adaptive_host_data(NEBTYPE_ADAPTIVEHOST_UPDATE,
-                            NEBFLAG_NONE,
-                            NEBATTR_NONE,
-                            hst,
-                            CMD_NONE,
-                            attr,
-                            hst->get_modified_attributes(),
-                            nullptr);
+  broker_adaptive_host_data(NEBTYPE_ADAPTIVEHOST_UPDATE, NEBFLAG_NONE,
+                            NEBATTR_NONE, hst, CMD_NONE, attr,
+                            hst->get_modified_attributes(), nullptr);
 
   /* update the status log with the host info */
   hst->update_status();
@@ -3231,15 +2879,10 @@ void start_using_event_handlers(void) {
   config->enable_event_handlers(true);
 
   /* send data to event broker */
-  broker_adaptive_program_data(NEBTYPE_ADAPTIVEPROGRAM_UPDATE,
-                               NEBFLAG_NONE,
-                               NEBATTR_NONE,
-                               CMD_NONE,
-                               attr,
-                               modified_host_process_attributes,
-                               attr,
-                               modified_service_process_attributes,
-                               nullptr);
+  broker_adaptive_program_data(NEBTYPE_ADAPTIVEPROGRAM_UPDATE, NEBFLAG_NONE,
+                               NEBATTR_NONE, CMD_NONE, attr,
+                               modified_host_process_attributes, attr,
+                               modified_service_process_attributes, nullptr);
 
   /* update the status log with the program info */
   update_program_status(false);
@@ -3261,15 +2904,10 @@ void stop_using_event_handlers(void) {
   config->enable_event_handlers(false);
 
   /* send data to event broker */
-  broker_adaptive_program_data(NEBTYPE_ADAPTIVEPROGRAM_UPDATE,
-                               NEBFLAG_NONE,
-                               NEBATTR_NONE,
-                               CMD_NONE,
-                               attr,
-                               modified_host_process_attributes,
-                               attr,
-                               modified_service_process_attributes,
-                               nullptr);
+  broker_adaptive_program_data(NEBTYPE_ADAPTIVEPROGRAM_UPDATE, NEBFLAG_NONE,
+                               NEBATTR_NONE, CMD_NONE, attr,
+                               modified_host_process_attributes, attr,
+                               modified_service_process_attributes, nullptr);
 
   /* update the status log with the program info */
   update_program_status(false);
@@ -3290,14 +2928,9 @@ void enable_service_event_handler(service* svc) {
   svc->set_event_handler_enabled(true);
 
   /* send data to event broker */
-  broker_adaptive_service_data(NEBTYPE_ADAPTIVESERVICE_UPDATE,
-                               NEBFLAG_NONE,
-                               NEBATTR_NONE,
-                               svc,
-                               CMD_NONE,
-                               attr,
-                               svc->get_modified_attributes(),
-                               nullptr);
+  broker_adaptive_service_data(NEBTYPE_ADAPTIVESERVICE_UPDATE, NEBFLAG_NONE,
+                               NEBATTR_NONE, svc, CMD_NONE, attr,
+                               svc->get_modified_attributes(), nullptr);
 
   /* update the status log with the service info */
   svc->update_status();
@@ -3318,14 +2951,9 @@ void disable_service_event_handler(service* svc) {
   svc->set_event_handler_enabled(false);
 
   /* send data to event broker */
-  broker_adaptive_service_data(NEBTYPE_ADAPTIVESERVICE_UPDATE,
-                               NEBFLAG_NONE,
-                               NEBATTR_NONE,
-                               svc,
-                               CMD_NONE,
-                               attr,
-                               svc->get_modified_attributes(),
-                               nullptr);
+  broker_adaptive_service_data(NEBTYPE_ADAPTIVESERVICE_UPDATE, NEBFLAG_NONE,
+                               NEBATTR_NONE, svc, CMD_NONE, attr,
+                               svc->get_modified_attributes(), nullptr);
 
   /* update the status log with the service info */
   svc->update_status();
@@ -3346,14 +2974,9 @@ void enable_host_event_handler(host* hst) {
   hst->set_event_handler_enabled(true);
 
   /* send data to event broker */
-  broker_adaptive_host_data(NEBTYPE_ADAPTIVEHOST_UPDATE,
-                            NEBFLAG_NONE,
-                            NEBATTR_NONE,
-                            hst,
-                            CMD_NONE,
-                            attr,
-                            hst->get_modified_attributes(),
-                            nullptr);
+  broker_adaptive_host_data(NEBTYPE_ADAPTIVEHOST_UPDATE, NEBFLAG_NONE,
+                            NEBATTR_NONE, hst, CMD_NONE, attr,
+                            hst->get_modified_attributes(), nullptr);
 
   /* update the status log with the host info */
   hst->update_status();
@@ -3374,14 +2997,9 @@ void disable_host_event_handler(host* hst) {
   hst->set_event_handler_enabled(false);
 
   /* send data to event broker */
-  broker_adaptive_host_data(NEBTYPE_ADAPTIVEHOST_UPDATE,
-                            NEBFLAG_NONE,
-                            NEBATTR_NONE,
-                            hst,
-                            CMD_NONE,
-                            attr,
-                            hst->get_modified_attributes(),
-                            nullptr);
+  broker_adaptive_host_data(NEBTYPE_ADAPTIVEHOST_UPDATE, NEBFLAG_NONE,
+                            NEBATTR_NONE, hst, CMD_NONE, attr,
+                            hst->get_modified_attributes(), nullptr);
 
   /* update the status log with the host info */
   hst->update_status();
@@ -3403,14 +3021,9 @@ void disable_host_checks(host* hst) {
   hst->set_should_be_scheduled(false);
 
   /* send data to event broker */
-  broker_adaptive_host_data(NEBTYPE_ADAPTIVEHOST_UPDATE,
-                            NEBFLAG_NONE,
-                            NEBATTR_NONE,
-                            hst,
-                            CMD_NONE,
-                            attr,
-                            hst->get_modified_attributes(),
-                            nullptr);
+  broker_adaptive_host_data(NEBTYPE_ADAPTIVEHOST_UPDATE, NEBFLAG_NONE,
+                            NEBATTR_NONE, hst, CMD_NONE, attr,
+                            hst->get_modified_attributes(), nullptr);
 
   /* update the status log with the host info */
   hst->update_status();
@@ -3440,8 +3053,8 @@ void enable_host_checks(host* hst) {
   /* schedule a check for right now (or as soon as possible) */
   time(&preferred_time);
   if (!check_time_against_period(preferred_time, hst->check_period_ptr)) {
-    get_next_valid_time(
-        preferred_time, &next_valid_time, hst->check_period_ptr);
+    get_next_valid_time(preferred_time, &next_valid_time,
+                        hst->check_period_ptr);
     hst->set_next_check(next_valid_time);
   } else
     hst->set_next_check(preferred_time);
@@ -3451,14 +3064,9 @@ void enable_host_checks(host* hst) {
     hst->schedule_check(hst->get_next_check(), CHECK_OPTION_NONE);
 
   /* send data to event broker */
-  broker_adaptive_host_data(NEBTYPE_ADAPTIVEHOST_UPDATE,
-                            NEBFLAG_NONE,
-                            NEBATTR_NONE,
-                            hst,
-                            CMD_NONE,
-                            attr,
-                            hst->get_modified_attributes(),
-                            nullptr);
+  broker_adaptive_host_data(NEBTYPE_ADAPTIVEHOST_UPDATE, NEBFLAG_NONE,
+                            NEBATTR_NONE, hst, CMD_NONE, attr,
+                            hst->get_modified_attributes(), nullptr);
 
   /* update the status log with the host info */
   hst->update_status();
@@ -3479,15 +3087,10 @@ void start_obsessing_over_service_checks(void) {
   config->obsess_over_services(true);
 
   /* send data to event broker */
-  broker_adaptive_program_data(NEBTYPE_ADAPTIVEPROGRAM_UPDATE,
-                               NEBFLAG_NONE,
-                               NEBATTR_NONE,
-                               CMD_NONE,
-                               MODATTR_NONE,
-                               modified_host_process_attributes,
-                               attr,
-                               modified_service_process_attributes,
-                               nullptr);
+  broker_adaptive_program_data(NEBTYPE_ADAPTIVEPROGRAM_UPDATE, NEBFLAG_NONE,
+                               NEBATTR_NONE, CMD_NONE, MODATTR_NONE,
+                               modified_host_process_attributes, attr,
+                               modified_service_process_attributes, nullptr);
 
   /* update the status log with the program info */
   update_program_status(false);
@@ -3508,15 +3111,10 @@ void stop_obsessing_over_service_checks(void) {
   config->obsess_over_services(false);
 
   /* send data to event broker */
-  broker_adaptive_program_data(NEBTYPE_ADAPTIVEPROGRAM_UPDATE,
-                               NEBFLAG_NONE,
-                               NEBATTR_NONE,
-                               CMD_NONE,
-                               MODATTR_NONE,
-                               modified_host_process_attributes,
-                               attr,
-                               modified_service_process_attributes,
-                               nullptr);
+  broker_adaptive_program_data(NEBTYPE_ADAPTIVEPROGRAM_UPDATE, NEBFLAG_NONE,
+                               NEBATTR_NONE, CMD_NONE, MODATTR_NONE,
+                               modified_host_process_attributes, attr,
+                               modified_service_process_attributes, nullptr);
 
   /* update the status log with the program info */
   update_program_status(false);
@@ -3537,15 +3135,10 @@ void start_obsessing_over_host_checks(void) {
   config->obsess_over_hosts(true);
 
   /* send data to event broker */
-  broker_adaptive_program_data(NEBTYPE_ADAPTIVEPROGRAM_UPDATE,
-                               NEBFLAG_NONE,
-                               NEBATTR_NONE,
-                               CMD_NONE,
-                               attr,
-                               modified_host_process_attributes,
-                               MODATTR_NONE,
-                               modified_service_process_attributes,
-                               nullptr);
+  broker_adaptive_program_data(NEBTYPE_ADAPTIVEPROGRAM_UPDATE, NEBFLAG_NONE,
+                               NEBATTR_NONE, CMD_NONE, attr,
+                               modified_host_process_attributes, MODATTR_NONE,
+                               modified_service_process_attributes, nullptr);
 
   /* update the status log with the program info */
   update_program_status(false);
@@ -3566,15 +3159,10 @@ void stop_obsessing_over_host_checks(void) {
   config->obsess_over_hosts(false);
 
   /* send data to event broker */
-  broker_adaptive_program_data(NEBTYPE_ADAPTIVEPROGRAM_UPDATE,
-                               NEBFLAG_NONE,
-                               NEBATTR_NONE,
-                               CMD_NONE,
-                               attr,
-                               modified_host_process_attributes,
-                               MODATTR_NONE,
-                               modified_service_process_attributes,
-                               nullptr);
+  broker_adaptive_program_data(NEBTYPE_ADAPTIVEPROGRAM_UPDATE, NEBFLAG_NONE,
+                               NEBATTR_NONE, CMD_NONE, attr,
+                               modified_host_process_attributes, MODATTR_NONE,
+                               modified_service_process_attributes, nullptr);
 
   /* update the status log with the program info */
   update_program_status(false);
@@ -3595,15 +3183,10 @@ void enable_service_freshness_checks(void) {
   config->check_service_freshness(true);
 
   /* send data to event broker */
-  broker_adaptive_program_data(NEBTYPE_ADAPTIVEPROGRAM_UPDATE,
-                               NEBFLAG_NONE,
-                               NEBATTR_NONE,
-                               CMD_NONE,
-                               MODATTR_NONE,
-                               modified_host_process_attributes,
-                               attr,
-                               modified_service_process_attributes,
-                               nullptr);
+  broker_adaptive_program_data(NEBTYPE_ADAPTIVEPROGRAM_UPDATE, NEBFLAG_NONE,
+                               NEBATTR_NONE, CMD_NONE, MODATTR_NONE,
+                               modified_host_process_attributes, attr,
+                               modified_service_process_attributes, nullptr);
 
   /* update the status log with the program info */
   update_program_status(false);
@@ -3624,15 +3207,10 @@ void disable_service_freshness_checks(void) {
   config->check_service_freshness(false);
 
   /* send data to event broker */
-  broker_adaptive_program_data(NEBTYPE_ADAPTIVEPROGRAM_UPDATE,
-                               NEBFLAG_NONE,
-                               NEBATTR_NONE,
-                               CMD_NONE,
-                               MODATTR_NONE,
-                               modified_host_process_attributes,
-                               attr,
-                               modified_service_process_attributes,
-                               nullptr);
+  broker_adaptive_program_data(NEBTYPE_ADAPTIVEPROGRAM_UPDATE, NEBFLAG_NONE,
+                               NEBATTR_NONE, CMD_NONE, MODATTR_NONE,
+                               modified_host_process_attributes, attr,
+                               modified_service_process_attributes, nullptr);
 
   /* update the status log with the program info */
   update_program_status(false);
@@ -3653,15 +3231,10 @@ void enable_host_freshness_checks(void) {
   config->check_host_freshness(true);
 
   /* send data to event broker */
-  broker_adaptive_program_data(NEBTYPE_ADAPTIVEPROGRAM_UPDATE,
-                               NEBFLAG_NONE,
-                               NEBATTR_NONE,
-                               CMD_NONE,
-                               attr,
-                               modified_host_process_attributes,
-                               MODATTR_NONE,
-                               modified_service_process_attributes,
-                               nullptr);
+  broker_adaptive_program_data(NEBTYPE_ADAPTIVEPROGRAM_UPDATE, NEBFLAG_NONE,
+                               NEBATTR_NONE, CMD_NONE, attr,
+                               modified_host_process_attributes, MODATTR_NONE,
+                               modified_service_process_attributes, nullptr);
   /* update the status log with the program info */
   update_program_status(false);
 }
@@ -3681,15 +3254,10 @@ void disable_host_freshness_checks(void) {
   config->check_host_freshness(false);
 
   /* send data to event broker */
-  broker_adaptive_program_data(NEBTYPE_ADAPTIVEPROGRAM_UPDATE,
-                               NEBFLAG_NONE,
-                               NEBATTR_NONE,
-                               CMD_NONE,
-                               attr,
-                               modified_host_process_attributes,
-                               MODATTR_NONE,
-                               modified_service_process_attributes,
-                               nullptr);
+  broker_adaptive_program_data(NEBTYPE_ADAPTIVEPROGRAM_UPDATE, NEBFLAG_NONE,
+                               NEBATTR_NONE, CMD_NONE, attr,
+                               modified_host_process_attributes, MODATTR_NONE,
+                               modified_service_process_attributes, nullptr);
 
   /* update the status log with the program info */
   update_program_status(false);
@@ -3710,15 +3278,10 @@ void enable_performance_data(void) {
   config->process_performance_data(true);
 
   /* send data to event broker */
-  broker_adaptive_program_data(NEBTYPE_ADAPTIVEPROGRAM_UPDATE,
-                               NEBFLAG_NONE,
-                               NEBATTR_NONE,
-                               CMD_NONE,
-                               attr,
-                               modified_host_process_attributes,
-                               attr,
-                               modified_service_process_attributes,
-                               nullptr);
+  broker_adaptive_program_data(NEBTYPE_ADAPTIVEPROGRAM_UPDATE, NEBFLAG_NONE,
+                               NEBATTR_NONE, CMD_NONE, attr,
+                               modified_host_process_attributes, attr,
+                               modified_service_process_attributes, nullptr);
 
   /* update the status log */
   update_program_status(false);
@@ -3739,15 +3302,10 @@ void disable_performance_data(void) {
   config->process_performance_data(false);
 
   /* send data to event broker */
-  broker_adaptive_program_data(NEBTYPE_ADAPTIVEPROGRAM_UPDATE,
-                               NEBFLAG_NONE,
-                               NEBATTR_NONE,
-                               CMD_NONE,
-                               attr,
-                               modified_host_process_attributes,
-                               attr,
-                               modified_service_process_attributes,
-                               nullptr);
+  broker_adaptive_program_data(NEBTYPE_ADAPTIVEPROGRAM_UPDATE, NEBFLAG_NONE,
+                               NEBATTR_NONE, CMD_NONE, attr,
+                               modified_host_process_attributes, attr,
+                               modified_service_process_attributes, nullptr);
 
   /* update the status log */
   update_program_status(false);
@@ -3768,14 +3326,9 @@ void start_obsessing_over_service(service* svc) {
   svc->set_obsess_over(true);
 
   /* send data to event broker */
-  broker_adaptive_service_data(NEBTYPE_ADAPTIVESERVICE_UPDATE,
-                               NEBFLAG_NONE,
-                               NEBATTR_NONE,
-                               svc,
-                               CMD_NONE,
-                               attr,
-                               svc->get_modified_attributes(),
-                               nullptr);
+  broker_adaptive_service_data(NEBTYPE_ADAPTIVESERVICE_UPDATE, NEBFLAG_NONE,
+                               NEBATTR_NONE, svc, CMD_NONE, attr,
+                               svc->get_modified_attributes(), nullptr);
 
   /* update the status log with the service info */
   svc->update_status();
@@ -3796,14 +3349,9 @@ void stop_obsessing_over_service(service* svc) {
   svc->set_obsess_over(false);
 
   /* send data to event broker */
-  broker_adaptive_service_data(NEBTYPE_ADAPTIVESERVICE_UPDATE,
-                               NEBFLAG_NONE,
-                               NEBATTR_NONE,
-                               svc,
-                               CMD_NONE,
-                               attr,
-                               svc->get_modified_attributes(),
-                               nullptr);
+  broker_adaptive_service_data(NEBTYPE_ADAPTIVESERVICE_UPDATE, NEBFLAG_NONE,
+                               NEBATTR_NONE, svc, CMD_NONE, attr,
+                               svc->get_modified_attributes(), nullptr);
 
   /* update the status log with the service info */
   svc->update_status();
@@ -3824,14 +3372,9 @@ void start_obsessing_over_host(host* hst) {
   hst->set_obsess_over(true);
 
   /* send data to event broker */
-  broker_adaptive_host_data(NEBTYPE_ADAPTIVEHOST_UPDATE,
-                            NEBFLAG_NONE,
-                            NEBATTR_NONE,
-                            hst,
-                            CMD_NONE,
-                            attr,
-                            hst->get_modified_attributes(),
-                            nullptr);
+  broker_adaptive_host_data(NEBTYPE_ADAPTIVEHOST_UPDATE, NEBFLAG_NONE,
+                            NEBATTR_NONE, hst, CMD_NONE, attr,
+                            hst->get_modified_attributes(), nullptr);
 
   /* update the status log with the host info */
   hst->update_status();
@@ -3852,14 +3395,9 @@ void stop_obsessing_over_host(host* hst) {
   hst->set_obsess_over(false);
 
   /* send data to event broker */
-  broker_adaptive_host_data(NEBTYPE_ADAPTIVEHOST_UPDATE,
-                            NEBFLAG_NONE,
-                            NEBATTR_NONE,
-                            hst,
-                            CMD_NONE,
-                            attr,
-                            hst->get_modified_attributes(),
-                            nullptr);
+  broker_adaptive_host_data(NEBTYPE_ADAPTIVEHOST_UPDATE, NEBFLAG_NONE,
+                            NEBATTR_NONE, hst, CMD_NONE, attr,
+                            hst->get_modified_attributes(), nullptr);
 
   /* update the status log with the host info */
   hst->update_status();

--- a/src/compatibility/mmap.cc
+++ b/src/compatibility/mmap.cc
@@ -91,7 +91,7 @@ int mmap_fclose(mmapfile* temp_mmapfile) {
   /* free memory */
   delete[] temp_mmapfile->path;
   delete temp_mmapfile;
-  return (OK);
+  return OK;
 }
 
 /* gets one line of input from an mmap()'ed file */
@@ -126,77 +126,5 @@ char* mmap_fgets(mmapfile* temp_mmapfile) {
 
   /* increment the current line */
   temp_mmapfile->current_line++;
-  return (buf);
-}
-
-/* gets one line of input from an mmap()'ed file (may be contained on more than
- * one line in the source file) */
-char* mmap_fgets_multiline(mmapfile* temp_mmapfile) {
-  if (!temp_mmapfile)
-    return nullptr;
-
-  char* buf(NULL);
-  char* tempbuf(NULL);
-  char* stripped(NULL);
-  int len(0);
-  int len2(0);
-  int end(0);
-
-  while (1) {
-    delete[] tempbuf;
-    tempbuf = NULL;
-
-    if ((tempbuf = mmap_fgets(temp_mmapfile)) == NULL)
-      break;
-
-    if (buf == NULL) {
-      len = strlen(tempbuf);
-      buf = new char[len + 1];
-      memcpy(buf, tempbuf, len);
-      buf[len] = '\x0';
-    } else {
-      /* strip leading white space from continuation lines */
-      stripped = tempbuf;
-      while (*stripped == ' ' || *stripped == '\t')
-        stripped++;
-      len = strlen(stripped);
-      len2 = strlen(buf);
-      buf = resize_string(buf, len + len2 + 1);
-      strcat(buf, stripped);
-      len += len2;
-      buf[len] = '\x0';
-    }
-
-    if (len == 0)
-      break;
-
-    /* handle Windows/DOS CR/LF */
-    if (len >= 2 && buf[len - 2] == '\r')
-      end = len - 3;
-    /* normal Unix LF */
-    else if (len >= 1 && buf[len - 1] == '\n')
-      end = len - 2;
-    else
-      end = len - 1;
-
-    /* two backslashes found. unescape first backslash first and break */
-    if (end >= 1 && buf[end - 1] == '\\' && buf[end] == '\\') {
-      buf[end] = '\n';
-      buf[end + 1] = '\x0';
-      break;
-    }
-
-    /* one backslash found. continue reading the next line */
-    else if (end > 0 && buf[end] == '\\')
-      buf[end] = '\x0';
-
-    /* no continuation marker was found, so break */
-    else
-      break;
-  }
-
-  delete[] tempbuf;
-  tempbuf = NULL;
-
-  return (buf);
+  return buf;
 }

--- a/src/contact.cc
+++ b/src/contact.cc
@@ -38,14 +38,10 @@ using namespace com::centreon::engine::string;
 
 contact_map contact::contacts;
 
-std::array<contact::to_notify, 6> const contact::_to_notify{{
-    &contact::_to_notify_normal,
-    &contact::_to_notify_recovery,
-    &contact::_to_notify_acknowledgement,
-    &contact::_to_notify_flapping,
-    &contact::_to_notify_downtime,
-    &contact::_to_notify_custom,
-}};
+std::array<contact::to_notify, 6> const contact::_to_notify{
+    {&contact::_to_notify_normal,          &contact::_to_notify_recovery,
+     &contact::_to_notify_acknowledgement, &contact::_to_notify_flapping,
+     &contact::_to_notify_downtime,        &contact::_to_notify_custom, }};
 
 /**************************************
  *                                     *
@@ -87,27 +83,21 @@ void contact::set_addresses(std::vector<std::string> const& addresses) {
  *
  *  @return a reference to the alias
  */
-std::string const& contact::get_alias() const {
-  return _alias;
-}
+std::string const& contact::get_alias() const { return _alias; }
 
 /**
  *  Set alias
  *
  *  @param[in] alias  New alias.
  */
-void contact::set_alias(std::string const& alias) {
-  _alias = alias;
-}
+void contact::set_alias(std::string const& alias) { _alias = alias; }
 
 /**
  *  Check if contact can submit commands.
  *
  *  @return True if contact can submit commands.
  */
-bool contact::get_can_submit_commands() const {
-  return _can_submit_commands;
-}
+bool contact::get_can_submit_commands() const { return _can_submit_commands; }
 
 /**
  *  (Dis)Allow a contact to submit commands.
@@ -123,18 +113,14 @@ void contact::set_can_submit_commands(bool can_submit) {
  *
  *  @return a reference to the email
  */
-std::string const& contact::get_email() const {
-  return _email;
-}
+std::string const& contact::get_email() const { return _email; }
 
 /**
  *  Set contact email.
  *
  *  @param[in] email  New email.
  */
-void contact::set_email(std::string const& email) {
-  _email = email;
-}
+void contact::set_email(std::string const& email) { _email = email; }
 
 /**
  *  Get the contact's modified attributes.
@@ -168,36 +154,28 @@ void contact::add_modified_attributes(uint32_t attr) {
  *
  *  @return A reference to the name.
  */
-std::string const& contact::get_name() const {
-  return _name;
-}
+std::string const& contact::get_name() const { return _name; }
 
 /**
  *  Set the contact name.
  *
  *  @param[in] name  New name.
  */
-void contact::set_name(std::string const& name) {
-  _name = name;
-}
+void contact::set_name(std::string const& name) { _name = name; }
 
 /**
  *  Return the contact pager
  *
  *  @return a reference to the pager
  */
-std::string const& contact::get_pager() const {
-  return _pager;
-}
+std::string const& contact::get_pager() const { return _pager; }
 
 /**
  *  Set the pager.
  *
  *  @param[in] pager  New pager.
  */
-void contact::set_pager(std::string const& pager) {
-  _pager = pager;
-}
+void contact::set_pager(std::string const& pager) { _pager = pager; }
 
 /**
  *  Check if status info should be retained.
@@ -240,9 +218,7 @@ void contact::set_retain_nonstatus_information(bool retain) {
  *
  *  @return Contact timezone.
  */
-std::string const& contact::get_timezone() const {
-  return _timezone;
-}
+std::string const& contact::get_timezone() const { return _timezone; }
 
 /**
  *  Set timezone.
@@ -334,17 +310,13 @@ std::ostream& operator<<(std::ostream& os, contact const& obj) {
     svc_notif_str = obj.get_service_notification_period_ptr()->get_name();
 
   os << "contact {\n"
-        "  name:                            "
-     << obj.get_name()
+        "  name:                            " << obj.get_name()
      << "\n"
-        "  alias:                           "
-     << obj.get_alias()
+        "  alias:                           " << obj.get_alias()
      << "\n"
-        "  email:                           "
-     << obj.get_email()
+        "  email:                           " << obj.get_email()
      << "\n"
-        "  pager:                           "
-     << obj.get_pager()
+        "  pager:                           " << obj.get_pager()
      << "\n"
         "  address:                         ";
   std::vector<std::string> const& address(obj.get_addresses());
@@ -419,8 +391,7 @@ std::ostream& operator<<(std::ostream& os, contact const& obj) {
         "  service_notifications_enabled:     "
      << obj.get_service_notifications_enabled()
      << "\n"
-        "  can_submit_commands:               "
-     << obj.get_can_submit_commands()
+        "  can_submit_commands:               " << obj.get_can_submit_commands()
      << "\n"
         "  retain_status_information:         "
      << obj.get_retain_status_information()
@@ -434,8 +405,7 @@ std::ostream& operator<<(std::ostream& os, contact const& obj) {
         "  last_service_notification:         "
      << string::ctime(obj.get_last_service_notification())
      << "\n"
-        "  modified_attributes:               "
-     << obj.get_modified_attributes()
+        "  modified_attributes:               " << obj.get_modified_attributes()
      << "\n"
         "  modified_host_attributes:          "
      << obj.get_modified_host_attributes()
@@ -443,14 +413,11 @@ std::ostream& operator<<(std::ostream& os, contact const& obj) {
         "  modified_service_attributes:       "
      << obj.get_modified_service_attributes()
      << "\n"
-        "  host_notification_period_ptr:      "
-     << hst_notif_str
+        "  host_notification_period_ptr:      " << hst_notif_str
      << "\n"
-        "  service_notification_period_ptr:   "
-     << svc_notif_str
+        "  service_notification_period_ptr:   " << svc_notif_str
      << "\n"
-        "  contactgroups_ptr:                 "
-     << cg_name
+        "  contactgroups_ptr:                 " << cg_name
      << "\n"
         "  customvariables:                   ";
   for (auto const& cv : obj.get_custom_variables())
@@ -538,8 +505,8 @@ std::shared_ptr<contact> add_contact(
   // Check if the contact already exist.
   std::string const& id(name);
   if (contact::contacts.count(id)) {
-    logger(log_config_error, basic)
-        << "Error: Contact '" << name << "' has already been defined";
+    logger(log_config_error, basic) << "Error: Contact '" << name
+                                    << "' has already been defined";
     return nullptr;
   }
 
@@ -596,11 +563,20 @@ std::shared_ptr<contact> add_contact(
 
     // Notify event broker.
     timeval tv(get_broker_timestamp(nullptr));
-    broker_adaptive_contact_data(NEBTYPE_CONTACT_ADD, NEBFLAG_NONE,
-                                 NEBATTR_NONE, obj.get(), CMD_NONE, MODATTR_ALL,
-                                 MODATTR_ALL, MODATTR_ALL, MODATTR_ALL,
-                                 MODATTR_ALL, MODATTR_ALL, &tv);
-  } catch (...) {
+    broker_adaptive_contact_data(NEBTYPE_CONTACT_ADD,
+                                 NEBFLAG_NONE,
+                                 NEBATTR_NONE,
+                                 obj.get(),
+                                 CMD_NONE,
+                                 MODATTR_ALL,
+                                 MODATTR_ALL,
+                                 MODATTR_ALL,
+                                 MODATTR_ALL,
+                                 MODATTR_ALL,
+                                 MODATTR_ALL,
+                                 &tv);
+  }
+  catch (...) {
     obj.reset();
   }
 
@@ -781,33 +757,37 @@ void contact::set_service_notifications_enabled(bool enabled) {
 void contact::update_status_info(bool aggregated_dump) {
   /* send data to event broker (non-aggregated dumps only) */
   if (!aggregated_dump)
-    broker_contact_status(NEBTYPE_CONTACTSTATUS_UPDATE, NEBFLAG_NONE,
-                          NEBATTR_NONE, this, nullptr);
+    broker_contact_status(NEBTYPE_CONTACTSTATUS_UPDATE,
+                          NEBFLAG_NONE,
+                          NEBATTR_NONE,
+                          this,
+                          nullptr);
 }
 
-std::list<std::shared_ptr<commands::command>> const&
+std::list<std::shared_ptr<commands::command> > const&
 contact::get_host_notification_commands() const {
   return _host_notification_commands;
 }
 
-std::list<std::shared_ptr<commands::command>>&
+std::list<std::shared_ptr<commands::command> >&
 contact::get_host_notification_commands() {
   return _host_notification_commands;
 }
 
-std::list<std::shared_ptr<commands::command>> const&
+std::list<std::shared_ptr<commands::command> > const&
 contact::get_service_notification_commands() const {
   return _service_notification_commands;
 }
 
-std::list<std::shared_ptr<commands::command>>&
+std::list<std::shared_ptr<commands::command> >&
 contact::get_service_notification_commands() {
   return _service_notification_commands;
 }
 
 std::ostream& operator<<(std::ostream& os, contact_map_unsafe const& obj) {
   for (contact_map_unsafe::const_iterator it{obj.begin()}, end{obj.end()};
-       it != end; ++it) {
+       it != end;
+       ++it) {
     os << it->first;
     if (next(it) != end)
       os << ", ";
@@ -821,9 +801,7 @@ contactgroup_map_unsafe const& contact::get_parent_groups() const {
   return _contactgroups;
 }
 
-contactgroup_map_unsafe& contact::get_parent_groups() {
-  return _contactgroups;
-}
+contactgroup_map_unsafe& contact::get_parent_groups() { return _contactgroups; }
 
 /**
  *  Returns a boolean telling if this contact should be notified by a notifier
@@ -917,8 +895,8 @@ bool contact::_to_notify_recovery(notifier::reason_type type
     return false;
   }
 
-  std::shared_ptr<notification> normal_notif =
-      notif.get_current_notifications()[notifier::cat_normal];
+  notification* normal_notif =
+      notif.get_current_notifications()[notifier::cat_normal].get();
   if (!normal_notif || !normal_notif->sent_to(get_name())) {
     logger(dbg_notifications, most)
         << "We shouldn't notify this contact about a "
@@ -958,9 +936,10 @@ bool contact::_to_notify_flapping(notifier::reason_type type,
     what_notif = notifier::flappingdisabled;
 
   if (!notify_on(nt, what_notif)) {
-    logger(dbg_notifications, most)
-        << "We shouldn't notify contact '" << _name << "' about "
-        << notifier::tab_notification_str[type] << " notifier events.";
+    logger(dbg_notifications, most) << "We shouldn't notify contact '" << _name
+                                    << "' about "
+                                    << notifier::tab_notification_str[type]
+                                    << " notifier events.";
     return false;
   }
   return true;
@@ -1139,9 +1118,8 @@ void contact::resolve(int& w, int& e) {
   /* check service notification timeperiod */
   if (get_service_notification_period().empty()) {
     logger(log_verification_error, basic)
-        << "Warning: Contact '" << _name
-        << "' has no service "
-           "notification time period defined!";
+        << "Warning: Contact '" << _name << "' has no service "
+                                            "notification time period defined!";
     warnings++;
     _service_notification_period_ptr = nullptr;
   } else {
@@ -1163,9 +1141,8 @@ void contact::resolve(int& w, int& e) {
   /* check host notification timeperiod */
   if (get_host_notification_period().empty()) {
     logger(log_verification_error, basic)
-        << "Warning: Contact '" << _name
-        << "' has no host "
-           "notification time period defined!";
+        << "Warning: Contact '" << _name << "' has no host "
+                                            "notification time period defined!";
     warnings++;
     _host_notification_period_ptr = nullptr;
   } else {
@@ -1201,9 +1178,8 @@ void contact::resolve(int& w, int& e) {
       !notify_on(notifier::service_notification, notifier::warning)) {
     logger(log_verification_error, basic)
         << "Warning: Service recovery notification option for contact '"
-        << _name
-        << "' doesn't make any sense - specify critical "
-           "and/or warning options as well";
+        << _name << "' doesn't make any sense - specify critical "
+                    "and/or warning options as well";
     warnings++;
   }
 
@@ -1242,6 +1218,4 @@ map_customvar const& contact::get_custom_variables() const {
   return _custom_variables;
 }
 
-map_customvar& contact::get_custom_variables() {
-  return _custom_variables;
-}
+map_customvar& contact::get_custom_variables() { return _custom_variables; }

--- a/src/contact.cc
+++ b/src/contact.cc
@@ -38,10 +38,14 @@ using namespace com::centreon::engine::string;
 
 contact_map contact::contacts;
 
-std::array<contact::to_notify, 6> const contact::_to_notify{
-    {&contact::_to_notify_normal,          &contact::_to_notify_recovery,
-     &contact::_to_notify_acknowledgement, &contact::_to_notify_flapping,
-     &contact::_to_notify_downtime,        &contact::_to_notify_custom, }};
+std::array<contact::to_notify, 6> const contact::_to_notify{{
+    &contact::_to_notify_normal,
+    &contact::_to_notify_recovery,
+    &contact::_to_notify_acknowledgement,
+    &contact::_to_notify_flapping,
+    &contact::_to_notify_downtime,
+    &contact::_to_notify_custom,
+}};
 
 /**************************************
  *                                     *
@@ -83,21 +87,27 @@ void contact::set_addresses(std::vector<std::string> const& addresses) {
  *
  *  @return a reference to the alias
  */
-std::string const& contact::get_alias() const { return _alias; }
+std::string const& contact::get_alias() const {
+  return _alias;
+}
 
 /**
  *  Set alias
  *
  *  @param[in] alias  New alias.
  */
-void contact::set_alias(std::string const& alias) { _alias = alias; }
+void contact::set_alias(std::string const& alias) {
+  _alias = alias;
+}
 
 /**
  *  Check if contact can submit commands.
  *
  *  @return True if contact can submit commands.
  */
-bool contact::get_can_submit_commands() const { return _can_submit_commands; }
+bool contact::get_can_submit_commands() const {
+  return _can_submit_commands;
+}
 
 /**
  *  (Dis)Allow a contact to submit commands.
@@ -113,14 +123,18 @@ void contact::set_can_submit_commands(bool can_submit) {
  *
  *  @return a reference to the email
  */
-std::string const& contact::get_email() const { return _email; }
+std::string const& contact::get_email() const {
+  return _email;
+}
 
 /**
  *  Set contact email.
  *
  *  @param[in] email  New email.
  */
-void contact::set_email(std::string const& email) { _email = email; }
+void contact::set_email(std::string const& email) {
+  _email = email;
+}
 
 /**
  *  Get the contact's modified attributes.
@@ -154,28 +168,36 @@ void contact::add_modified_attributes(uint32_t attr) {
  *
  *  @return A reference to the name.
  */
-std::string const& contact::get_name() const { return _name; }
+std::string const& contact::get_name() const {
+  return _name;
+}
 
 /**
  *  Set the contact name.
  *
  *  @param[in] name  New name.
  */
-void contact::set_name(std::string const& name) { _name = name; }
+void contact::set_name(std::string const& name) {
+  _name = name;
+}
 
 /**
  *  Return the contact pager
  *
  *  @return a reference to the pager
  */
-std::string const& contact::get_pager() const { return _pager; }
+std::string const& contact::get_pager() const {
+  return _pager;
+}
 
 /**
  *  Set the pager.
  *
  *  @param[in] pager  New pager.
  */
-void contact::set_pager(std::string const& pager) { _pager = pager; }
+void contact::set_pager(std::string const& pager) {
+  _pager = pager;
+}
 
 /**
  *  Check if status info should be retained.
@@ -218,7 +240,9 @@ void contact::set_retain_nonstatus_information(bool retain) {
  *
  *  @return Contact timezone.
  */
-std::string const& contact::get_timezone() const { return _timezone; }
+std::string const& contact::get_timezone() const {
+  return _timezone;
+}
 
 /**
  *  Set timezone.
@@ -310,13 +334,17 @@ std::ostream& operator<<(std::ostream& os, contact const& obj) {
     svc_notif_str = obj.get_service_notification_period_ptr()->get_name();
 
   os << "contact {\n"
-        "  name:                            " << obj.get_name()
+        "  name:                            "
+     << obj.get_name()
      << "\n"
-        "  alias:                           " << obj.get_alias()
+        "  alias:                           "
+     << obj.get_alias()
      << "\n"
-        "  email:                           " << obj.get_email()
+        "  email:                           "
+     << obj.get_email()
      << "\n"
-        "  pager:                           " << obj.get_pager()
+        "  pager:                           "
+     << obj.get_pager()
      << "\n"
         "  address:                         ";
   std::vector<std::string> const& address(obj.get_addresses());
@@ -391,7 +419,8 @@ std::ostream& operator<<(std::ostream& os, contact const& obj) {
         "  service_notifications_enabled:     "
      << obj.get_service_notifications_enabled()
      << "\n"
-        "  can_submit_commands:               " << obj.get_can_submit_commands()
+        "  can_submit_commands:               "
+     << obj.get_can_submit_commands()
      << "\n"
         "  retain_status_information:         "
      << obj.get_retain_status_information()
@@ -405,7 +434,8 @@ std::ostream& operator<<(std::ostream& os, contact const& obj) {
         "  last_service_notification:         "
      << string::ctime(obj.get_last_service_notification())
      << "\n"
-        "  modified_attributes:               " << obj.get_modified_attributes()
+        "  modified_attributes:               "
+     << obj.get_modified_attributes()
      << "\n"
         "  modified_host_attributes:          "
      << obj.get_modified_host_attributes()
@@ -413,11 +443,14 @@ std::ostream& operator<<(std::ostream& os, contact const& obj) {
         "  modified_service_attributes:       "
      << obj.get_modified_service_attributes()
      << "\n"
-        "  host_notification_period_ptr:      " << hst_notif_str
+        "  host_notification_period_ptr:      "
+     << hst_notif_str
      << "\n"
-        "  service_notification_period_ptr:   " << svc_notif_str
+        "  service_notification_period_ptr:   "
+     << svc_notif_str
      << "\n"
-        "  contactgroups_ptr:                 " << cg_name
+        "  contactgroups_ptr:                 "
+     << cg_name
      << "\n"
         "  customvariables:                   ";
   for (auto const& cv : obj.get_custom_variables())
@@ -505,8 +538,8 @@ std::shared_ptr<contact> add_contact(
   // Check if the contact already exist.
   std::string const& id(name);
   if (contact::contacts.count(id)) {
-    logger(log_config_error, basic) << "Error: Contact '" << name
-                                    << "' has already been defined";
+    logger(log_config_error, basic)
+        << "Error: Contact '" << name << "' has already been defined";
     return nullptr;
   }
 
@@ -563,20 +596,11 @@ std::shared_ptr<contact> add_contact(
 
     // Notify event broker.
     timeval tv(get_broker_timestamp(nullptr));
-    broker_adaptive_contact_data(NEBTYPE_CONTACT_ADD,
-                                 NEBFLAG_NONE,
-                                 NEBATTR_NONE,
-                                 obj.get(),
-                                 CMD_NONE,
-                                 MODATTR_ALL,
-                                 MODATTR_ALL,
-                                 MODATTR_ALL,
-                                 MODATTR_ALL,
-                                 MODATTR_ALL,
-                                 MODATTR_ALL,
-                                 &tv);
-  }
-  catch (...) {
+    broker_adaptive_contact_data(NEBTYPE_CONTACT_ADD, NEBFLAG_NONE,
+                                 NEBATTR_NONE, obj.get(), CMD_NONE, MODATTR_ALL,
+                                 MODATTR_ALL, MODATTR_ALL, MODATTR_ALL,
+                                 MODATTR_ALL, MODATTR_ALL, &tv);
+  } catch (...) {
     obj.reset();
   }
 
@@ -757,11 +781,8 @@ void contact::set_service_notifications_enabled(bool enabled) {
 void contact::update_status_info(bool aggregated_dump) {
   /* send data to event broker (non-aggregated dumps only) */
   if (!aggregated_dump)
-    broker_contact_status(NEBTYPE_CONTACTSTATUS_UPDATE,
-                          NEBFLAG_NONE,
-                          NEBATTR_NONE,
-                          this,
-                          nullptr);
+    broker_contact_status(NEBTYPE_CONTACTSTATUS_UPDATE, NEBFLAG_NONE,
+                          NEBATTR_NONE, this, nullptr);
 }
 
 std::list<std::shared_ptr<commands::command> > const&
@@ -786,8 +807,7 @@ contact::get_service_notification_commands() {
 
 std::ostream& operator<<(std::ostream& os, contact_map_unsafe const& obj) {
   for (contact_map_unsafe::const_iterator it{obj.begin()}, end{obj.end()};
-       it != end;
-       ++it) {
+       it != end; ++it) {
     os << it->first;
     if (next(it) != end)
       os << ", ";
@@ -801,7 +821,9 @@ contactgroup_map_unsafe const& contact::get_parent_groups() const {
   return _contactgroups;
 }
 
-contactgroup_map_unsafe& contact::get_parent_groups() { return _contactgroups; }
+contactgroup_map_unsafe& contact::get_parent_groups() {
+  return _contactgroups;
+}
 
 /**
  *  Returns a boolean telling if this contact should be notified by a notifier
@@ -936,10 +958,9 @@ bool contact::_to_notify_flapping(notifier::reason_type type,
     what_notif = notifier::flappingdisabled;
 
   if (!notify_on(nt, what_notif)) {
-    logger(dbg_notifications, most) << "We shouldn't notify contact '" << _name
-                                    << "' about "
-                                    << notifier::tab_notification_str[type]
-                                    << " notifier events.";
+    logger(dbg_notifications, most)
+        << "We shouldn't notify contact '" << _name << "' about "
+        << notifier::tab_notification_str[type] << " notifier events.";
     return false;
   }
   return true;
@@ -1118,8 +1139,9 @@ void contact::resolve(int& w, int& e) {
   /* check service notification timeperiod */
   if (get_service_notification_period().empty()) {
     logger(log_verification_error, basic)
-        << "Warning: Contact '" << _name << "' has no service "
-                                            "notification time period defined!";
+        << "Warning: Contact '" << _name
+        << "' has no service "
+           "notification time period defined!";
     warnings++;
     _service_notification_period_ptr = nullptr;
   } else {
@@ -1141,8 +1163,9 @@ void contact::resolve(int& w, int& e) {
   /* check host notification timeperiod */
   if (get_host_notification_period().empty()) {
     logger(log_verification_error, basic)
-        << "Warning: Contact '" << _name << "' has no host "
-                                            "notification time period defined!";
+        << "Warning: Contact '" << _name
+        << "' has no host "
+           "notification time period defined!";
     warnings++;
     _host_notification_period_ptr = nullptr;
   } else {
@@ -1178,8 +1201,9 @@ void contact::resolve(int& w, int& e) {
       !notify_on(notifier::service_notification, notifier::warning)) {
     logger(log_verification_error, basic)
         << "Warning: Service recovery notification option for contact '"
-        << _name << "' doesn't make any sense - specify critical "
-                    "and/or warning options as well";
+        << _name
+        << "' doesn't make any sense - specify critical "
+           "and/or warning options as well";
     warnings++;
   }
 
@@ -1218,4 +1242,6 @@ map_customvar const& contact::get_custom_variables() const {
   return _custom_variables;
 }
 
-map_customvar& contact::get_custom_variables() { return _custom_variables; }
+map_customvar& contact::get_custom_variables() {
+  return _custom_variables;
+}

--- a/src/downtimes/downtime_finder.cc
+++ b/src/downtimes/downtime_finder.cc
@@ -28,7 +28,7 @@ using namespace com::centreon::engine::downtimes;
 
 // Helper macro.
 #define ARE_STRINGS_MATCHING(stdstring, cstring) \
-  ((cstring && (cstring == stdstring)) || (!cstring && stdstring.empty()))
+  ((cstring&&(cstring == stdstring)) || (!cstring && stdstring.empty()))
 
 /**
  *  Constructor.
@@ -37,7 +37,7 @@ using namespace com::centreon::engine::downtimes;
  *                   on this list.
  */
 downtime_finder::downtime_finder(
-    std::multimap<time_t, std::shared_ptr<downtime>> const& map)
+    std::multimap<time_t, std::shared_ptr<downtime> > const& map)
     : _map(&map) {}
 
 /**
@@ -73,22 +73,27 @@ downtime_finder::result_set downtime_finder::find_matching_all(
     downtime_finder::criteria_set const& criterias) {
   result_set result;
   // Process all downtimes.
-  for (std::pair<time_t, std::shared_ptr<downtime>> const& dt : *_map) {
+  for (std::pair<time_t, std::shared_ptr<downtime> > const& dt : *_map) {
     // Process all criterias.
     bool matched_all{true};
     for (criteria_set::const_iterator it(criterias.begin()),
          end(criterias.end());
-         it != end; ++it) {
+         it != end;
+         ++it) {
       switch (dt.second->get_type()) {
         case downtime::host_downtime:
           if (!_match_criteria(
-                  *std::static_pointer_cast<host_downtime>(dt.second), *it))
+                   *std::static_pointer_cast<host_downtime>(dt.second), *it))
             matched_all = false;
           break;
         case downtime::service_downtime:
           if (!_match_criteria(
-                  *std::static_pointer_cast<service_downtime>(dt.second), *it))
+                   *std::static_pointer_cast<service_downtime>(dt.second), *it))
             matched_all = false;
+          break;
+        case downtime::any_downtime:
+          /* This case does not need to be handled here. A downtime concerns a
+           * host or a service. */
           break;
       }
     }

--- a/src/downtimes/downtime_finder.cc
+++ b/src/downtimes/downtime_finder.cc
@@ -28,7 +28,7 @@ using namespace com::centreon::engine::downtimes;
 
 // Helper macro.
 #define ARE_STRINGS_MATCHING(stdstring, cstring) \
-  ((cstring&&(cstring == stdstring)) || (!cstring && stdstring.empty()))
+  ((cstring && (cstring == stdstring)) || (!cstring && stdstring.empty()))
 
 /**
  *  Constructor.
@@ -78,17 +78,16 @@ downtime_finder::result_set downtime_finder::find_matching_all(
     bool matched_all{true};
     for (criteria_set::const_iterator it(criterias.begin()),
          end(criterias.end());
-         it != end;
-         ++it) {
+         it != end; ++it) {
       switch (dt.second->get_type()) {
         case downtime::host_downtime:
           if (!_match_criteria(
-                   *std::static_pointer_cast<host_downtime>(dt.second), *it))
+                  *std::static_pointer_cast<host_downtime>(dt.second), *it))
             matched_all = false;
           break;
         case downtime::service_downtime:
           if (!_match_criteria(
-                   *std::static_pointer_cast<service_downtime>(dt.second), *it))
+                  *std::static_pointer_cast<service_downtime>(dt.second), *it))
             matched_all = false;
           break;
         case downtime::any_downtime:

--- a/src/events/loop.cc
+++ b/src/events/loop.cc
@@ -113,8 +113,7 @@ static void apply_conf(std::atomic<bool>* reloading) {
     configuration::applier::state::instance().apply(config);
     logger(log_info_message, basic)
         << "Configuration reloaded, main loop continuing.";
-  }
-  catch (std::exception const& e) {
+  } catch (std::exception const& e) {
     logger(log_config_error, most) << "Error: " << e.what();
   }
   *reloading = false;
@@ -183,20 +182,20 @@ void loop::_dispatching() {
     // Log messages about event lists.
     logger(dbg_events, more) << "** Event Check Loop";
     if (!_event_list_high.empty())
-      logger(dbg_events, more) << "Next High Priority Event Time: "
-                               << my_ctime(
-                                      &(*_event_list_high.begin())->run_time);
+      logger(dbg_events, more)
+          << "Next High Priority Event Time: "
+          << my_ctime(&(*_event_list_high.begin())->run_time);
     else
       logger(dbg_events, more) << "No high priority events are scheduled...";
     if (!_event_list_low.empty())
-      logger(dbg_events, more) << "Next Low Priority Event Time:  "
-                               << my_ctime(
-                                      &(*_event_list_low.begin())->run_time);
+      logger(dbg_events, more)
+          << "Next Low Priority Event Time:  "
+          << my_ctime(&(*_event_list_low.begin())->run_time);
     else
       logger(dbg_events, more) << "No low priority events are scheduled...";
-    logger(dbg_events, more) << "Current/Max Service Checks: "
-                             << currently_running_service_checks << '/'
-                             << config->max_parallel_service_checks();
+    logger(dbg_events, more)
+        << "Current/Max Service Checks: " << currently_running_service_checks
+        << '/' << config->max_parallel_service_checks();
 
     // Update status information occassionally - NagVis watches the
     // NDOUtils DB to see if Engine is alive.
@@ -394,14 +393,9 @@ void loop::_dispatching() {
       // often as possible.
       if (config->command_check_interval() == -1) {
         // Send data to event broker.
-        broker_external_command(NEBTYPE_EXTERNALCOMMAND_CHECK,
-                                NEBFLAG_NONE,
-                                NEBATTR_NONE,
-                                CMD_NONE,
-                                time(nullptr),
-                                nullptr,
-                                nullptr,
-                                nullptr);
+        broker_external_command(NEBTYPE_EXTERNALCOMMAND_CHECK, NEBFLAG_NONE,
+                                NEBATTR_NONE, CMD_NONE, time(nullptr), nullptr,
+                                nullptr, nullptr);
       }
 
       auto t1 = std::chrono::system_clock::now();
@@ -421,11 +415,8 @@ void loop::_dispatching() {
       _sleep_event.event_data = (void*)&sleep_time;
 
       // Send event data to broker.
-      broker_timed_event(NEBTYPE_TIMEDEVENT_SLEEP,
-                         NEBFLAG_NONE,
-                         NEBATTR_NONE,
-                         &_sleep_event,
-                         nullptr);
+      broker_timed_event(NEBTYPE_TIMEDEVENT_SLEEP, NEBFLAG_NONE, NEBATTR_NONE,
+                         &_sleep_event, nullptr);
 
       std::this_thread::sleep_until(t2);
     }
@@ -467,8 +458,7 @@ void loop::adjust_check_scheduling() {
   // get current scheduling data.
   for (timed_event_list::iterator it{_event_list_low.begin()},
        end{_event_list_low.end()};
-       it != end;
-       ++it) {
+       it != end; ++it) {
     // skip events outside of our current window.
     if ((*it)->run_time <= first_window_time)
       continue;
@@ -546,8 +536,7 @@ void loop::adjust_check_scheduling() {
   double current_icd_offset(inter_check_delay / 2.0);
   for (timed_event_list::iterator it = _event_list_low.begin(),
                                   end = _event_list_low.end();
-       it != end;
-       ++it) {
+       it != end; ++it) {
     // skip events outside of our current window.
     if ((*it)->run_time <= first_window_time)
       continue;
@@ -617,16 +606,16 @@ void loop::compensate_for_system_time_change(unsigned long last_time,
   // we moved back in time...
   if (time_difference < 0) {
     get_time_breakdown(-time_difference, &days, &hours, &minutes, &seconds);
-    logger(dbg_events, basic) << "Detected a backwards time change of " << days
-                              << "d " << hours << "h " << minutes << "m "
-                              << seconds << "s.";
+    logger(dbg_events, basic)
+        << "Detected a backwards time change of " << days << "d " << hours
+        << "h " << minutes << "m " << seconds << "s.";
   }
   // we moved into the future...
   else {
     get_time_breakdown(time_difference, &days, &hours, &minutes, &seconds);
-    logger(dbg_events, basic) << "Detected a forwards time change of " << days
-                              << "d " << hours << "h " << minutes << "m "
-                              << seconds << "s.";
+    logger(dbg_events, basic)
+        << "Detected a forwards time change of " << days << "d " << hours
+        << "h " << minutes << "m " << seconds << "s.";
   }
 
   // log the time change.
@@ -638,8 +627,7 @@ void loop::compensate_for_system_time_change(unsigned long last_time,
 
   // adjust the next run time for all high priority timed events.
   for (auto it = _event_list_high.begin(), end = _event_list_high.end();
-       it != end;
-       ++it) {
+       it != end; ++it) {
     // skip special events that occur at specific times...
     if (!(*it)->compensate_for_time_change)
       continue;
@@ -665,8 +653,7 @@ void loop::compensate_for_system_time_change(unsigned long last_time,
 
   // adjust the next run time for all low priority timed events.
   for (auto it = _event_list_low.begin(), end = _event_list_low.end();
-       it != end;
-       ++it) {
+       it != end; ++it) {
     // skip special events that occur at specific times...
     if (!(*it)->compensate_for_time_change)
       continue;
@@ -693,8 +680,7 @@ void loop::compensate_for_system_time_change(unsigned long last_time,
   // adjust service timestamps.
   for (service_map::iterator it(service::services.begin()),
        end(service::services.end());
-       it != end;
-       ++it) {
+       it != end; ++it) {
     it->second->set_last_notification(adjust_timestamp_for_time_change(
         time_difference, it->second->get_last_notification()));
     it->second->set_last_check(adjust_timestamp_for_time_change(
@@ -722,8 +708,7 @@ void loop::compensate_for_system_time_change(unsigned long last_time,
   // adjust host timestamps.
   for (host_map::iterator it(com::centreon::engine::host::hosts.begin()),
        end(com::centreon::engine::host::hosts.end());
-       it != end;
-       ++it) {
+       it != end; ++it) {
     time_t last_host_notif{adjust_timestamp_for_time_change(
         time_difference, it->second->get_last_notification())};
     time_t last_check{adjust_timestamp_for_time_change(
@@ -795,8 +780,7 @@ void loop::add_event(timed_event* event, loop::priority priority) {
     // be executed in the future, rather than now...
     for (timed_event_list::reverse_iterator it(list->rbegin()),
          end(list->rend());
-         it != end;
-         ++it) {
+         it != end; ++it) {
       if (event->run_time >= (*it)->run_time) {
         list->insert(it.base(), event);
         break;
@@ -805,22 +789,21 @@ void loop::add_event(timed_event* event, loop::priority priority) {
   }
 
   // send event data to broker.
-  broker_timed_event(
-      NEBTYPE_TIMEDEVENT_ADD, NEBFLAG_NONE, NEBATTR_NONE, event, nullptr);
+  broker_timed_event(NEBTYPE_TIMEDEVENT_ADD, NEBFLAG_NONE, NEBATTR_NONE, event,
+                     nullptr);
 }
 
 void loop::remove_downtime(uint64_t downtime_id) {
   logger(dbg_functions, basic) << "loop::remove_downtime()";
 
   for (auto it = _event_list_high.begin(), end = _event_list_high.end();
-       it != end;
-       ++it) {
+       it != end; ++it) {
     if ((*it)->event_type != timed_event::EVENT_SCHEDULED_DOWNTIME)
       continue;
     if (((uint64_t)(*it)->event_data) == downtime_id) {
       // send event data to broker.
-      broker_timed_event(
-          NEBTYPE_TIMEDEVENT_REMOVE, NEBFLAG_NONE, NEBATTR_NONE, *it, nullptr);
+      broker_timed_event(NEBTYPE_TIMEDEVENT_REMOVE, NEBFLAG_NONE, NEBATTR_NONE,
+                         *it, nullptr);
       _event_list_high.erase(it);
       break;
     }
@@ -838,8 +821,8 @@ void loop::remove_event(timed_event* event, loop::priority priority) {
   logger(dbg_functions, basic) << "loop::remove_event()";
 
   // send event data to broker.
-  broker_timed_event(
-      NEBTYPE_TIMEDEVENT_REMOVE, NEBFLAG_NONE, NEBATTR_NONE, event, NULL);
+  broker_timed_event(NEBTYPE_TIMEDEVENT_REMOVE, NEBFLAG_NONE, NEBATTR_NONE,
+                     event, NULL);
 
   if (!event)
     return;
@@ -948,16 +931,15 @@ void loop::resort_event_list(loop::priority priority) {
   else
     list = &_event_list_high;
 
-  std::sort(list->begin(),
-            list->end(),
+  std::sort(list->begin(), list->end(),
             [](timed_event* const& first, timed_event* const& second) {
-    return first->run_time < second->run_time;
-  });
+              return first->run_time < second->run_time;
+            });
 
   // send event data to broker.
   for (auto& evt : *list)
-    broker_timed_event(
-        NEBTYPE_TIMEDEVENT_ADD, NEBFLAG_NONE, NEBATTR_NONE, evt, nullptr);
+    broker_timed_event(NEBTYPE_TIMEDEVENT_ADD, NEBFLAG_NONE, NEBATTR_NONE, evt,
+                       nullptr);
 }
 
 /**

--- a/src/events/loop.cc
+++ b/src/events/loop.cc
@@ -52,10 +52,14 @@ loop& loop::instance() {
 }
 
 void loop::clear() {
-  for (timed_event* ev : _event_list_low)
+  for (timed_event* ev : _event_list_low) {
     delete ev;
-  for (timed_event* ev : _event_list_high)
+    ev = nullptr;
+  }
+  for (timed_event* ev : _event_list_high) {
     delete ev;
+    ev = nullptr;
+  }
   _event_list_low.clear();
   _event_list_high.clear();
 
@@ -89,6 +93,7 @@ void loop::run() {
   _sleep_event.event_options = 0;
 
   _dispatching();
+  clear();
 }
 
 /**
@@ -108,7 +113,8 @@ static void apply_conf(std::atomic<bool>* reloading) {
     configuration::applier::state::instance().apply(config);
     logger(log_info_message, basic)
         << "Configuration reloaded, main loop continuing.";
-  } catch (std::exception const& e) {
+  }
+  catch (std::exception const& e) {
     logger(log_config_error, most) << "Error: " << e.what();
   }
   *reloading = false;
@@ -177,20 +183,20 @@ void loop::_dispatching() {
     // Log messages about event lists.
     logger(dbg_events, more) << "** Event Check Loop";
     if (!_event_list_high.empty())
-      logger(dbg_events, more)
-          << "Next High Priority Event Time: "
-          << my_ctime(&(*_event_list_high.begin())->run_time);
+      logger(dbg_events, more) << "Next High Priority Event Time: "
+                               << my_ctime(
+                                      &(*_event_list_high.begin())->run_time);
     else
       logger(dbg_events, more) << "No high priority events are scheduled...";
     if (!_event_list_low.empty())
-      logger(dbg_events, more)
-          << "Next Low Priority Event Time:  "
-          << my_ctime(&(*_event_list_low.begin())->run_time);
+      logger(dbg_events, more) << "Next Low Priority Event Time:  "
+                               << my_ctime(
+                                      &(*_event_list_low.begin())->run_time);
     else
       logger(dbg_events, more) << "No low priority events are scheduled...";
-    logger(dbg_events, more)
-        << "Current/Max Service Checks: " << currently_running_service_checks
-        << '/' << config->max_parallel_service_checks();
+    logger(dbg_events, more) << "Current/Max Service Checks: "
+                             << currently_running_service_checks << '/'
+                             << config->max_parallel_service_checks();
 
     // Update status information occassionally - NagVis watches the
     // NDOUtils DB to see if Engine is alive.
@@ -388,9 +394,14 @@ void loop::_dispatching() {
       // often as possible.
       if (config->command_check_interval() == -1) {
         // Send data to event broker.
-        broker_external_command(NEBTYPE_EXTERNALCOMMAND_CHECK, NEBFLAG_NONE,
-                                NEBATTR_NONE, CMD_NONE, time(nullptr), nullptr,
-                                nullptr, nullptr);
+        broker_external_command(NEBTYPE_EXTERNALCOMMAND_CHECK,
+                                NEBFLAG_NONE,
+                                NEBATTR_NONE,
+                                CMD_NONE,
+                                time(nullptr),
+                                nullptr,
+                                nullptr,
+                                nullptr);
       }
 
       auto t1 = std::chrono::system_clock::now();
@@ -410,8 +421,11 @@ void loop::_dispatching() {
       _sleep_event.event_data = (void*)&sleep_time;
 
       // Send event data to broker.
-      broker_timed_event(NEBTYPE_TIMEDEVENT_SLEEP, NEBFLAG_NONE, NEBATTR_NONE,
-                         &_sleep_event, nullptr);
+      broker_timed_event(NEBTYPE_TIMEDEVENT_SLEEP,
+                         NEBFLAG_NONE,
+                         NEBATTR_NONE,
+                         &_sleep_event,
+                         nullptr);
 
       std::this_thread::sleep_until(t2);
     }
@@ -453,7 +467,8 @@ void loop::adjust_check_scheduling() {
   // get current scheduling data.
   for (timed_event_list::iterator it{_event_list_low.begin()},
        end{_event_list_low.end()};
-       it != end; ++it) {
+       it != end;
+       ++it) {
     // skip events outside of our current window.
     if ((*it)->run_time <= first_window_time)
       continue;
@@ -520,11 +535,19 @@ void loop::adjust_check_scheduling() {
     exec_time_factor = 1.0;
   }
 
+  auto compute_new_run_time = [](double current_exec_time_offset,
+                                 double current_icd_offset,
+                                 time_t first_window_time) {
+    double offset = current_exec_time_offset + current_icd_offset;
+    time_t retval = first_window_time + static_cast<unsigned long>(offset);
+    return retval;
+  };
   // adjust check scheduling.
   double current_icd_offset(inter_check_delay / 2.0);
   for (timed_event_list::iterator it = _event_list_low.begin(),
                                   end = _event_list_low.end();
-       it != end; ++it) {
+       it != end;
+       ++it) {
     // skip events outside of our current window.
     if ((*it)->run_time <= first_window_time)
       continue;
@@ -540,8 +563,13 @@ void loop::adjust_check_scheduling() {
         continue;
 
       current_exec_time =
-          ((hst->get_execution_time() + projected_host_check_overhead) *
-           exec_time_factor);
+          (hst->get_execution_time() + projected_host_check_overhead) *
+          exec_time_factor;
+      time_t new_run_time = compute_new_run_time(
+          current_exec_time_offset, current_icd_offset, first_window_time);
+      (*it)->run_time = new_run_time;
+      hst->set_next_check(new_run_time);
+      hst->update_status();
     } else if ((*it)->event_type == timed_event::EVENT_SERVICE_CHECK) {
       if (!(svc = (com::centreon::engine::service*)(*it)->event_data))
         continue;
@@ -552,23 +580,14 @@ void loop::adjust_check_scheduling() {
 
       // NOTE: service check execution time is not taken into
       // account, as service checks are run in parallel.
-      current_exec_time = (projected_service_check_overhead * exec_time_factor);
-    } else
-      continue;
-
-    double new_run_time_offset(current_exec_time_offset + current_icd_offset);
-    time_t new_run_time(
-        (time_t)(first_window_time + (unsigned long)new_run_time_offset));
-
-    if ((*it)->event_type == timed_event::EVENT_HOST_CHECK) {
-      (*it)->run_time = new_run_time;
-      hst->set_next_check(new_run_time);
-      hst->update_status();
-    } else {
+      current_exec_time = projected_service_check_overhead * exec_time_factor;
+      time_t new_run_time = compute_new_run_time(
+          current_exec_time_offset, current_icd_offset, first_window_time);
       (*it)->run_time = new_run_time;
       svc->set_next_check(new_run_time);
       svc->update_status();
-    }
+    } else
+      continue;
 
     current_icd_offset += inter_check_delay;
     current_exec_time_offset += current_exec_time;
@@ -598,16 +617,16 @@ void loop::compensate_for_system_time_change(unsigned long last_time,
   // we moved back in time...
   if (time_difference < 0) {
     get_time_breakdown(-time_difference, &days, &hours, &minutes, &seconds);
-    logger(dbg_events, basic)
-        << "Detected a backwards time change of " << days << "d " << hours
-        << "h " << minutes << "m " << seconds << "s.";
+    logger(dbg_events, basic) << "Detected a backwards time change of " << days
+                              << "d " << hours << "h " << minutes << "m "
+                              << seconds << "s.";
   }
   // we moved into the future...
   else {
     get_time_breakdown(time_difference, &days, &hours, &minutes, &seconds);
-    logger(dbg_events, basic)
-        << "Detected a forwards time change of " << days << "d " << hours
-        << "h " << minutes << "m " << seconds << "s.";
+    logger(dbg_events, basic) << "Detected a forwards time change of " << days
+                              << "d " << hours << "h " << minutes << "m "
+                              << seconds << "s.";
   }
 
   // log the time change.
@@ -619,7 +638,8 @@ void loop::compensate_for_system_time_change(unsigned long last_time,
 
   // adjust the next run time for all high priority timed events.
   for (auto it = _event_list_high.begin(), end = _event_list_high.end();
-       it != end; ++it) {
+       it != end;
+       ++it) {
     // skip special events that occur at specific times...
     if (!(*it)->compensate_for_time_change)
       continue;
@@ -645,7 +665,8 @@ void loop::compensate_for_system_time_change(unsigned long last_time,
 
   // adjust the next run time for all low priority timed events.
   for (auto it = _event_list_low.begin(), end = _event_list_low.end();
-       it != end; ++it) {
+       it != end;
+       ++it) {
     // skip special events that occur at specific times...
     if (!(*it)->compensate_for_time_change)
       continue;
@@ -672,7 +693,8 @@ void loop::compensate_for_system_time_change(unsigned long last_time,
   // adjust service timestamps.
   for (service_map::iterator it(service::services.begin()),
        end(service::services.end());
-       it != end; ++it) {
+       it != end;
+       ++it) {
     it->second->set_last_notification(adjust_timestamp_for_time_change(
         time_difference, it->second->get_last_notification()));
     it->second->set_last_check(adjust_timestamp_for_time_change(
@@ -700,7 +722,8 @@ void loop::compensate_for_system_time_change(unsigned long last_time,
   // adjust host timestamps.
   for (host_map::iterator it(com::centreon::engine::host::hosts.begin()),
        end(com::centreon::engine::host::hosts.end());
-       it != end; ++it) {
+       it != end;
+       ++it) {
     time_t last_host_notif{adjust_timestamp_for_time_change(
         time_difference, it->second->get_last_notification())};
     time_t last_check{adjust_timestamp_for_time_change(
@@ -772,7 +795,8 @@ void loop::add_event(timed_event* event, loop::priority priority) {
     // be executed in the future, rather than now...
     for (timed_event_list::reverse_iterator it(list->rbegin()),
          end(list->rend());
-         it != end; ++it) {
+         it != end;
+         ++it) {
       if (event->run_time >= (*it)->run_time) {
         list->insert(it.base(), event);
         break;
@@ -781,21 +805,22 @@ void loop::add_event(timed_event* event, loop::priority priority) {
   }
 
   // send event data to broker.
-  broker_timed_event(NEBTYPE_TIMEDEVENT_ADD, NEBFLAG_NONE, NEBATTR_NONE, event,
-                     nullptr);
+  broker_timed_event(
+      NEBTYPE_TIMEDEVENT_ADD, NEBFLAG_NONE, NEBATTR_NONE, event, nullptr);
 }
 
 void loop::remove_downtime(uint64_t downtime_id) {
   logger(dbg_functions, basic) << "loop::remove_downtime()";
 
   for (auto it = _event_list_high.begin(), end = _event_list_high.end();
-       it != end; ++it) {
+       it != end;
+       ++it) {
     if ((*it)->event_type != timed_event::EVENT_SCHEDULED_DOWNTIME)
       continue;
     if (((uint64_t)(*it)->event_data) == downtime_id) {
       // send event data to broker.
-      broker_timed_event(NEBTYPE_TIMEDEVENT_REMOVE, NEBFLAG_NONE, NEBATTR_NONE,
-                         *it, nullptr);
+      broker_timed_event(
+          NEBTYPE_TIMEDEVENT_REMOVE, NEBFLAG_NONE, NEBATTR_NONE, *it, nullptr);
       _event_list_high.erase(it);
       break;
     }
@@ -813,8 +838,8 @@ void loop::remove_event(timed_event* event, loop::priority priority) {
   logger(dbg_functions, basic) << "loop::remove_event()";
 
   // send event data to broker.
-  broker_timed_event(NEBTYPE_TIMEDEVENT_REMOVE, NEBFLAG_NONE, NEBATTR_NONE,
-                     event, NULL);
+  broker_timed_event(
+      NEBTYPE_TIMEDEVENT_REMOVE, NEBFLAG_NONE, NEBATTR_NONE, event, NULL);
 
   if (!event)
     return;
@@ -923,15 +948,16 @@ void loop::resort_event_list(loop::priority priority) {
   else
     list = &_event_list_high;
 
-  std::sort(list->begin(), list->end(),
+  std::sort(list->begin(),
+            list->end(),
             [](timed_event* const& first, timed_event* const& second) {
-              return first->run_time < second->run_time;
-            });
+    return first->run_time < second->run_time;
+  });
 
   // send event data to broker.
   for (auto& evt : *list)
-    broker_timed_event(NEBTYPE_TIMEDEVENT_ADD, NEBFLAG_NONE, NEBATTR_NONE, evt,
-                       nullptr);
+    broker_timed_event(
+        NEBTYPE_TIMEDEVENT_ADD, NEBFLAG_NONE, NEBATTR_NONE, evt, nullptr);
 }
 
 /**

--- a/src/host.cc
+++ b/src/host.cc
@@ -445,6 +445,7 @@ time_t host::get_last_time_down() const {
 }
 
 void host::set_last_time_down(time_t last_time) {
+  assert(last_time < 2000000000);
   _last_time_down = last_time;
 }
 
@@ -453,6 +454,7 @@ time_t host::get_last_time_unreachable() const {
 }
 
 void host::set_last_time_unreachable(time_t last_time) {
+  assert(last_time < 2000000000);
   _last_time_unreachable = last_time;
 }
 
@@ -461,6 +463,7 @@ time_t host::get_last_time_up() const {
 }
 
 void host::set_last_time_up(time_t last_time) {
+  assert(last_time < 2000000000);
   _last_time_up = last_time;
 }
 

--- a/src/host.cc
+++ b/src/host.cc
@@ -53,7 +53,8 @@ using namespace com::centreon::engine::logging;
 using namespace com::centreon::engine::string;
 
 std::array<std::pair<uint32_t, std::string>, 3> const host::tab_host_states{
-    {{NSLOG_HOST_UP, "UP"}, {NSLOG_HOST_DOWN, "DOWN"},
+    {{NSLOG_HOST_UP, "UP"},
+     {NSLOG_HOST_DOWN, "DOWN"},
      {NSLOG_HOST_UNREACHABLE, "UNREACHABLE"}}};
 
 host_map host::hosts;
@@ -190,9 +191,14 @@ host::host(uint64_t host_id,
            bool retain_nonstatus_information,
            bool obsess_over_host,
            std::string const& timezone)
-    : notifier{host_notification, !display_name.empty() ? display_name : name,
-               check_command, checks_enabled, accept_passive_checks,
-               check_interval, retry_interval, notification_interval,
+    : notifier{host_notification,
+               !display_name.empty() ? display_name : name,
+               check_command,
+               checks_enabled,
+               accept_passive_checks,
+               check_interval,
+               retry_interval,
+               notification_interval,
                max_attempts,
                (notify_up > 0 ? up : 0) | (notify_down > 0 ? down : 0) |
                    (notify_downtime > 0 ? downtime : 0) |
@@ -203,13 +209,27 @@ host::host(uint64_t host_id,
                (stalk_on_down > 0 ? down : 0) |
                    (stalk_on_unreachable > 0 ? unreachable : 0) |
                    (stalk_on_up > 0 ? up : 0),
-               first_notification_delay, recovery_notification_delay,
-               notification_period, notifications_enabled, check_period,
-               event_handler, event_handler_enabled, notes, notes_url,
-               action_url, icon_image, icon_image_alt, flap_detection_enabled,
-               low_flap_threshold, high_flap_threshold, check_freshness,
-               freshness_threshold, obsess_over_host, timezone,
-               retain_status_information > 0, retain_nonstatus_information > 0,
+               first_notification_delay,
+               recovery_notification_delay,
+               notification_period,
+               notifications_enabled,
+               check_period,
+               event_handler,
+               event_handler_enabled,
+               notes,
+               notes_url,
+               action_url,
+               icon_image,
+               icon_image_alt,
+               flap_detection_enabled,
+               low_flap_threshold,
+               high_flap_threshold,
+               check_freshness,
+               freshness_threshold,
+               obsess_over_host,
+               timezone,
+               retain_status_information > 0,
+               retain_nonstatus_information > 0,
                false},
       _id{host_id},
       _name{name},
@@ -252,8 +272,8 @@ host::host(uint64_t host_id,
   // Check if the host already exists.
   uint64_t id{host_id};
   if (is_host_exist(id)) {
-    logger(log_config_error, basic) << "Error: Host '" << name
-                                    << "' has already been defined";
+    logger(log_config_error, basic)
+        << "Error: Host '" << name << "' has already been defined";
     throw engine_error() << "Could not register host '" << name << "'";
   }
 
@@ -269,9 +289,13 @@ host::host(uint64_t host_id,
                 (flap_detection_on_up > 0 ? up : 0));
 }
 
-uint64_t host::get_host_id(void) const { return _id; }
+uint64_t host::get_host_id(void) const {
+  return _id;
+}
 
-void host::set_host_id(uint64_t id) { _id = id; }
+void host::set_host_id(uint64_t id) {
+  _id = id;
+}
 
 void host::add_child_host(host* child) {
   // Make sure we have the data we need.
@@ -282,14 +306,8 @@ void host::add_child_host(host* child) {
 
   // Notify event broker.
   timeval tv(get_broker_timestamp(nullptr));
-  broker_relation_data(NEBTYPE_PARENT_ADD,
-                       NEBFLAG_NONE,
-                       NEBATTR_NONE,
-                       this,
-                       nullptr,
-                       child,
-                       nullptr,
-                       &tv);
+  broker_relation_data(NEBTYPE_PARENT_ADD, NEBFLAG_NONE, NEBATTR_NONE, this,
+                       nullptr, child, nullptr, &tv);
 }
 
 void host::add_parent_host(std::string const& host_name) {
@@ -302,25 +320,37 @@ void host::add_parent_host(std::string const& host_name) {
 
   // A host cannot be a parent/child of itself.
   if (_name == host_name) {
-    logger(log_config_error, basic) << "Error: Host '" << _name
-                                    << "' cannot be a child/parent of itself";
+    logger(log_config_error, basic)
+        << "Error: Host '" << _name << "' cannot be a child/parent of itself";
     throw engine_error() << "host is child/parent itself";
   }
 
   parent_hosts.insert({host_name, nullptr});
 }
 
-std::string const& host::get_name() const { return _name; }
+std::string const& host::get_name() const {
+  return _name;
+}
 
-void host::set_name(std::string const& name) { _name = name; }
+void host::set_name(std::string const& name) {
+  _name = name;
+}
 
-std::string const& host::get_alias() const { return _alias; }
+std::string const& host::get_alias() const {
+  return _alias;
+}
 
-void host::set_alias(std::string const& alias) { _alias = alias; }
+void host::set_alias(std::string const& alias) {
+  _alias = alias;
+}
 
-std::string const& host::get_address() const { return _address; }
+std::string const& host::get_address() const {
+  return _address;
+}
 
-void host::set_address(std::string const& address) { _address = address; }
+void host::set_address(std::string const& address) {
+  _address = address;
+}
 
 bool host::get_process_performance_data() const {
   return _process_performance_data;
@@ -330,9 +360,13 @@ void host::set_process_performance_data(bool process_performance_data) {
   _process_performance_data = process_performance_data;
 }
 
-std::string const& host::get_vrml_image() const { return _vrml_image; }
+std::string const& host::get_vrml_image() const {
+  return _vrml_image;
+}
 
-void host::set_vrml_image(std::string const& image) { _vrml_image = image; }
+void host::set_vrml_image(std::string const& image) {
+  _vrml_image = image;
+}
 
 std::string const& host::get_statusmap_image() const {
   return _statusmap_image;
@@ -342,43 +376,77 @@ void host::set_statusmap_image(std::string const& image) {
   _statusmap_image = image;
 }
 
-bool host::get_have_2d_coords() const { return _have_2d_coords; }
+bool host::get_have_2d_coords() const {
+  return _have_2d_coords;
+}
 
-void host::set_have_2d_coords(bool has_coords) { _have_2d_coords = has_coords; }
+void host::set_have_2d_coords(bool has_coords) {
+  _have_2d_coords = has_coords;
+}
 
-bool host::get_have_3d_coords() const { return _have_3d_coords; }
+bool host::get_have_3d_coords() const {
+  return _have_3d_coords;
+}
 
-void host::set_have_3d_coords(bool has_coords) { _have_3d_coords = has_coords; }
+void host::set_have_3d_coords(bool has_coords) {
+  _have_3d_coords = has_coords;
+}
 
-double host::get_x_2d() const { return _x_2d; }
+double host::get_x_2d() const {
+  return _x_2d;
+}
 
-void host::set_x_2d(double x) { _x_2d = x; }
+void host::set_x_2d(double x) {
+  _x_2d = x;
+}
 
-double host::get_y_2d() const { return _y_2d; }
+double host::get_y_2d() const {
+  return _y_2d;
+}
 
-void host::set_y_2d(double y) { _y_2d = y; }
+void host::set_y_2d(double y) {
+  _y_2d = y;
+}
 
-double host::get_x_3d() const { return _x_3d; }
+double host::get_x_3d() const {
+  return _x_3d;
+}
 
-void host::set_x_3d(double x) { _x_3d = x; }
+void host::set_x_3d(double x) {
+  _x_3d = x;
+}
 
-double host::get_y_3d() const { return _y_3d; }
+double host::get_y_3d() const {
+  return _y_3d;
+}
 
-void host::set_y_3d(double y) { _y_3d = y; }
+void host::set_y_3d(double y) {
+  _y_3d = y;
+}
 
-double host::get_z_3d() const { return _z_3d; }
+double host::get_z_3d() const {
+  return _z_3d;
+}
 
-void host::set_z_3d(double z) { _z_3d = z; }
+void host::set_z_3d(double z) {
+  _z_3d = z;
+}
 
-int host::get_should_be_drawn() const { return _should_be_drawn; }
+int host::get_should_be_drawn() const {
+  return _should_be_drawn;
+}
 
 void host::set_should_be_drawn(int should_be_drawn) {
   _should_be_drawn = should_be_drawn;
 }
 
-time_t host::get_last_time_down() const { return _last_time_down; }
+time_t host::get_last_time_down() const {
+  return _last_time_down;
+}
 
-void host::set_last_time_down(time_t last_time) { _last_time_down = last_time; }
+void host::set_last_time_down(time_t last_time) {
+  _last_time_down = last_time;
+}
 
 time_t host::get_last_time_unreachable() const {
   return _last_time_unreachable;
@@ -388,9 +456,13 @@ void host::set_last_time_unreachable(time_t last_time) {
   _last_time_unreachable = last_time;
 }
 
-time_t host::get_last_time_up() const { return _last_time_up; }
+time_t host::get_last_time_up() const {
+  return _last_time_up;
+}
 
-void host::set_last_time_up(time_t last_time) { _last_time_up = last_time; }
+void host::set_last_time_up(time_t last_time) {
+  _last_time_up = last_time;
+}
 
 bool host::get_should_reschedule_current_check() const {
   return _should_reschedule_current_check;
@@ -408,7 +480,9 @@ void host::set_last_state_history_update(time_t last_state_history_update) {
   _last_state_history_update = last_state_history_update;
 }
 
-int host::get_total_services() const { return _total_services; }
+int host::get_total_services() const {
+  return _total_services;
+}
 
 void host::set_total_services(int total_services) {
   _total_services = total_services;
@@ -423,7 +497,9 @@ void host::set_total_service_check_interval(
   _total_service_check_interval = total_service_check_interval;
 }
 
-int host::get_circular_path_checked() const { return _circular_path_checked; }
+int host::get_circular_path_checked() const {
+  return _circular_path_checked;
+}
 
 void host::set_circular_path_checked(int check_level) {
   _circular_path_checked = check_level;
@@ -437,13 +513,17 @@ void host::set_contains_circular_path(bool contains_circular_path) {
   _contains_circular_path = contains_circular_path;
 }
 
-enum host::host_state host::get_current_state() const { return _current_state; }
+enum host::host_state host::get_current_state() const {
+  return _current_state;
+}
 
 void host::set_current_state(enum host::host_state current_state) {
   _current_state = current_state;
 }
 
-enum host::host_state host::get_last_state() const { return _last_state; }
+enum host::host_state host::get_last_state() const {
+  return _last_state;
+}
 
 void host::set_last_state(enum host::host_state last_state) {
   _last_state = last_state;
@@ -457,13 +537,17 @@ void host::set_last_hard_state(enum host::host_state last_hard_state) {
   _last_hard_state = last_hard_state;
 }
 
-enum host::host_state host::get_initial_state() const { return _initial_state; }
+enum host::host_state host::get_initial_state() const {
+  return _initial_state;
+}
 
 void host::set_initial_state(enum host::host_state current_state) {
   _initial_state = current_state;
 }
 
-bool host::recovered() const { return _current_state == host::state_up; }
+bool host::recovered() const {
+  return _current_state == host::state_up;
+}
 
 int host::get_current_state_int() const {
   return static_cast<int>(_current_state);
@@ -471,8 +555,7 @@ int host::get_current_state_int() const {
 
 std::ostream& operator<<(std::ostream& os, host_map_unsafe const& obj) {
   for (host_map_unsafe::const_iterator it{obj.begin()}, end{obj.end()};
-       it != end;
-       ++it) {
+       it != end; ++it) {
     os << it->first;
     if (next(it) != end)
       os << ", ";
@@ -554,35 +637,50 @@ std::ostream& operator<<(std::ostream& os, host const& obj) {
   }
 
   os << "host {\n"
-        "  name:                                 " << obj.get_name()
+        "  name:                                 "
+     << obj.get_name()
      << "\n"
-        "  display_name:                         " << obj.get_display_name()
+        "  display_name:                         "
+     << obj.get_display_name()
      << "\n"
-        "  alias:                                " << obj.get_alias()
+        "  alias:                                "
+     << obj.get_alias()
      << "\n"
-        "  address:                              " << obj.get_address()
+        "  address:                              "
+     << obj.get_address()
      << "\n"
-        "  parent_hosts:                         " << p_oss
+        "  parent_hosts:                         "
+     << p_oss
      << "\n"
-        "  child_hosts:                          " << child_oss
+        "  child_hosts:                          "
+     << child_oss
      << "\n"
-        "  services:                             " << obj.services
+        "  services:                             "
+     << obj.services
      << "\n"
-        "  host_check_command:                   " << obj.get_check_command()
+        "  host_check_command:                   "
+     << obj.get_check_command()
      << "\n"
-        "  initial_state:                        " << obj.get_initial_state()
+        "  initial_state:                        "
+     << obj.get_initial_state()
      << "\n"
-        "  check_interval:                       " << obj.get_check_interval()
+        "  check_interval:                       "
+     << obj.get_check_interval()
      << "\n"
-        "  retry_interval:                       " << obj.get_retry_interval()
+        "  retry_interval:                       "
+     << obj.get_retry_interval()
      << "\n"
-        "  max_attempts:                         " << obj.get_max_attempts()
+        "  max_attempts:                         "
+     << obj.get_max_attempts()
      << "\n"
-        "  event_handler:                        " << obj.get_event_handler()
+        "  event_handler:                        "
+     << obj.get_event_handler()
      << "\n"
-        "  contact_groups:                       " << cg_oss
+        "  contact_groups:                       "
+     << cg_oss
      << "\n"
-        "  contacts:                             " << c_oss
+        "  contacts:                             "
+     << c_oss
      << "\n"
         "  notification_interval:                "
      << obj.get_notification_interval()
@@ -615,7 +713,8 @@ std::ostream& operator<<(std::ostream& os, host const& obj) {
      << obj.get_notify_on(notifier::downtime)
      << "\n"
         "  notification_period:                  "
-     << obj.get_notification_period() << "\n" << notifications
+     << obj.get_notification_period() << "\n"
+     << notifications
      << "  check_period:                         " << obj.get_check_period()
      << "\n"
         "  flap_detection_enabled:               "
@@ -645,7 +744,8 @@ std::ostream& operator<<(std::ostream& os, host const& obj) {
         "  stalk_on_unreachable:                 "
      << obj.get_stalk_on(notifier::unreachable)
      << "\n"
-        "  check_freshness:                      " << obj.get_check_freshness()
+        "  check_freshness:                      "
+     << obj.get_check_freshness()
      << "\n"
         "  freshness_threshold:                  "
      << obj.get_freshness_threshold()
@@ -653,7 +753,8 @@ std::ostream& operator<<(std::ostream& os, host const& obj) {
         "  process_performance_data:             "
      << obj.get_process_performance_data()
      << "\n"
-        "  checks_enabled:                       " << obj.get_checks_enabled()
+        "  checks_enabled:                       "
+     << obj.get_checks_enabled()
      << "\n"
         "  accept_passive_checks:                "
      << obj.get_accept_passive_checks()
@@ -667,37 +768,53 @@ std::ostream& operator<<(std::ostream& os, host const& obj) {
         "  retain_nonstatus_information:         "
      << obj.get_retain_nonstatus_information()
      << "\n"
-        "  obsess_over_host:                     " << obj.get_obsess_over()
+        "  obsess_over_host:                     "
+     << obj.get_obsess_over()
      << "\n"
-        "  notes:                                " << obj.get_notes()
+        "  notes:                                "
+     << obj.get_notes()
      << "\n"
-        "  notes_url:                            " << obj.get_notes_url()
+        "  notes_url:                            "
+     << obj.get_notes_url()
      << "\n"
-        "  action_url:                           " << obj.get_action_url()
+        "  action_url:                           "
+     << obj.get_action_url()
      << "\n"
-        "  icon_image:                           " << obj.get_icon_image()
+        "  icon_image:                           "
+     << obj.get_icon_image()
      << "\n"
-        "  icon_image_alt:                       " << obj.get_icon_image_alt()
+        "  icon_image_alt:                       "
+     << obj.get_icon_image_alt()
      << "\n"
-        "  vrml_image:                           " << obj.get_vrml_image()
+        "  vrml_image:                           "
+     << obj.get_vrml_image()
      << "\n"
-        "  statusmap_image:                      " << obj.get_statusmap_image()
+        "  statusmap_image:                      "
+     << obj.get_statusmap_image()
      << "\n"
-        "  have_2d_coords:                       " << obj.get_have_2d_coords()
+        "  have_2d_coords:                       "
+     << obj.get_have_2d_coords()
      << "\n"
-        "  x_2d:                                 " << obj.get_x_2d()
+        "  x_2d:                                 "
+     << obj.get_x_2d()
      << "\n"
-        "  y_2d:                                 " << obj.get_y_2d()
+        "  y_2d:                                 "
+     << obj.get_y_2d()
      << "\n"
-        "  have_3d_coords:                       " << obj.get_have_3d_coords()
+        "  have_3d_coords:                       "
+     << obj.get_have_3d_coords()
      << "\n"
-        "  x_3d:                                 " << obj.get_x_3d()
+        "  x_3d:                                 "
+     << obj.get_x_3d()
      << "\n"
-        "  y_3d:                                 " << obj.get_y_3d()
+        "  y_3d:                                 "
+     << obj.get_y_3d()
      << "\n"
-        "  z_3d:                                 " << obj.get_z_3d()
+        "  z_3d:                                 "
+     << obj.get_z_3d()
      << "\n"
-        "  should_be_drawn:                      " << obj.get_should_be_drawn()
+        "  should_be_drawn:                      "
+     << obj.get_should_be_drawn()
      << "\n"
         "  problem_has_been_acknowledged:        "
      << obj.get_problem_has_been_acknowledged()
@@ -705,41 +822,56 @@ std::ostream& operator<<(std::ostream& os, host const& obj) {
         "  acknowledgement_type:                 "
      << obj.get_acknowledgement_type()
      << "\n"
-        "  check_type:                           " << obj.get_check_type()
+        "  check_type:                           "
+     << obj.get_check_type()
      << "\n"
-        "  current_state:                        " << obj.get_current_state()
+        "  current_state:                        "
+     << obj.get_current_state()
      << "\n"
-        "  last_state:                           " << obj.get_last_state()
+        "  last_state:                           "
+     << obj.get_last_state()
      << "\n"
-        "  last_hard_state:                      " << obj.get_last_hard_state()
+        "  last_hard_state:                      "
+     << obj.get_last_hard_state()
      << "\n"
-        "  plugin_output:                        " << obj.get_plugin_output()
+        "  plugin_output:                        "
+     << obj.get_plugin_output()
      << "\n"
         "  long_plugin_output:                   "
      << obj.get_long_plugin_output()
      << "\n"
-        "  perf_data:                            " << obj.get_perf_data()
+        "  perf_data:                            "
+     << obj.get_perf_data()
      << "\n"
-        "  state_type:                           " << obj.get_state_type()
+        "  state_type:                           "
+     << obj.get_state_type()
      << "\n"
-        "  current_attempt:                      " << obj.get_current_attempt()
+        "  current_attempt:                      "
+     << obj.get_current_attempt()
      << "\n"
-        "  current_event_id:                     " << obj.get_current_event_id()
+        "  current_event_id:                     "
+     << obj.get_current_event_id()
      << "\n"
-        "  last_event_id:                        " << obj.get_last_event_id()
+        "  last_event_id:                        "
+     << obj.get_last_event_id()
      << "\n"
         "  current_problem_id:                   "
      << obj.get_current_problem_id()
      << "\n"
-        "  last_problem_id:                      " << obj.get_last_problem_id()
+        "  last_problem_id:                      "
+     << obj.get_last_problem_id()
      << "\n"
-        "  latency:                              " << obj.get_latency()
+        "  latency:                              "
+     << obj.get_latency()
      << "\n"
-        "  execution_time:                       " << obj.get_execution_time()
+        "  execution_time:                       "
+     << obj.get_execution_time()
      << "\n"
-        "  is_executing:                         " << obj.get_is_executing()
+        "  is_executing:                         "
+     << obj.get_is_executing()
      << "\n"
-        "  check_options:                        " << obj.get_check_options()
+        "  check_options:                        "
+     << obj.get_check_options()
      << "\n"
         "  notifications_enabled:                "
      << obj.get_notifications_enabled()
@@ -774,7 +906,8 @@ std::ostream& operator<<(std::ostream& os, host const& obj) {
         "  last_time_unreachable:                "
      << string::ctime(obj.get_last_time_unreachable())
      << "\n"
-        "  has_been_checked:                     " << obj.has_been_checked()
+        "  has_been_checked:                     "
+     << obj.has_been_checked()
      << "\n"
         "  is_being_freshened:                   "
      << obj.get_is_being_freshened()
@@ -807,7 +940,8 @@ std::ostream& operator<<(std::ostream& os, host const& obj) {
         "  last_state_history_update:            "
      << string::ctime(obj.get_last_state_history_update())
      << "\n"
-        "  is_flapping:                          " << obj.get_is_flapping()
+        "  is_flapping:                          "
+     << obj.get_is_flapping()
      << "\n"
         "  flapping_comment_id:                  "
      << obj.get_flapping_comment_id()
@@ -815,7 +949,8 @@ std::ostream& operator<<(std::ostream& os, host const& obj) {
         "  percent_state_change:                 "
      << obj.get_percent_state_change()
      << "\n"
-        "  total_services:                       " << obj.get_total_services()
+        "  total_services:                       "
+     << obj.get_total_services()
      << "\n"
         "  total_service_check_interval:         "
      << obj.get_total_service_check_interval()
@@ -829,13 +964,17 @@ std::ostream& operator<<(std::ostream& os, host const& obj) {
         "  contains_circular_path:               "
      << obj.get_contains_circular_path()
      << "\n"
-        "  event_handler_ptr:                    " << evt_str
+        "  event_handler_ptr:                    "
+     << evt_str
      << "\n"
-        "  check_command_ptr:                    " << cmd_str
+        "  check_command_ptr:                    "
+     << cmd_str
      << "\n"
-        "  check_period_ptr:                     " << chk_period_str
+        "  check_period_ptr:                     "
+     << chk_period_str
      << "\n"
-        "  notification_period_ptr:              " << notif_period_str
+        "  notification_period_ptr:              "
+     << notif_period_str
      << "\n"
         "  hostgroups_ptr:                       "
      << (hg ? hg->get_group_name() : "") << "\n";
@@ -905,8 +1044,7 @@ int is_host_immediate_parent_of_host(com::centreon::engine::host* child_host,
 int number_of_immediate_child_hosts(com::centreon::engine::host* hst) {
   int children(0);
   for (host_map::iterator it{host::hosts.begin()}, end{host::hosts.end()};
-       it != end;
-       ++it)
+       it != end; ++it)
     if (is_host_immediate_child_of_host(hst, it->second.get()))
       ++children;
   return children;
@@ -924,8 +1062,7 @@ int number_of_immediate_child_hosts(com::centreon::engine::host* hst) {
 int number_of_immediate_parent_hosts(com::centreon::engine::host* hst) {
   int parents(0);
   for (host_map::iterator it{host::hosts.begin()}, end{host::hosts.end()};
-       it != end;
-       ++it)
+       it != end; ++it)
     if (is_host_immediate_parent_of_host(hst, it->second.get()))
       ++parents;
   return parents;
@@ -943,8 +1080,7 @@ int number_of_immediate_parent_hosts(com::centreon::engine::host* hst) {
 int number_of_total_child_hosts(com::centreon::engine::host* hst) {
   int children(0);
   for (host_map::iterator it{host::hosts.begin()}, end{host::hosts.end()};
-       it != end;
-       ++it)
+       it != end; ++it)
     if (is_host_immediate_child_of_host(hst, it->second.get()))
       children += number_of_total_child_hosts(it->second.get()) + 1;
   return children;
@@ -962,8 +1098,7 @@ int number_of_total_child_hosts(com::centreon::engine::host* hst) {
 int number_of_total_parent_hosts(com::centreon::engine::host* hst) {
   int parents(0);
   for (host_map::iterator it{host::hosts.begin()}, end{host::hosts.end()};
-       it != end;
-       ++it)
+       it != end; ++it)
     if (is_host_immediate_parent_of_host(hst, it->second.get()))
       parents += number_of_total_parent_hosts(it->second.get()) + 1;
   return parents;
@@ -1017,14 +1152,8 @@ void host::schedule_acknowledgement_expiration() {
       get_last_acknowledgement() != (time_t)0) {
     timed_event* evt = new timed_event(
         timed_event::EVENT_EXPIRE_HOST_ACK,
-        get_last_acknowledgement() + get_acknowledgement_timeout(),
-        false,
-        0,
-        nullptr,
-        true,
-        this,
-        nullptr,
-        0);
+        get_last_acknowledgement() + get_acknowledgement_timeout(), false, 0,
+        nullptr, true, this, nullptr, 0);
     events::loop::instance().schedule(evt, false);
   }
 }
@@ -1047,22 +1176,17 @@ int host::log_event() {
   }
   std::string const& state_type(tab_state_type[get_state_type()]);
 
-  logger(log_options, basic) << "HOST ALERT: " << get_name() << ";" << state
-                             << ";" << state_type << ";"
-                             << get_current_attempt() << ";"
-                             << get_plugin_output();
+  logger(log_options, basic)
+      << "HOST ALERT: " << get_name() << ";" << state << ";" << state_type
+      << ";" << get_current_attempt() << ";" << get_plugin_output();
 
   return OK;
 }
 
 /* process results of an asynchronous host check */
 int host::handle_async_check_result_3x(check_result* queued_check_result) {
-  enum service::service_state svc_res {
-    service::state_ok
-  };
-  enum host::host_state hst_res {
-    host::state_up
-  };
+  enum service::service_state svc_res{service::state_ok};
+  enum host::host_state hst_res{host::state_up};
   int reschedule_check{false};
   std::string old_plugin_output;
   struct timeval start_time_hires;
@@ -1216,8 +1340,8 @@ int host::handle_async_check_result_3x(check_result* queued_check_result) {
   std::string plugin_output;
   std::string long_plugin_output;
   std::string perf_data;
-  parse_check_output(
-      output, plugin_output, long_plugin_output, perf_data, true, false);
+  parse_check_output(output, plugin_output, long_plugin_output, perf_data, true,
+                     false);
   set_plugin_output(plugin_output);
   set_long_plugin_output(long_plugin_output);
   set_perf_data(perf_data);
@@ -1240,7 +1364,8 @@ int host::handle_async_check_result_3x(check_result* queued_check_result) {
       << "Long Output:\n"
       << (get_long_plugin_output().empty() ? "NULL" : get_long_plugin_output())
       << "\n"
-      << "Perf Data:\n" << (get_perf_data().empty() ? "NULL" : get_perf_data());
+      << "Perf Data:\n"
+      << (get_perf_data().empty() ? "NULL" : get_perf_data());
 
   /* get the unprocessed return code */
   /* NOTE: for passive checks, this is the final/processed state */
@@ -1254,9 +1379,9 @@ int host::handle_async_check_result_3x(check_result* queued_check_result) {
     /* if there was some error running the command, just skip it (this shouldn't
      * be happening) */
     if (!queued_check_result->get_exited_ok()) {
-      logger(log_runtime_warning, basic) << "Warning:  Check of host '"
-                                         << get_name()
-                                         << "' did not exit properly!";
+      logger(log_runtime_warning, basic)
+          << "Warning:  Check of host '" << get_name()
+          << "' did not exit properly!";
 
       set_plugin_output("(Host check did not exit properly)");
       set_long_plugin_output("");
@@ -1284,7 +1409,8 @@ int host::handle_async_check_result_3x(check_result* queued_check_result) {
           << ((queued_check_result->get_return_code() == 126 ||
                queued_check_result->get_return_code() == 127)
                   ? " - plugin may be missing"
-                  : "") << ")";
+                  : "")
+          << ")";
 
       set_plugin_output(oss.str());
       set_long_plugin_output("");
@@ -1322,11 +1448,8 @@ int host::handle_async_check_result_3x(check_result* queued_check_result) {
   /******************* PROCESS THE CHECK RESULTS ******************/
 
   /* process the host check result */
-  process_check_result_3x(hst_res,
-                          old_plugin_output,
-                          CHECK_OPTION_NONE,
-                          reschedule_check,
-                          true,
+  process_check_result_3x(hst_res, old_plugin_output, CHECK_OPTION_NONE,
+                          reschedule_check, true,
                           config->cached_host_check_horizon());
 
   logger(dbg_checks, more) << "** Async check result for host '" << get_name()
@@ -1339,26 +1462,16 @@ int host::handle_async_check_result_3x(check_result* queued_check_result) {
   gettimeofday(&end_time_hires, nullptr);
 
   /* send data to event broker */
-  broker_host_check(NEBTYPE_HOSTCHECK_PROCESSED,
-                    NEBFLAG_NONE,
-                    NEBATTR_NONE,
-                    this,
-                    get_check_type(),
-                    get_current_state(),
-                    get_state_type(),
-                    start_time_hires,
-                    end_time_hires,
-                    get_check_command().c_str(),
-                    get_latency(),
-                    get_execution_time(),
-                    config->host_check_timeout(),
+  broker_host_check(NEBTYPE_HOSTCHECK_PROCESSED, NEBFLAG_NONE, NEBATTR_NONE,
+                    this, get_check_type(), get_current_state(),
+                    get_state_type(), start_time_hires, end_time_hires,
+                    get_check_command().c_str(), get_latency(),
+                    get_execution_time(), config->host_check_timeout(),
                     queued_check_result->get_early_timeout(),
-                    queued_check_result->get_return_code(),
-                    nullptr,
+                    queued_check_result->get_return_code(), nullptr,
                     const_cast<char*>(get_plugin_output().c_str()),
                     const_cast<char*>(get_long_plugin_output().c_str()),
-                    const_cast<char*>(get_perf_data().c_str()),
-                    nullptr);
+                    const_cast<char*>(get_perf_data().c_str()), nullptr);
   return OK;
 }
 
@@ -1372,14 +1485,13 @@ int host::run_scheduled_check(int check_options, double latency) {
 
   logger(dbg_functions, basic) << "run_scheduled_host_check_3x()";
 
-  logger(dbg_checks, basic) << "Attempting to run scheduled check of host '"
-                            << get_name()
-                            << "': check options=" << check_options
-                            << ", latency=" << latency;
+  logger(dbg_checks, basic)
+      << "Attempting to run scheduled check of host '" << get_name()
+      << "': check options=" << check_options << ", latency=" << latency;
 
   /* attempt to run the check */
-  result = run_async_check(
-      check_options, latency, true, true, &time_is_valid, &preferred_time);
+  result = run_async_check(check_options, latency, true, true, &time_is_valid,
+                           &preferred_time);
 
   /* an error occurred, so reschedule the check */
   if (result == ERROR) {
@@ -1404,8 +1516,8 @@ int host::run_scheduled_check(int check_options, double latency) {
       // Make sure we rescheduled the next host check at a valid time.
       {
         timezone_locker lock(get_timezone());
-        get_next_valid_time(
-            preferred_time, &next_valid_time, this->check_period_ptr);
+        get_next_valid_time(preferred_time, &next_valid_time,
+                            this->check_period_ptr);
       }
 
       /* the host could not be rescheduled properly - set the next check time
@@ -1432,8 +1544,8 @@ int host::run_scheduled_check(int check_options, double latency) {
         set_next_check(next_valid_time);
         set_should_be_scheduled(true);
 
-        logger(dbg_checks, more) << "Rescheduled next host check for "
-                                 << my_ctime(&next_valid_time);
+        logger(dbg_checks, more)
+            << "Rescheduled next host check for " << my_ctime(&next_valid_time);
       }
     }
 
@@ -1460,10 +1572,10 @@ int host::run_async_check(int check_options,
                           bool reschedule_check,
                           bool* time_is_valid,
                           time_t* preferred_time) noexcept {
-  logger(dbg_functions, basic) << "host::run_async_check, check_options="
-                               << check_options << ", latency=" << latency
-                               << ", scheduled_check=" << scheduled_check
-                               << ", reschedule_check=" << reschedule_check;
+  logger(dbg_functions, basic)
+      << "host::run_async_check, check_options=" << check_options
+      << ", latency=" << latency << ", scheduled_check=" << scheduled_check
+      << ", reschedule_check=" << reschedule_check;
 
   // Preamble.
   if (!get_check_command_ptr()) {
@@ -1473,8 +1585,8 @@ int host::run_async_check(int check_options,
     return ERROR;
   }
 
-  logger(dbg_checks, basic) << "** Running async check of host '" << get_name()
-                            << "'...";
+  logger(dbg_checks, basic)
+      << "** Running async check of host '" << get_name() << "'...";
 
   // Check if the host is viable now.
   if (!verify_check_viability(check_options, time_is_valid, preferred_time))
@@ -1500,26 +1612,12 @@ int host::run_async_check(int check_options,
   timeval end_time;
   memset(&start_time, 0, sizeof(start_time));
   memset(&end_time, 0, sizeof(end_time));
-  int res = broker_host_check(NEBTYPE_HOSTCHECK_ASYNC_PRECHECK,
-                              NEBFLAG_NONE,
-                              NEBATTR_NONE,
-                              this,
-                              checkable::check_active,
-                              get_current_state(),
-                              get_state_type(),
-                              start_time,
-                              end_time,
-                              get_check_command().c_str(),
-                              get_latency(),
-                              0.0,
-                              config->host_check_timeout(),
-                              false,
-                              0,
-                              nullptr,
-                              nullptr,
-                              nullptr,
-                              nullptr,
-                              nullptr);
+  int res = broker_host_check(
+      NEBTYPE_HOSTCHECK_ASYNC_PRECHECK, NEBFLAG_NONE, NEBATTR_NONE, this,
+      checkable::check_active, get_current_state(), get_state_type(),
+      start_time, end_time, get_check_command().c_str(), get_latency(), 0.0,
+      config->host_check_timeout(), false, 0, nullptr, nullptr, nullptr,
+      nullptr, nullptr);
 
   // Host check was cancel by NEB module. Reschedule check later.
   if (NEBERROR_CALLBACKCANCEL == res) {
@@ -1554,8 +1652,8 @@ int host::run_async_check(int check_options,
   nagios_macros* macros(get_global_macros());
   grab_host_macros_r(macros, this);
   std::string tmp;
-  get_raw_command_line_r(
-      macros, get_check_command_ptr(), get_check_command().c_str(), tmp, 0);
+  get_raw_command_line_r(macros, get_check_command_ptr(),
+                         get_check_command().c_str(), tmp, 0);
 
   // Time to start command.
   gettimeofday(&start_time, nullptr);
@@ -1576,26 +1674,12 @@ int host::run_async_check(int check_options,
   std::string processed_cmd(cmd->process_cmd(macros));
 
   // Send event broker.
-  broker_host_check(NEBTYPE_HOSTCHECK_INITIATE,
-                    NEBFLAG_NONE,
-                    NEBATTR_NONE,
-                    this,
-                    checkable::check_active,
-                    get_current_state(),
-                    get_state_type(),
-                    start_time,
-                    end_time,
-                    get_check_command().c_str(),
-                    get_latency(),
-                    0.0,
-                    config->host_check_timeout(),
-                    false,
-                    0,
-                    processed_cmd.c_str(),
-                    nullptr,
-                    nullptr,
-                    nullptr,
-                    nullptr);
+  broker_host_check(NEBTYPE_HOSTCHECK_INITIATE, NEBFLAG_NONE, NEBATTR_NONE,
+                    this, checkable::check_active, get_current_state(),
+                    get_state_type(), start_time, end_time,
+                    get_check_command().c_str(), get_latency(), 0.0,
+                    config->host_check_timeout(), false, 0,
+                    processed_cmd.c_str(), nullptr, nullptr, nullptr, nullptr);
 
   // Restore latency.
   set_latency(old_latency);
@@ -1611,18 +1695,10 @@ int host::run_async_check(int check_options,
   std::unique_ptr<check_result> check_result_info;
   do {
     // Init check result info.
-    check_result_info.reset(new check_result(host_check,
-                                             this,
-                                             checkable::check_active,
-                                             check_options,
-                                             reschedule_check,
-                                             latency,
-                                             start_time,
-                                             start_time,
-                                             false,
-                                             true,
-                                             service::state_ok,
-                                             ""));
+    check_result_info.reset(
+        new check_result(host_check, this, checkable::check_active,
+                         check_options, reschedule_check, latency, start_time,
+                         start_time, false, true, service::state_ok, ""));
 
     retry = false;
     try {
@@ -1632,11 +1708,9 @@ int host::run_async_check(int check_options,
       if (id != 0)
         checks::checker::instance().add_check_result(
             id, check_result_info.release());
-    }
-    catch (com::centreon::exceptions::interruption const& e) {
+    } catch (com::centreon::exceptions::interruption const& e) {
       retry = true;
-    }
-    catch (std::exception const& e) {
+    } catch (std::exception const& e) {
       // Update check result.
       timeval tv;
       gettimeofday(&tv, nullptr);
@@ -1674,12 +1748,11 @@ bool host::schedule_check(time_t check_time, int options) {
 
   logger(dbg_functions, basic) << "schedule_host_check()";
 
-  logger(dbg_checks, basic) << "Scheduling a "
-                            << (options & CHECK_OPTION_FORCE_EXECUTION
-                                    ? "forced"
-                                    : "non-forced")
-                            << ", active check of host '" << get_name()
-                            << "' @ " << my_ctime(&check_time);
+  logger(dbg_checks, basic)
+      << "Scheduling a "
+      << (options & CHECK_OPTION_FORCE_EXECUTION ? "forced" : "non-forced")
+      << ", active check of host '" << get_name() << "' @ "
+      << my_ctime(&check_time);
 
   /* don't schedule a check if active checks of this host are disabled */
   if (!get_checks_enabled() && !(options & CHECK_OPTION_FORCE_EXECUTION)) {
@@ -1766,15 +1839,9 @@ bool host::schedule_check(time_t check_time, int options) {
     set_next_check(check_time);
 
     /* place the new event in the event queue */
-    timed_event* new_event = new timed_event(timed_event::EVENT_HOST_CHECK,
-                                             get_next_check(),
-                                             false,
-                                             0L,
-                                             nullptr,
-                                             true,
-                                             (void*)this,
-                                             nullptr,
-                                             options);
+    timed_event* new_event =
+        new timed_event(timed_event::EVENT_HOST_CHECK, get_next_check(), false,
+                        0L, nullptr, true, (void*)this, nullptr, options);
 
     events::loop::instance().reschedule_event(new_event, events::loop::low);
   } else {
@@ -1811,8 +1878,8 @@ void host::check_for_flapping(bool update,
 
   logger(dbg_functions, basic) << "host::check_for_flapping()";
 
-  logger(dbg_flapping, more) << "Checking host '" << get_name()
-                             << "' for flapping...";
+  logger(dbg_flapping, more)
+      << "Checking host '" << get_name() << "' for flapping...";
 
   time(&current_time);
 
@@ -1899,11 +1966,10 @@ void host::check_for_flapping(bool update,
 
   set_percent_state_change(curved_percent_change);
 
-  logger(dbg_flapping, most) << com::centreon::logging::setprecision(2)
-                             << "LFT=" << low_threshold
-                             << ", HFT=" << high_threshold
-                             << ", CPC=" << curved_percent_change
-                             << ", PSC=" << curved_percent_change << "%";
+  logger(dbg_flapping, most)
+      << com::centreon::logging::setprecision(2) << "LFT=" << low_threshold
+      << ", HFT=" << high_threshold << ", CPC=" << curved_percent_change
+      << ", PSC=" << curved_percent_change << "%";
 
   /* don't do anything if we don't have flap detection enabled on a program-wide
    * basis */
@@ -1927,15 +1993,13 @@ void host::check_for_flapping(bool update,
   else if (curved_percent_change >= high_threshold)
     is_flapping = true;
 
-  logger(dbg_flapping, more) << "Host " << (is_flapping ? "is" : "is not")
-                             << " flapping (" << curved_percent_change
-                             << "% state change).";
+  logger(dbg_flapping, more)
+      << "Host " << (is_flapping ? "is" : "is not") << " flapping ("
+      << curved_percent_change << "% state change).";
 
   /* did the host just start flapping? */
   if (is_flapping && !get_is_flapping())
-    set_flap(curved_percent_change,
-             high_threshold,
-             low_threshold,
+    set_flap(curved_percent_change, high_threshold, low_threshold,
              allow_flapstart_notification);
 
   /* did the host just stop flapping? */
@@ -1964,21 +2028,15 @@ void host::set_flap(double percent_change,
       << "Notifications for this host are being suppressed because it "
          "was detected as "
       << "having been flapping between different "
-         "states (" << percent_change << "% change > " << high_threshold
+         "states ("
+      << percent_change << "% change > " << high_threshold
       << "% threshold).  When the host state stabilizes and the "
       << "flapping stops, notifications will be re-enabled.";
 
-  std::shared_ptr<comment> com{new comment(comment::host,
-                                           comment::flapping,
-                                           get_host_id(),
-                                           0,
-                                           time(nullptr),
-                                           "(Centreon Engine Process)",
-                                           oss.str(),
-                                           false,
-                                           comment::internal,
-                                           false,
-                                           (time_t)0)};
+  std::shared_ptr<comment> com{
+      new comment(comment::host, comment::flapping, get_host_id(), 0,
+                  time(nullptr), "(Centreon Engine Process)", oss.str(), false,
+                  comment::internal, false, (time_t)0)};
 
   comment::comments.insert({com->get_comment_id(), com});
 
@@ -1989,15 +2047,9 @@ void host::set_flap(double percent_change,
   set_is_flapping(true);
 
   /* send data to event broker */
-  broker_flapping_data(NEBTYPE_FLAPPING_START,
-                       NEBFLAG_NONE,
-                       NEBATTR_NONE,
-                       HOST_FLAPPING,
-                       this,
-                       percent_change,
-                       high_threshold,
-                       low_threshold,
-                       nullptr);
+  broker_flapping_data(NEBTYPE_FLAPPING_START, NEBFLAG_NONE, NEBATTR_NONE,
+                       HOST_FLAPPING, this, percent_change, high_threshold,
+                       low_threshold, nullptr);
 
   /* send a notification */
   if (allow_flapstart_notification)
@@ -2010,8 +2062,8 @@ void host::clear_flap(double percent_change,
                       double low_threshold) {
   logger(dbg_functions, basic) << "host::clear_flap()";
 
-  logger(dbg_flapping, basic) << "Host '" << get_name()
-                              << "' stopped flapping.";
+  logger(dbg_flapping, basic)
+      << "Host '" << get_name() << "' stopped flapping.";
 
   /* log a notice - this one is parsed by the history CGI */
   logger(log_info_message, basic)
@@ -2029,15 +2081,9 @@ void host::clear_flap(double percent_change,
   set_is_flapping(false);
 
   /* send data to event broker */
-  broker_flapping_data(NEBTYPE_FLAPPING_STOP,
-                       NEBFLAG_NONE,
-                       NEBATTR_FLAPPING_STOP_NORMAL,
-                       HOST_FLAPPING,
-                       this,
-                       percent_change,
-                       high_threshold,
-                       low_threshold,
-                       nullptr);
+  broker_flapping_data(NEBTYPE_FLAPPING_STOP, NEBFLAG_NONE,
+                       NEBATTR_FLAPPING_STOP_NORMAL, HOST_FLAPPING, this,
+                       percent_change, high_threshold, low_threshold, nullptr);
 
   /* send a notification */
   notify(reason_flappingstop, "", "", notifier::notification_option_none);
@@ -2050,8 +2096,8 @@ void host::clear_flap(double percent_change,
  * @brief Updates host status info. Data are sent to event broker.
  */
 void host::update_status() {
-  broker_host_status(
-      NEBTYPE_HOSTSTATUS_UPDATE, NEBFLAG_NONE, NEBATTR_NONE, this, nullptr);
+  broker_host_status(NEBTYPE_HOSTSTATUS_UPDATE, NEBFLAG_NONE, NEBATTR_NONE,
+                     this, nullptr);
 }
 
 /**
@@ -2063,8 +2109,8 @@ void host::check_for_expired_acknowledgement() {
     if (get_acknowledgement_timeout() > 0) {
       time_t now(time(nullptr));
       if (get_last_acknowledgement() + get_acknowledgement_timeout() >= now) {
-        logger(log_info_message, basic) << "Acknowledgement of host '"
-                                        << get_name() << "' just expired";
+        logger(log_info_message, basic)
+            << "Acknowledgement of host '" << get_name() << "' just expired";
         set_problem_has_been_acknowledged(false);
         set_acknowledgement_type(ACKNOWLEDGEMENT_NONE);
         update_status();
@@ -2286,7 +2332,9 @@ bool host::verify_check_viability(int check_options,
   return result;
 }
 
-void host::grab_macros_r(nagios_macros* mac) { grab_host_macros_r(mac, this); }
+void host::grab_macros_r(nagios_macros* mac) {
+  grab_host_macros_r(mac, this);
+}
 
 /* notify a specific contact that an entire host is down or up */
 int host::notify_contact(nagios_macros* mac,
@@ -2306,8 +2354,8 @@ int host::notify_contact(nagios_macros* mac,
   int neb_result;
 
   logger(dbg_functions, basic) << "notify_contact_of_host()";
-  logger(dbg_notifications, most) << "** Notifying contact '"
-                                  << cntct->get_name() << "'";
+  logger(dbg_notifications, most)
+      << "** Notifying contact '" << cntct->get_name() << "'";
 
   /* get start time */
   gettimeofday(&start_time, nullptr);
@@ -2315,20 +2363,10 @@ int host::notify_contact(nagios_macros* mac,
   /* send data to event broker */
   end_time.tv_sec = 0L;
   end_time.tv_usec = 0L;
-  neb_result =
-      broker_contact_notification_data(NEBTYPE_CONTACTNOTIFICATION_START,
-                                       NEBFLAG_NONE,
-                                       NEBATTR_NONE,
-                                       host_notification,
-                                       type,
-                                       start_time,
-                                       end_time,
-                                       (void*)this,
-                                       cntct,
-                                       not_author.c_str(),
-                                       not_data.c_str(),
-                                       escalated,
-                                       nullptr);
+  neb_result = broker_contact_notification_data(
+      NEBTYPE_CONTACTNOTIFICATION_START, NEBFLAG_NONE, NEBATTR_NONE,
+      host_notification, type, start_time, end_time, (void*)this, cntct,
+      not_author.c_str(), not_data.c_str(), escalated, nullptr);
   if (NEBERROR_CALLBACKCANCEL == neb_result)
     return ERROR;
   else if (NEBERROR_CALLBACKOVERRIDE == neb_result)
@@ -2344,36 +2382,23 @@ int host::notify_contact(nagios_macros* mac,
     method_end_time.tv_sec = 0L;
     method_end_time.tv_usec = 0L;
     neb_result = broker_contact_notification_method_data(
-        NEBTYPE_CONTACTNOTIFICATIONMETHOD_START,
-        NEBFLAG_NONE,
-        NEBATTR_NONE,
-        host_notification,
-        type,
-        method_start_time,
-        method_end_time,
-        (void*)this,
-        cntct,
-        cmd->get_command_line().c_str(),
-        not_author.c_str(),
-        not_data.c_str(),
-        escalated,
-        nullptr);
+        NEBTYPE_CONTACTNOTIFICATIONMETHOD_START, NEBFLAG_NONE, NEBATTR_NONE,
+        host_notification, type, method_start_time, method_end_time,
+        (void*)this, cntct, cmd->get_command_line().c_str(), not_author.c_str(),
+        not_data.c_str(), escalated, nullptr);
     if (NEBERROR_CALLBACKCANCEL == neb_result)
       break;
     else if (NEBERROR_CALLBACKOVERRIDE == neb_result)
       continue;
 
     /* get the raw command line */
-    get_raw_command_line_r(mac,
-                           cmd.get(),
-                           cmd->get_command_line().c_str(),
-                           raw_command,
-                           macro_options);
+    get_raw_command_line_r(mac, cmd.get(), cmd->get_command_line().c_str(),
+                           raw_command, macro_options);
     if (raw_command.empty())
       continue;
 
-    logger(dbg_notifications, most) << "Raw notification command: "
-                                    << raw_command;
+    logger(dbg_notifications, most)
+        << "Raw notification command: " << raw_command;
 
     /* process any macros contained in the argument */
     process_macros_r(mac, raw_command, processed_command, macro_options);
@@ -2382,8 +2407,8 @@ int host::notify_contact(nagios_macros* mac,
 
     /* run the notification command... */
 
-    logger(dbg_notifications, most) << "Processed notification command: "
-                                    << processed_command;
+    logger(dbg_notifications, most)
+        << "Processed notification command: " << processed_command;
 
     /* log the notification to program log file */
     if (config->log_notifications()) {
@@ -2420,15 +2445,9 @@ int host::notify_contact(nagios_macros* mac,
     /* run the notification command */
     try {
       std::string out;
-      my_system_r(mac,
-                  processed_command,
-                  config->notification_timeout(),
-                  &early_timeout,
-                  &exectime,
-                  out,
-                  0);
-    }
-    catch (std::exception const& e) {
+      my_system_r(mac, processed_command, config->notification_timeout(),
+                  &early_timeout, &exectime, out, 0);
+    } catch (std::exception const& e) {
       logger(log_runtime_error, basic)
           << "Error: can't execute host notification '" << cntct->get_name()
           << "' : " << e.what();
@@ -2448,20 +2467,10 @@ int host::notify_contact(nagios_macros* mac,
 
     /* send data to event broker */
     broker_contact_notification_method_data(
-        NEBTYPE_CONTACTNOTIFICATIONMETHOD_END,
-        NEBFLAG_NONE,
-        NEBATTR_NONE,
-        host_notification,
-        type,
-        method_start_time,
-        method_end_time,
-        (void*)this,
-        cntct,
-        cmd->get_command_line().c_str(),
-        not_author.c_str(),
-        not_data.c_str(),
-        escalated,
-        nullptr);
+        NEBTYPE_CONTACTNOTIFICATIONMETHOD_END, NEBFLAG_NONE, NEBATTR_NONE,
+        host_notification, type, method_start_time, method_end_time,
+        (void*)this, cntct, cmd->get_command_line().c_str(), not_author.c_str(),
+        not_data.c_str(), escalated, nullptr);
   }
 
   /* get end time */
@@ -2471,19 +2480,10 @@ int host::notify_contact(nagios_macros* mac,
   cntct->set_last_host_notification(start_time.tv_sec);
 
   /* send data to event broker */
-  broker_contact_notification_data(NEBTYPE_CONTACTNOTIFICATION_END,
-                                   NEBFLAG_NONE,
-                                   NEBATTR_NONE,
-                                   host_notification,
-                                   type,
-                                   start_time,
-                                   end_time,
-                                   (void*)this,
-                                   cntct,
-                                   not_author.c_str(),
-                                   not_data.c_str(),
-                                   escalated,
-                                   nullptr);
+  broker_contact_notification_data(
+      NEBTYPE_CONTACTNOTIFICATION_END, NEBFLAG_NONE, NEBATTR_NONE,
+      host_notification, type, start_time, end_time, (void*)this, cntct,
+      not_author.c_str(), not_data.c_str(), escalated, nullptr);
 
   return OK;
 }
@@ -2502,8 +2502,8 @@ void host::disable_flap_detection() {
 
   logger(dbg_functions, basic) << "disable_host_flap_detection()";
 
-  logger(dbg_functions, more) << "Disabling flap detection for host '"
-                              << get_name() << "'.";
+  logger(dbg_functions, more)
+      << "Disabling flap detection for host '" << get_name() << "'.";
 
   /* nothing to do... */
   if (!get_flap_detection_enabled())
@@ -2516,14 +2516,9 @@ void host::disable_flap_detection() {
   set_flap_detection_enabled(false);
 
   /* send data to event broker */
-  broker_adaptive_host_data(NEBTYPE_ADAPTIVEHOST_UPDATE,
-                            NEBFLAG_NONE,
-                            NEBATTR_NONE,
-                            this,
-                            CMD_NONE,
-                            attr,
-                            get_modified_attributes(),
-                            nullptr);
+  broker_adaptive_host_data(NEBTYPE_ADAPTIVEHOST_UPDATE, NEBFLAG_NONE,
+                            NEBATTR_NONE, this, CMD_NONE, attr,
+                            get_modified_attributes(), nullptr);
 
   /* handle the details... */
   handle_flap_detection_disabled();
@@ -2535,8 +2530,8 @@ void host::enable_flap_detection() {
 
   logger(dbg_functions, basic) << "host::enable_flap_detection()";
 
-  logger(dbg_flapping, more) << "Enabling flap detection for host '"
-                             << get_name() << "'.";
+  logger(dbg_flapping, more)
+      << "Enabling flap detection for host '" << get_name() << "'.";
 
   /* nothing to do... */
   if (get_flap_detection_enabled())
@@ -2549,14 +2544,9 @@ void host::enable_flap_detection() {
   set_flap_detection_enabled(true);
 
   /* send data to event broker */
-  broker_adaptive_host_data(NEBTYPE_ADAPTIVEHOST_UPDATE,
-                            NEBFLAG_NONE,
-                            NEBATTR_NONE,
-                            this,
-                            CMD_NONE,
-                            attr,
-                            get_modified_attributes(),
-                            nullptr);
+  broker_adaptive_host_data(NEBTYPE_ADAPTIVEHOST_UPDATE, NEBFLAG_NONE,
+                            NEBATTR_NONE, this, CMD_NONE, attr,
+                            get_modified_attributes(), nullptr);
 
   /* check for flapping */
   check_for_flapping(false, false, true);
@@ -2689,10 +2679,10 @@ bool host::is_result_fresh(time_t current_time, int log_this) {
 
   /* the results for the last check of this host are stale */
   if (expiration_time < current_time) {
-    get_time_breakdown(
-        (current_time - expiration_time), &days, &hours, &minutes, &seconds);
-    get_time_breakdown(
-        freshness_threshold, &tdays, &thours, &tminutes, &tseconds);
+    get_time_breakdown((current_time - expiration_time), &days, &hours,
+                       &minutes, &seconds);
+    get_time_breakdown(freshness_threshold, &tdays, &thours, &tminutes,
+                       &tseconds);
 
     /* log a warning */
     if (log_this)
@@ -2700,21 +2690,22 @@ bool host::is_result_fresh(time_t current_time, int log_this) {
           << "Warning: The results of host '" << _name << "' are stale by "
           << days << "d " << hours << "h " << minutes << "m " << seconds
           << "s (threshold=" << tdays << "d " << thours << "h " << tminutes
-          << "m " << tseconds << "s).  I'm forcing an immediate check of"
-                                 " the host.";
+          << "m " << tseconds
+          << "s).  I'm forcing an immediate check of"
+             " the host.";
 
-    logger(dbg_checks, more) << "Check results for host '" << _name
-                             << "' are stale by " << days << "d " << hours
-                             << "h " << minutes << "m " << seconds
-                             << "s (threshold=" << tdays << "d " << thours
-                             << "h " << tminutes << "m " << tseconds
-                             << "s).  "
-                                "Forcing an immediate check of the host...";
+    logger(dbg_checks, more)
+        << "Check results for host '" << _name << "' are stale by " << days
+        << "d " << hours << "h " << minutes << "m " << seconds
+        << "s (threshold=" << tdays << "d " << thours << "h " << tminutes
+        << "m " << tseconds
+        << "s).  "
+           "Forcing an immediate check of the host...";
 
     return false;
   } else
-    logger(dbg_checks, more) << "Check results for host '" << this->get_name()
-                             << "' are fresh.";
+    logger(dbg_checks, more)
+        << "Check results for host '" << this->get_name() << "' are fresh.";
 
   return true;
 }
@@ -2739,15 +2730,9 @@ void host::handle_flap_detection_disabled() {
         << ";DISABLED; Flap detection has been disabled";
 
     /* send data to event broker */
-    broker_flapping_data(NEBTYPE_FLAPPING_STOP,
-                         NEBFLAG_NONE,
-                         NEBATTR_FLAPPING_STOP_DISABLED,
-                         HOST_FLAPPING,
-                         this,
-                         this->get_percent_state_change(),
-                         0.0,
-                         0.0,
-                         nullptr);
+    broker_flapping_data(NEBTYPE_FLAPPING_STOP, NEBFLAG_NONE,
+                         NEBATTR_FLAPPING_STOP_DISABLED, HOST_FLAPPING, this,
+                         this->get_percent_state_change(), 0.0, 0.0, nullptr);
 
     /* send a notification */
     notify(reason_flappingdisabled, "", "", notifier::notification_option_none);
@@ -2766,10 +2751,8 @@ int host::perform_on_demand_check(enum host::host_state* check_return_code,
                                   unsigned long check_timestamp_horizon) {
   logger(dbg_functions, basic) << "perform_on_demand_host_check()";
 
-  perform_on_demand_check_3x(check_return_code,
-                             check_options,
-                             use_cached_result,
-                             check_timestamp_horizon);
+  perform_on_demand_check_3x(check_return_code, check_options,
+                             use_cached_result, check_timestamp_horizon);
   return OK;
 }
 
@@ -2782,14 +2765,12 @@ int host::perform_on_demand_check_3x(host::host_state* check_result_code,
 
   logger(dbg_functions, basic) << "perform_on_demand_host_check_3x()";
 
-  logger(dbg_checks, basic) << "** On-demand check for host '" << _name
-                            << "'...";
+  logger(dbg_checks, basic)
+      << "** On-demand check for host '" << _name << "'...";
 
   /* check the status of the host */
-  result = this->run_sync_check_3x(check_result_code,
-                                   check_options,
-                                   use_cached_result,
-                                   check_timestamp_horizon);
+  result = this->run_sync_check_3x(check_result_code, check_options,
+                                   use_cached_result, check_timestamp_horizon);
   return result;
 }
 
@@ -2799,20 +2780,17 @@ int host::run_sync_check_3x(enum host::host_state* check_result_code,
                             int check_options,
                             int use_cached_result,
                             unsigned long check_timestamp_horizon) {
-  logger(dbg_functions, basic) << "run_sync_host_check_3x: hst=" << this
-                               << ", check_options=" << check_options
-                               << ", use_cached_result=" << use_cached_result
-                               << ", check_timestamp_horizon="
-                               << check_timestamp_horizon;
+  logger(dbg_functions, basic)
+      << "run_sync_host_check_3x: hst=" << this
+      << ", check_options=" << check_options
+      << ", use_cached_result=" << use_cached_result
+      << ", check_timestamp_horizon=" << check_timestamp_horizon;
 
   try {
-    checks::checker::instance().run_sync(this,
-                                         check_result_code,
-                                         check_options,
+    checks::checker::instance().run_sync(this, check_result_code, check_options,
                                          use_cached_result,
                                          check_timestamp_horizon);
-  }
-  catch (std::exception const& e) {
+  } catch (std::exception const& e) {
     logger(log_runtime_error, basic) << "Error: " << e.what();
     return ERROR;
   }
@@ -2863,9 +2841,9 @@ int host::process_check_result_3x(enum host::host_state new_state,
    * commands by getting dropped in checkresults dir */
   if (get_check_type() == check_passive) {
     if (config->log_passive_checks())
-      logger(log_passive_check, basic) << "PASSIVE HOST CHECK: " << _name << ";"
-                                       << new_state << ";"
-                                       << get_plugin_output();
+      logger(log_passive_check, basic)
+          << "PASSIVE HOST CHECK: " << _name << ";" << new_state << ";"
+          << get_plugin_output();
   }
 
   /******* HOST WAS DOWN/UNREACHABLE INITIALLY *******/
@@ -2903,13 +2881,12 @@ int host::process_check_result_3x(enum host::host_state new_state,
 
       for (host_map_unsafe::iterator it{parent_hosts.begin()},
            end{parent_hosts.end()};
-           it != end;
-           it++) {
+           it != end; it++) {
         if (!it->second)
           continue;
         if (it->second->get_current_state() != host::state_up) {
-          logger(dbg_checks, more) << "Check of parent host '" << it->first
-                                   << "' queued.";
+          logger(dbg_checks, more)
+              << "Check of parent host '" << it->first << "' queued.";
           check_hostlist.push_back(it->second);
         }
       }
@@ -2921,13 +2898,12 @@ int host::process_check_result_3x(enum host::host_state new_state,
 
       for (host_map_unsafe::iterator it{child_hosts.begin()},
            end{child_hosts.end()};
-           it != end;
-           it++) {
+           it != end; it++) {
         if (!it->second)
           continue;
         if (it->second->get_current_state() != host::state_up) {
-          logger(dbg_checks, more) << "Check of child host '" << it->first
-                                   << "' queued.";
+          logger(dbg_checks, more)
+              << "Check of child host '" << it->first << "' queued.";
           check_hostlist.push_back(it->second);
         }
       }
@@ -3046,19 +3022,17 @@ int host::process_check_result_3x(enum host::host_state new_state,
 
           for (host_map_unsafe::iterator it{parent_hosts.begin()},
                end{parent_hosts.end()};
-               it != end;
-               it++) {
+               it != end; it++) {
             if (!it->second)
               continue;
 
             has_parent = true;
 
-            logger(dbg_checks, more) << "Running serial check parent host '"
-                                     << it->first << "'...";
+            logger(dbg_checks, more)
+                << "Running serial check parent host '" << it->first << "'...";
 
             /* run an immediate check of the parent host */
-            it->second->run_sync_check_3x(&parent_state,
-                                          check_options,
+            it->second->run_sync_check_3x(&parent_state, check_options,
                                           use_cached_result,
                                           check_timestamp_horizon);
 
@@ -3105,13 +3079,12 @@ int host::process_check_result_3x(enum host::host_state new_state,
 
         for (host_map_unsafe::iterator it{child_hosts.begin()},
              end{child_hosts.end()};
-             it != end;
-             it++) {
+             it != end; it++) {
           if (!it->second)
             continue;
           if (it->second->get_current_state() != host::state_unreachable) {
-            logger(dbg_checks, more) << "Check of child host '" << it->first
-                                     << "' queued.";
+            logger(dbg_checks, more)
+                << "Check of child host '" << it->first << "' queued.";
             check_hostlist.push_back(it->second);
           }
         }
@@ -3171,14 +3144,13 @@ int host::process_check_result_3x(enum host::host_state new_state,
 
         for (host_map_unsafe::iterator it{parent_hosts.begin()},
              end{parent_hosts.end()};
-             it != end;
-             it++) {
+             it != end; it++) {
           if (it->second == nullptr)
             continue;
           if (it->second->get_current_state() == host::state_up) {
             check_hostlist.push_back(it->second);
-            logger(dbg_checks, more) << "Check of host '" << it->first
-                                     << "' queued.";
+            logger(dbg_checks, more)
+                << "Check of host '" << it->first << "' queued.";
           }
         }
 
@@ -3190,13 +3162,12 @@ int host::process_check_result_3x(enum host::host_state new_state,
 
         for (host_map_unsafe::iterator it{child_hosts.begin()},
              end{child_hosts.end()};
-             it != end;
-             it++) {
+             it != end; it++) {
           if (!it->second)
             continue;
           if (it->second->get_current_state() != host::state_unreachable) {
-            logger(dbg_checks, more) << "Check of child host '" << it->first
-                                     << "' queued.";
+            logger(dbg_checks, more)
+                << "Check of child host '" << it->first << "' queued.";
             check_hostlist.push_back(it->second);
           }
         }
@@ -3215,15 +3186,14 @@ int host::process_check_result_3x(enum host::host_state new_state,
           for (hostdependency_mmap::const_iterator
                    it{hostdependency::hostdependencies.find(_name)},
                end{hostdependency::hostdependencies.end()};
-               it != end && it->first == _name;
-               ++it) {
+               it != end && it->first == _name; ++it) {
             hostdependency* temp_dependency(it->second.get());
             if (temp_dependency->dependent_host_ptr == this &&
                 temp_dependency->master_host_ptr != nullptr) {
               master_host = (host*)temp_dependency->master_host_ptr;
-              logger(dbg_checks, more) << "Check of host '"
-                                       << master_host->get_name()
-                                       << "' queued.";
+              logger(dbg_checks, more)
+                  << "Check of host '" << master_host->get_name()
+                  << "' queued.";
               check_hostlist.push_back(master_host);
             }
           }
@@ -3271,8 +3241,8 @@ int host::process_check_result_3x(enum host::host_state new_state,
    * checks, unless overridden above) */
   bool sent = false;
   if (reschedule_check) {
-    logger(dbg_checks, more) << "Rescheduling next check of host at "
-                             << my_ctime(&next_check);
+    logger(dbg_checks, more)
+        << "Rescheduling next check of host at " << my_ctime(&next_check);
 
     /* default is to reschedule host check unless a test below fails... */
     set_should_be_scheduled(true);
@@ -3321,20 +3291,17 @@ int host::process_check_result_3x(enum host::host_state new_state,
    * cached state */
   for (std::list<host*>::iterator it{check_hostlist.begin()},
        end{check_hostlist.end()};
-       it != end;
-       ++it) {
+       it != end; ++it) {
     run_async_check = true;
     temp_host = *it;
 
-    logger(dbg_checks, most) << "ASYNC CHECK OF HOST: " << temp_host->get_name()
-                             << ", CURRENTTIME: " << current_time
-                             << ", LASTHOSTCHECK: "
-                             << temp_host->get_last_check()
-                             << ", CACHEDTIMEHORIZON: "
-                             << check_timestamp_horizon
-                             << ", USECACHEDRESULT: " << use_cached_result
-                             << ", ISEXECUTING: "
-                             << temp_host->get_is_executing();
+    logger(dbg_checks, most)
+        << "ASYNC CHECK OF HOST: " << temp_host->get_name()
+        << ", CURRENTTIME: " << current_time
+        << ", LASTHOSTCHECK: " << temp_host->get_last_check()
+        << ", CACHEDTIMEHORIZON: " << check_timestamp_horizon
+        << ", USECACHEDRESULT: " << use_cached_result
+        << ", ISEXECUTING: " << temp_host->get_is_executing();
 
     if (use_cached_result && (static_cast<unsigned long>(
                                   current_time - temp_host->get_last_check()) <=
@@ -3343,8 +3310,8 @@ int host::process_check_result_3x(enum host::host_state new_state,
     if (temp_host->get_is_executing())
       run_async_check = false;
     if (run_async_check)
-      temp_host->run_async_check(
-          CHECK_OPTION_NONE, 0.0, false, false, nullptr, nullptr);
+      temp_host->run_async_check(CHECK_OPTION_NONE, 0.0, false, false, nullptr,
+                                 nullptr);
   }
   return OK;
 }
@@ -3382,8 +3349,7 @@ enum host::host_state host::determine_host_reachability() {
   else {
     for (host_map_unsafe::iterator it{parent_hosts.begin()},
          end{parent_hosts.end()};
-         it != end;
-         it++) {
+         it != end; it++) {
       if (!it->second)
         continue;
 
@@ -3411,7 +3377,9 @@ std::list<hostgroup*> const& host::get_parent_groups() const {
   return _hostgroups;
 }
 
-std::list<hostgroup*>& host::get_parent_groups() { return _hostgroups; }
+std::list<hostgroup*>& host::get_parent_groups() {
+  return _hostgroups;
+}
 
 /**
  *  This function returns a boolean telling if the master hosts of this one
@@ -3426,8 +3394,7 @@ bool host::authorized_by_dependencies(dependency::types dependency_type) const {
 
   auto p(hostdependency::hostdependencies.equal_range(_name));
   for (hostdependency_mmap::const_iterator it{p.first}, end{p.second};
-       it != end;
-       ++it) {
+       it != end; ++it) {
     hostdependency* dep{it->second.get()};
     /* Only check dependencies of the desired type (notification or execution)
      */
@@ -3490,8 +3457,7 @@ void host::check_result_freshness() {
 
   /* check all hosts... */
   for (host_map::iterator it{host::hosts.begin()}, end{host::hosts.end()};
-       it != end;
-       ++it) {
+       it != end; ++it) {
     /* skip hosts we shouldn't be checking for freshness */
     if (!it->second->get_check_freshness())
       continue;
@@ -3577,8 +3543,7 @@ void host::check_for_orphaned() {
 
   /* check all hosts... */
   for (host_map::iterator it{host::hosts.begin()}, end{host::hosts.end()};
-       it != end;
-       ++it) {
+       it != end; ++it) {
     /* skip hosts that don't have a set check interval (on-demand checks are
      * missed by the orphan logic) */
     if (it->second->get_next_check() == (time_t)0L)
@@ -3630,7 +3595,9 @@ bool host::get_notify_on_current_state() const {
   return retval;
 }
 
-bool host::is_in_downtime() const { return get_scheduled_downtime_depth() > 0; }
+bool host::is_in_downtime() const {
+  return get_scheduled_downtime_depth() > 0;
+}
 
 /**
  *  This method resolves pointers involved in this host life. If a pointer
@@ -3645,8 +3612,7 @@ void host::resolve(int& w, int& e) {
 
   try {
     notifier::resolve(warnings, errors);
-  }
-  catch (std::exception const& e) {
+  } catch (std::exception const& e) {
     logger(log_verification_error, basic)
         << "Error: Host '" << _name
         << "' has problem in its notifier part: " << e.what();
@@ -3654,8 +3620,7 @@ void host::resolve(int& w, int& e) {
 
   for (service_map::iterator it_svc{service::services.begin()},
        end_svc{service::services.end()};
-       it_svc != end_svc;
-       ++it_svc) {
+       it_svc != end_svc; ++it_svc) {
     if (_name == it_svc->first.first)
       services.insert({it_svc->first, nullptr});
   }
@@ -3667,8 +3632,7 @@ void host::resolve(int& w, int& e) {
     ++w;
   } else {
     for (service_map_unsafe::iterator it{services.begin()}, end{services.end()};
-         it != end;
-         ++it) {
+         it != end; ++it) {
       service_map::const_iterator found{service::services.find(it->first)};
       if (found == service::services.end() || !found->second) {
         logger(log_verification_error, basic)
@@ -3684,14 +3648,13 @@ void host::resolve(int& w, int& e) {
   /* check all parent parent host */
   for (host_map_unsafe::iterator it(parent_hosts.begin()),
        end(parent_hosts.end());
-       it != end;
-       it++) {
+       it != end; it++) {
     host_map::const_iterator it_host{host::hosts.find(it->first)};
     if (it_host == host::hosts.end() || !it_host->second) {
-      logger(log_verification_error, basic)
-          << "Error: '" << it->first << "' is not a "
-                                        "valid parent for host '" << _name
-          << "'!";
+      logger(log_verification_error, basic) << "Error: '" << it->first
+                                            << "' is not a "
+                                               "valid parent for host '"
+                                            << _name << "'!";
       errors++;
     } else {
       it->second = it_host->second.get();

--- a/src/host.cc
+++ b/src/host.cc
@@ -53,8 +53,7 @@ using namespace com::centreon::engine::logging;
 using namespace com::centreon::engine::string;
 
 std::array<std::pair<uint32_t, std::string>, 3> const host::tab_host_states{
-    {{NSLOG_HOST_UP, "UP"},
-     {NSLOG_HOST_DOWN, "DOWN"},
+    {{NSLOG_HOST_UP, "UP"}, {NSLOG_HOST_DOWN, "DOWN"},
      {NSLOG_HOST_UNREACHABLE, "UNREACHABLE"}}};
 
 host_map host::hosts;
@@ -191,14 +190,9 @@ host::host(uint64_t host_id,
            bool retain_nonstatus_information,
            bool obsess_over_host,
            std::string const& timezone)
-    : notifier{host_notification,
-               !display_name.empty() ? display_name : name,
-               check_command,
-               checks_enabled,
-               accept_passive_checks,
-               check_interval,
-               retry_interval,
-               notification_interval,
+    : notifier{host_notification, !display_name.empty() ? display_name : name,
+               check_command, checks_enabled, accept_passive_checks,
+               check_interval, retry_interval, notification_interval,
                max_attempts,
                (notify_up > 0 ? up : 0) | (notify_down > 0 ? down : 0) |
                    (notify_downtime > 0 ? downtime : 0) |
@@ -209,27 +203,13 @@ host::host(uint64_t host_id,
                (stalk_on_down > 0 ? down : 0) |
                    (stalk_on_unreachable > 0 ? unreachable : 0) |
                    (stalk_on_up > 0 ? up : 0),
-               first_notification_delay,
-               recovery_notification_delay,
-               notification_period,
-               notifications_enabled,
-               check_period,
-               event_handler,
-               event_handler_enabled,
-               notes,
-               notes_url,
-               action_url,
-               icon_image,
-               icon_image_alt,
-               flap_detection_enabled,
-               low_flap_threshold,
-               high_flap_threshold,
-               check_freshness,
-               freshness_threshold,
-               obsess_over_host,
-               timezone,
-               retain_status_information > 0,
-               retain_nonstatus_information > 0,
+               first_notification_delay, recovery_notification_delay,
+               notification_period, notifications_enabled, check_period,
+               event_handler, event_handler_enabled, notes, notes_url,
+               action_url, icon_image, icon_image_alt, flap_detection_enabled,
+               low_flap_threshold, high_flap_threshold, check_freshness,
+               freshness_threshold, obsess_over_host, timezone,
+               retain_status_information > 0, retain_nonstatus_information > 0,
                false},
       _id{host_id},
       _name{name},
@@ -272,8 +252,8 @@ host::host(uint64_t host_id,
   // Check if the host already exists.
   uint64_t id{host_id};
   if (is_host_exist(id)) {
-    logger(log_config_error, basic)
-        << "Error: Host '" << name << "' has already been defined";
+    logger(log_config_error, basic) << "Error: Host '" << name
+                                    << "' has already been defined";
     throw engine_error() << "Could not register host '" << name << "'";
   }
 
@@ -289,13 +269,9 @@ host::host(uint64_t host_id,
                 (flap_detection_on_up > 0 ? up : 0));
 }
 
-uint64_t host::get_host_id(void) const {
-  return _id;
-}
+uint64_t host::get_host_id(void) const { return _id; }
 
-void host::set_host_id(uint64_t id) {
-  _id = id;
-}
+void host::set_host_id(uint64_t id) { _id = id; }
 
 void host::add_child_host(host* child) {
   // Make sure we have the data we need.
@@ -306,8 +282,14 @@ void host::add_child_host(host* child) {
 
   // Notify event broker.
   timeval tv(get_broker_timestamp(nullptr));
-  broker_relation_data(NEBTYPE_PARENT_ADD, NEBFLAG_NONE, NEBATTR_NONE, this,
-                       nullptr, child, nullptr, &tv);
+  broker_relation_data(NEBTYPE_PARENT_ADD,
+                       NEBFLAG_NONE,
+                       NEBATTR_NONE,
+                       this,
+                       nullptr,
+                       child,
+                       nullptr,
+                       &tv);
 }
 
 void host::add_parent_host(std::string const& host_name) {
@@ -320,37 +302,25 @@ void host::add_parent_host(std::string const& host_name) {
 
   // A host cannot be a parent/child of itself.
   if (_name == host_name) {
-    logger(log_config_error, basic)
-        << "Error: Host '" << _name << "' cannot be a child/parent of itself";
+    logger(log_config_error, basic) << "Error: Host '" << _name
+                                    << "' cannot be a child/parent of itself";
     throw engine_error() << "host is child/parent itself";
   }
 
   parent_hosts.insert({host_name, nullptr});
 }
 
-std::string const& host::get_name() const {
-  return _name;
-}
+std::string const& host::get_name() const { return _name; }
 
-void host::set_name(std::string const& name) {
-  _name = name;
-}
+void host::set_name(std::string const& name) { _name = name; }
 
-std::string const& host::get_alias() const {
-  return _alias;
-}
+std::string const& host::get_alias() const { return _alias; }
 
-void host::set_alias(std::string const& alias) {
-  _alias = alias;
-}
+void host::set_alias(std::string const& alias) { _alias = alias; }
 
-std::string const& host::get_address() const {
-  return _address;
-}
+std::string const& host::get_address() const { return _address; }
 
-void host::set_address(std::string const& address) {
-  _address = address;
-}
+void host::set_address(std::string const& address) { _address = address; }
 
 bool host::get_process_performance_data() const {
   return _process_performance_data;
@@ -360,13 +330,9 @@ void host::set_process_performance_data(bool process_performance_data) {
   _process_performance_data = process_performance_data;
 }
 
-std::string const& host::get_vrml_image() const {
-  return _vrml_image;
-}
+std::string const& host::get_vrml_image() const { return _vrml_image; }
 
-void host::set_vrml_image(std::string const& image) {
-  _vrml_image = image;
-}
+void host::set_vrml_image(std::string const& image) { _vrml_image = image; }
 
 std::string const& host::get_statusmap_image() const {
   return _statusmap_image;
@@ -376,96 +342,55 @@ void host::set_statusmap_image(std::string const& image) {
   _statusmap_image = image;
 }
 
-bool host::get_have_2d_coords() const {
-  return _have_2d_coords;
-}
+bool host::get_have_2d_coords() const { return _have_2d_coords; }
 
-void host::set_have_2d_coords(bool has_coords) {
-  _have_2d_coords = has_coords;
-}
+void host::set_have_2d_coords(bool has_coords) { _have_2d_coords = has_coords; }
 
-bool host::get_have_3d_coords() const {
-  return _have_3d_coords;
-}
+bool host::get_have_3d_coords() const { return _have_3d_coords; }
 
-void host::set_have_3d_coords(bool has_coords) {
-  _have_3d_coords = has_coords;
-}
+void host::set_have_3d_coords(bool has_coords) { _have_3d_coords = has_coords; }
 
-double host::get_x_2d() const {
-  return _x_2d;
-}
+double host::get_x_2d() const { return _x_2d; }
 
-void host::set_x_2d(double x) {
-  _x_2d = x;
-}
+void host::set_x_2d(double x) { _x_2d = x; }
 
-double host::get_y_2d() const {
-  return _y_2d;
-}
+double host::get_y_2d() const { return _y_2d; }
 
-void host::set_y_2d(double y) {
-  _y_2d = y;
-}
+void host::set_y_2d(double y) { _y_2d = y; }
 
-double host::get_x_3d() const {
-  return _x_3d;
-}
+double host::get_x_3d() const { return _x_3d; }
 
-void host::set_x_3d(double x) {
-  _x_3d = x;
-}
+void host::set_x_3d(double x) { _x_3d = x; }
 
-double host::get_y_3d() const {
-  return _y_3d;
-}
+double host::get_y_3d() const { return _y_3d; }
 
-void host::set_y_3d(double y) {
-  _y_3d = y;
-}
+void host::set_y_3d(double y) { _y_3d = y; }
 
-double host::get_z_3d() const {
-  return _z_3d;
-}
+double host::get_z_3d() const { return _z_3d; }
 
-void host::set_z_3d(double z) {
-  _z_3d = z;
-}
+void host::set_z_3d(double z) { _z_3d = z; }
 
-int host::get_should_be_drawn() const {
-  return _should_be_drawn;
-}
+int host::get_should_be_drawn() const { return _should_be_drawn; }
 
 void host::set_should_be_drawn(int should_be_drawn) {
   _should_be_drawn = should_be_drawn;
 }
 
-time_t host::get_last_time_down() const {
-  return _last_time_down;
-}
+time_t host::get_last_time_down() const { return _last_time_down; }
 
-void host::set_last_time_down(time_t last_time) {
-  assert(last_time < 2000000000);
-  _last_time_down = last_time;
-}
+void host::set_last_time_down(time_t last_time) { _last_time_down = last_time; }
 
 time_t host::get_last_time_unreachable() const {
   return _last_time_unreachable;
 }
 
 void host::set_last_time_unreachable(time_t last_time) {
-  assert(last_time < 2000000000);
   _last_time_unreachable = last_time;
 }
 
-time_t host::get_last_time_up() const {
-  return _last_time_up;
-}
+time_t host::get_last_time_up() const { return _last_time_up; }
 
-void host::set_last_time_up(time_t last_time) {
-  assert(last_time < 2000000000);
-  _last_time_up = last_time;
-}
+void host::set_last_time_up(time_t last_time) { _last_time_up = last_time; }
 
 bool host::get_should_reschedule_current_check() const {
   return _should_reschedule_current_check;
@@ -483,9 +408,7 @@ void host::set_last_state_history_update(time_t last_state_history_update) {
   _last_state_history_update = last_state_history_update;
 }
 
-int host::get_total_services() const {
-  return _total_services;
-}
+int host::get_total_services() const { return _total_services; }
 
 void host::set_total_services(int total_services) {
   _total_services = total_services;
@@ -500,9 +423,7 @@ void host::set_total_service_check_interval(
   _total_service_check_interval = total_service_check_interval;
 }
 
-int host::get_circular_path_checked() const {
-  return _circular_path_checked;
-}
+int host::get_circular_path_checked() const { return _circular_path_checked; }
 
 void host::set_circular_path_checked(int check_level) {
   _circular_path_checked = check_level;
@@ -516,17 +437,13 @@ void host::set_contains_circular_path(bool contains_circular_path) {
   _contains_circular_path = contains_circular_path;
 }
 
-enum host::host_state host::get_current_state() const {
-  return _current_state;
-}
+enum host::host_state host::get_current_state() const { return _current_state; }
 
 void host::set_current_state(enum host::host_state current_state) {
   _current_state = current_state;
 }
 
-enum host::host_state host::get_last_state() const {
-  return _last_state;
-}
+enum host::host_state host::get_last_state() const { return _last_state; }
 
 void host::set_last_state(enum host::host_state last_state) {
   _last_state = last_state;
@@ -540,17 +457,13 @@ void host::set_last_hard_state(enum host::host_state last_hard_state) {
   _last_hard_state = last_hard_state;
 }
 
-enum host::host_state host::get_initial_state() const {
-  return _initial_state;
-}
+enum host::host_state host::get_initial_state() const { return _initial_state; }
 
 void host::set_initial_state(enum host::host_state current_state) {
   _initial_state = current_state;
 }
 
-bool host::recovered() const {
-  return _current_state == host::state_up;
-}
+bool host::recovered() const { return _current_state == host::state_up; }
 
 int host::get_current_state_int() const {
   return static_cast<int>(_current_state);
@@ -558,7 +471,8 @@ int host::get_current_state_int() const {
 
 std::ostream& operator<<(std::ostream& os, host_map_unsafe const& obj) {
   for (host_map_unsafe::const_iterator it{obj.begin()}, end{obj.end()};
-       it != end; ++it) {
+       it != end;
+       ++it) {
     os << it->first;
     if (next(it) != end)
       os << ", ";
@@ -632,7 +546,7 @@ std::ostream& operator<<(std::ostream& os, host const& obj) {
   {
     std::ostringstream oss;
     for (int i = 0; i < 6; i++) {
-      std::shared_ptr<notification> s{obj.get_current_notifications()[i]};
+      notification* s{obj.get_current_notifications()[i].get()};
       if (s)
         oss << "  notification_" << i << ": " << *s;
     }
@@ -640,50 +554,35 @@ std::ostream& operator<<(std::ostream& os, host const& obj) {
   }
 
   os << "host {\n"
-        "  name:                                 "
-     << obj.get_name()
+        "  name:                                 " << obj.get_name()
      << "\n"
-        "  display_name:                         "
-     << obj.get_display_name()
+        "  display_name:                         " << obj.get_display_name()
      << "\n"
-        "  alias:                                "
-     << obj.get_alias()
+        "  alias:                                " << obj.get_alias()
      << "\n"
-        "  address:                              "
-     << obj.get_address()
+        "  address:                              " << obj.get_address()
      << "\n"
-        "  parent_hosts:                         "
-     << p_oss
+        "  parent_hosts:                         " << p_oss
      << "\n"
-        "  child_hosts:                          "
-     << child_oss
+        "  child_hosts:                          " << child_oss
      << "\n"
-        "  services:                             "
-     << obj.services
+        "  services:                             " << obj.services
      << "\n"
-        "  host_check_command:                   "
-     << obj.get_check_command()
+        "  host_check_command:                   " << obj.get_check_command()
      << "\n"
-        "  initial_state:                        "
-     << obj.get_initial_state()
+        "  initial_state:                        " << obj.get_initial_state()
      << "\n"
-        "  check_interval:                       "
-     << obj.get_check_interval()
+        "  check_interval:                       " << obj.get_check_interval()
      << "\n"
-        "  retry_interval:                       "
-     << obj.get_retry_interval()
+        "  retry_interval:                       " << obj.get_retry_interval()
      << "\n"
-        "  max_attempts:                         "
-     << obj.get_max_attempts()
+        "  max_attempts:                         " << obj.get_max_attempts()
      << "\n"
-        "  event_handler:                        "
-     << obj.get_event_handler()
+        "  event_handler:                        " << obj.get_event_handler()
      << "\n"
-        "  contact_groups:                       "
-     << cg_oss
+        "  contact_groups:                       " << cg_oss
      << "\n"
-        "  contacts:                             "
-     << c_oss
+        "  contacts:                             " << c_oss
      << "\n"
         "  notification_interval:                "
      << obj.get_notification_interval()
@@ -716,8 +615,7 @@ std::ostream& operator<<(std::ostream& os, host const& obj) {
      << obj.get_notify_on(notifier::downtime)
      << "\n"
         "  notification_period:                  "
-     << obj.get_notification_period() << "\n"
-     << notifications
+     << obj.get_notification_period() << "\n" << notifications
      << "  check_period:                         " << obj.get_check_period()
      << "\n"
         "  flap_detection_enabled:               "
@@ -747,8 +645,7 @@ std::ostream& operator<<(std::ostream& os, host const& obj) {
         "  stalk_on_unreachable:                 "
      << obj.get_stalk_on(notifier::unreachable)
      << "\n"
-        "  check_freshness:                      "
-     << obj.get_check_freshness()
+        "  check_freshness:                      " << obj.get_check_freshness()
      << "\n"
         "  freshness_threshold:                  "
      << obj.get_freshness_threshold()
@@ -756,8 +653,7 @@ std::ostream& operator<<(std::ostream& os, host const& obj) {
         "  process_performance_data:             "
      << obj.get_process_performance_data()
      << "\n"
-        "  checks_enabled:                       "
-     << obj.get_checks_enabled()
+        "  checks_enabled:                       " << obj.get_checks_enabled()
      << "\n"
         "  accept_passive_checks:                "
      << obj.get_accept_passive_checks()
@@ -771,53 +667,37 @@ std::ostream& operator<<(std::ostream& os, host const& obj) {
         "  retain_nonstatus_information:         "
      << obj.get_retain_nonstatus_information()
      << "\n"
-        "  obsess_over_host:                     "
-     << obj.get_obsess_over()
+        "  obsess_over_host:                     " << obj.get_obsess_over()
      << "\n"
-        "  notes:                                "
-     << obj.get_notes()
+        "  notes:                                " << obj.get_notes()
      << "\n"
-        "  notes_url:                            "
-     << obj.get_notes_url()
+        "  notes_url:                            " << obj.get_notes_url()
      << "\n"
-        "  action_url:                           "
-     << obj.get_action_url()
+        "  action_url:                           " << obj.get_action_url()
      << "\n"
-        "  icon_image:                           "
-     << obj.get_icon_image()
+        "  icon_image:                           " << obj.get_icon_image()
      << "\n"
-        "  icon_image_alt:                       "
-     << obj.get_icon_image_alt()
+        "  icon_image_alt:                       " << obj.get_icon_image_alt()
      << "\n"
-        "  vrml_image:                           "
-     << obj.get_vrml_image()
+        "  vrml_image:                           " << obj.get_vrml_image()
      << "\n"
-        "  statusmap_image:                      "
-     << obj.get_statusmap_image()
+        "  statusmap_image:                      " << obj.get_statusmap_image()
      << "\n"
-        "  have_2d_coords:                       "
-     << obj.get_have_2d_coords()
+        "  have_2d_coords:                       " << obj.get_have_2d_coords()
      << "\n"
-        "  x_2d:                                 "
-     << obj.get_x_2d()
+        "  x_2d:                                 " << obj.get_x_2d()
      << "\n"
-        "  y_2d:                                 "
-     << obj.get_y_2d()
+        "  y_2d:                                 " << obj.get_y_2d()
      << "\n"
-        "  have_3d_coords:                       "
-     << obj.get_have_3d_coords()
+        "  have_3d_coords:                       " << obj.get_have_3d_coords()
      << "\n"
-        "  x_3d:                                 "
-     << obj.get_x_3d()
+        "  x_3d:                                 " << obj.get_x_3d()
      << "\n"
-        "  y_3d:                                 "
-     << obj.get_y_3d()
+        "  y_3d:                                 " << obj.get_y_3d()
      << "\n"
-        "  z_3d:                                 "
-     << obj.get_z_3d()
+        "  z_3d:                                 " << obj.get_z_3d()
      << "\n"
-        "  should_be_drawn:                      "
-     << obj.get_should_be_drawn()
+        "  should_be_drawn:                      " << obj.get_should_be_drawn()
      << "\n"
         "  problem_has_been_acknowledged:        "
      << obj.get_problem_has_been_acknowledged()
@@ -825,56 +705,41 @@ std::ostream& operator<<(std::ostream& os, host const& obj) {
         "  acknowledgement_type:                 "
      << obj.get_acknowledgement_type()
      << "\n"
-        "  check_type:                           "
-     << obj.get_check_type()
+        "  check_type:                           " << obj.get_check_type()
      << "\n"
-        "  current_state:                        "
-     << obj.get_current_state()
+        "  current_state:                        " << obj.get_current_state()
      << "\n"
-        "  last_state:                           "
-     << obj.get_last_state()
+        "  last_state:                           " << obj.get_last_state()
      << "\n"
-        "  last_hard_state:                      "
-     << obj.get_last_hard_state()
+        "  last_hard_state:                      " << obj.get_last_hard_state()
      << "\n"
-        "  plugin_output:                        "
-     << obj.get_plugin_output()
+        "  plugin_output:                        " << obj.get_plugin_output()
      << "\n"
         "  long_plugin_output:                   "
      << obj.get_long_plugin_output()
      << "\n"
-        "  perf_data:                            "
-     << obj.get_perf_data()
+        "  perf_data:                            " << obj.get_perf_data()
      << "\n"
-        "  state_type:                           "
-     << obj.get_state_type()
+        "  state_type:                           " << obj.get_state_type()
      << "\n"
-        "  current_attempt:                      "
-     << obj.get_current_attempt()
+        "  current_attempt:                      " << obj.get_current_attempt()
      << "\n"
-        "  current_event_id:                     "
-     << obj.get_current_event_id()
+        "  current_event_id:                     " << obj.get_current_event_id()
      << "\n"
-        "  last_event_id:                        "
-     << obj.get_last_event_id()
+        "  last_event_id:                        " << obj.get_last_event_id()
      << "\n"
         "  current_problem_id:                   "
      << obj.get_current_problem_id()
      << "\n"
-        "  last_problem_id:                      "
-     << obj.get_last_problem_id()
+        "  last_problem_id:                      " << obj.get_last_problem_id()
      << "\n"
-        "  latency:                              "
-     << obj.get_latency()
+        "  latency:                              " << obj.get_latency()
      << "\n"
-        "  execution_time:                       "
-     << obj.get_execution_time()
+        "  execution_time:                       " << obj.get_execution_time()
      << "\n"
-        "  is_executing:                         "
-     << obj.get_is_executing()
+        "  is_executing:                         " << obj.get_is_executing()
      << "\n"
-        "  check_options:                        "
-     << obj.get_check_options()
+        "  check_options:                        " << obj.get_check_options()
      << "\n"
         "  notifications_enabled:                "
      << obj.get_notifications_enabled()
@@ -909,8 +774,7 @@ std::ostream& operator<<(std::ostream& os, host const& obj) {
         "  last_time_unreachable:                "
      << string::ctime(obj.get_last_time_unreachable())
      << "\n"
-        "  has_been_checked:                     "
-     << obj.has_been_checked()
+        "  has_been_checked:                     " << obj.has_been_checked()
      << "\n"
         "  is_being_freshened:                   "
      << obj.get_is_being_freshened()
@@ -943,8 +807,7 @@ std::ostream& operator<<(std::ostream& os, host const& obj) {
         "  last_state_history_update:            "
      << string::ctime(obj.get_last_state_history_update())
      << "\n"
-        "  is_flapping:                          "
-     << obj.get_is_flapping()
+        "  is_flapping:                          " << obj.get_is_flapping()
      << "\n"
         "  flapping_comment_id:                  "
      << obj.get_flapping_comment_id()
@@ -952,8 +815,7 @@ std::ostream& operator<<(std::ostream& os, host const& obj) {
         "  percent_state_change:                 "
      << obj.get_percent_state_change()
      << "\n"
-        "  total_services:                       "
-     << obj.get_total_services()
+        "  total_services:                       " << obj.get_total_services()
      << "\n"
         "  total_service_check_interval:         "
      << obj.get_total_service_check_interval()
@@ -967,17 +829,13 @@ std::ostream& operator<<(std::ostream& os, host const& obj) {
         "  contains_circular_path:               "
      << obj.get_contains_circular_path()
      << "\n"
-        "  event_handler_ptr:                    "
-     << evt_str
+        "  event_handler_ptr:                    " << evt_str
      << "\n"
-        "  check_command_ptr:                    "
-     << cmd_str
+        "  check_command_ptr:                    " << cmd_str
      << "\n"
-        "  check_period_ptr:                     "
-     << chk_period_str
+        "  check_period_ptr:                     " << chk_period_str
      << "\n"
-        "  notification_period_ptr:              "
-     << notif_period_str
+        "  notification_period_ptr:              " << notif_period_str
      << "\n"
         "  hostgroups_ptr:                       "
      << (hg ? hg->get_group_name() : "") << "\n";
@@ -1047,7 +905,8 @@ int is_host_immediate_parent_of_host(com::centreon::engine::host* child_host,
 int number_of_immediate_child_hosts(com::centreon::engine::host* hst) {
   int children(0);
   for (host_map::iterator it{host::hosts.begin()}, end{host::hosts.end()};
-       it != end; ++it)
+       it != end;
+       ++it)
     if (is_host_immediate_child_of_host(hst, it->second.get()))
       ++children;
   return children;
@@ -1065,7 +924,8 @@ int number_of_immediate_child_hosts(com::centreon::engine::host* hst) {
 int number_of_immediate_parent_hosts(com::centreon::engine::host* hst) {
   int parents(0);
   for (host_map::iterator it{host::hosts.begin()}, end{host::hosts.end()};
-       it != end; ++it)
+       it != end;
+       ++it)
     if (is_host_immediate_parent_of_host(hst, it->second.get()))
       ++parents;
   return parents;
@@ -1083,7 +943,8 @@ int number_of_immediate_parent_hosts(com::centreon::engine::host* hst) {
 int number_of_total_child_hosts(com::centreon::engine::host* hst) {
   int children(0);
   for (host_map::iterator it{host::hosts.begin()}, end{host::hosts.end()};
-       it != end; ++it)
+       it != end;
+       ++it)
     if (is_host_immediate_child_of_host(hst, it->second.get()))
       children += number_of_total_child_hosts(it->second.get()) + 1;
   return children;
@@ -1101,7 +962,8 @@ int number_of_total_child_hosts(com::centreon::engine::host* hst) {
 int number_of_total_parent_hosts(com::centreon::engine::host* hst) {
   int parents(0);
   for (host_map::iterator it{host::hosts.begin()}, end{host::hosts.end()};
-       it != end; ++it)
+       it != end;
+       ++it)
     if (is_host_immediate_parent_of_host(hst, it->second.get()))
       parents += number_of_total_parent_hosts(it->second.get()) + 1;
   return parents;
@@ -1155,8 +1017,14 @@ void host::schedule_acknowledgement_expiration() {
       get_last_acknowledgement() != (time_t)0) {
     timed_event* evt = new timed_event(
         timed_event::EVENT_EXPIRE_HOST_ACK,
-        get_last_acknowledgement() + get_acknowledgement_timeout(), false, 0,
-        nullptr, true, this, nullptr, 0);
+        get_last_acknowledgement() + get_acknowledgement_timeout(),
+        false,
+        0,
+        nullptr,
+        true,
+        this,
+        nullptr,
+        0);
     events::loop::instance().schedule(evt, false);
   }
 }
@@ -1179,17 +1047,22 @@ int host::log_event() {
   }
   std::string const& state_type(tab_state_type[get_state_type()]);
 
-  logger(log_options, basic)
-      << "HOST ALERT: " << get_name() << ";" << state << ";" << state_type
-      << ";" << get_current_attempt() << ";" << get_plugin_output();
+  logger(log_options, basic) << "HOST ALERT: " << get_name() << ";" << state
+                             << ";" << state_type << ";"
+                             << get_current_attempt() << ";"
+                             << get_plugin_output();
 
   return OK;
 }
 
 /* process results of an asynchronous host check */
 int host::handle_async_check_result_3x(check_result* queued_check_result) {
-  enum service::service_state svc_res{service::state_ok};
-  enum host::host_state hst_res{host::state_up};
+  enum service::service_state svc_res {
+    service::state_ok
+  };
+  enum host::host_state hst_res {
+    host::state_up
+  };
   int reschedule_check{false};
   std::string old_plugin_output;
   struct timeval start_time_hires;
@@ -1343,8 +1216,8 @@ int host::handle_async_check_result_3x(check_result* queued_check_result) {
   std::string plugin_output;
   std::string long_plugin_output;
   std::string perf_data;
-  parse_check_output(output, plugin_output, long_plugin_output, perf_data, true,
-                     false);
+  parse_check_output(
+      output, plugin_output, long_plugin_output, perf_data, true, false);
   set_plugin_output(plugin_output);
   set_long_plugin_output(long_plugin_output);
   set_perf_data(perf_data);
@@ -1367,8 +1240,7 @@ int host::handle_async_check_result_3x(check_result* queued_check_result) {
       << "Long Output:\n"
       << (get_long_plugin_output().empty() ? "NULL" : get_long_plugin_output())
       << "\n"
-      << "Perf Data:\n"
-      << (get_perf_data().empty() ? "NULL" : get_perf_data());
+      << "Perf Data:\n" << (get_perf_data().empty() ? "NULL" : get_perf_data());
 
   /* get the unprocessed return code */
   /* NOTE: for passive checks, this is the final/processed state */
@@ -1382,9 +1254,9 @@ int host::handle_async_check_result_3x(check_result* queued_check_result) {
     /* if there was some error running the command, just skip it (this shouldn't
      * be happening) */
     if (!queued_check_result->get_exited_ok()) {
-      logger(log_runtime_warning, basic)
-          << "Warning:  Check of host '" << get_name()
-          << "' did not exit properly!";
+      logger(log_runtime_warning, basic) << "Warning:  Check of host '"
+                                         << get_name()
+                                         << "' did not exit properly!";
 
       set_plugin_output("(Host check did not exit properly)");
       set_long_plugin_output("");
@@ -1412,8 +1284,7 @@ int host::handle_async_check_result_3x(check_result* queued_check_result) {
           << ((queued_check_result->get_return_code() == 126 ||
                queued_check_result->get_return_code() == 127)
                   ? " - plugin may be missing"
-                  : "")
-          << ")";
+                  : "") << ")";
 
       set_plugin_output(oss.str());
       set_long_plugin_output("");
@@ -1451,8 +1322,11 @@ int host::handle_async_check_result_3x(check_result* queued_check_result) {
   /******************* PROCESS THE CHECK RESULTS ******************/
 
   /* process the host check result */
-  process_check_result_3x(hst_res, old_plugin_output, CHECK_OPTION_NONE,
-                          reschedule_check, true,
+  process_check_result_3x(hst_res,
+                          old_plugin_output,
+                          CHECK_OPTION_NONE,
+                          reschedule_check,
+                          true,
                           config->cached_host_check_horizon());
 
   logger(dbg_checks, more) << "** Async check result for host '" << get_name()
@@ -1465,16 +1339,26 @@ int host::handle_async_check_result_3x(check_result* queued_check_result) {
   gettimeofday(&end_time_hires, nullptr);
 
   /* send data to event broker */
-  broker_host_check(NEBTYPE_HOSTCHECK_PROCESSED, NEBFLAG_NONE, NEBATTR_NONE,
-                    this, get_check_type(), get_current_state(),
-                    get_state_type(), start_time_hires, end_time_hires,
-                    get_check_command().c_str(), get_latency(),
-                    get_execution_time(), config->host_check_timeout(),
+  broker_host_check(NEBTYPE_HOSTCHECK_PROCESSED,
+                    NEBFLAG_NONE,
+                    NEBATTR_NONE,
+                    this,
+                    get_check_type(),
+                    get_current_state(),
+                    get_state_type(),
+                    start_time_hires,
+                    end_time_hires,
+                    get_check_command().c_str(),
+                    get_latency(),
+                    get_execution_time(),
+                    config->host_check_timeout(),
                     queued_check_result->get_early_timeout(),
-                    queued_check_result->get_return_code(), nullptr,
+                    queued_check_result->get_return_code(),
+                    nullptr,
                     const_cast<char*>(get_plugin_output().c_str()),
                     const_cast<char*>(get_long_plugin_output().c_str()),
-                    const_cast<char*>(get_perf_data().c_str()), nullptr);
+                    const_cast<char*>(get_perf_data().c_str()),
+                    nullptr);
   return OK;
 }
 
@@ -1488,13 +1372,14 @@ int host::run_scheduled_check(int check_options, double latency) {
 
   logger(dbg_functions, basic) << "run_scheduled_host_check_3x()";
 
-  logger(dbg_checks, basic)
-      << "Attempting to run scheduled check of host '" << get_name()
-      << "': check options=" << check_options << ", latency=" << latency;
+  logger(dbg_checks, basic) << "Attempting to run scheduled check of host '"
+                            << get_name()
+                            << "': check options=" << check_options
+                            << ", latency=" << latency;
 
   /* attempt to run the check */
-  result = run_async_check(check_options, latency, true, true, &time_is_valid,
-                           &preferred_time);
+  result = run_async_check(
+      check_options, latency, true, true, &time_is_valid, &preferred_time);
 
   /* an error occurred, so reschedule the check */
   if (result == ERROR) {
@@ -1519,8 +1404,8 @@ int host::run_scheduled_check(int check_options, double latency) {
       // Make sure we rescheduled the next host check at a valid time.
       {
         timezone_locker lock(get_timezone());
-        get_next_valid_time(preferred_time, &next_valid_time,
-                            this->check_period_ptr);
+        get_next_valid_time(
+            preferred_time, &next_valid_time, this->check_period_ptr);
       }
 
       /* the host could not be rescheduled properly - set the next check time
@@ -1547,8 +1432,8 @@ int host::run_scheduled_check(int check_options, double latency) {
         set_next_check(next_valid_time);
         set_should_be_scheduled(true);
 
-        logger(dbg_checks, more)
-            << "Rescheduled next host check for " << my_ctime(&next_valid_time);
+        logger(dbg_checks, more) << "Rescheduled next host check for "
+                                 << my_ctime(&next_valid_time);
       }
     }
 
@@ -1575,10 +1460,10 @@ int host::run_async_check(int check_options,
                           bool reschedule_check,
                           bool* time_is_valid,
                           time_t* preferred_time) noexcept {
-  logger(dbg_functions, basic)
-      << "host::run_async_check, check_options=" << check_options
-      << ", latency=" << latency << ", scheduled_check=" << scheduled_check
-      << ", reschedule_check=" << reschedule_check;
+  logger(dbg_functions, basic) << "host::run_async_check, check_options="
+                               << check_options << ", latency=" << latency
+                               << ", scheduled_check=" << scheduled_check
+                               << ", reschedule_check=" << reschedule_check;
 
   // Preamble.
   if (!get_check_command_ptr()) {
@@ -1588,8 +1473,8 @@ int host::run_async_check(int check_options,
     return ERROR;
   }
 
-  logger(dbg_checks, basic)
-      << "** Running async check of host '" << get_name() << "'...";
+  logger(dbg_checks, basic) << "** Running async check of host '" << get_name()
+                            << "'...";
 
   // Check if the host is viable now.
   if (!verify_check_viability(check_options, time_is_valid, preferred_time))
@@ -1615,12 +1500,26 @@ int host::run_async_check(int check_options,
   timeval end_time;
   memset(&start_time, 0, sizeof(start_time));
   memset(&end_time, 0, sizeof(end_time));
-  int res = broker_host_check(
-      NEBTYPE_HOSTCHECK_ASYNC_PRECHECK, NEBFLAG_NONE, NEBATTR_NONE, this,
-      checkable::check_active, get_current_state(), get_state_type(),
-      start_time, end_time, get_check_command().c_str(), get_latency(), 0.0,
-      config->host_check_timeout(), false, 0, nullptr, nullptr, nullptr,
-      nullptr, nullptr);
+  int res = broker_host_check(NEBTYPE_HOSTCHECK_ASYNC_PRECHECK,
+                              NEBFLAG_NONE,
+                              NEBATTR_NONE,
+                              this,
+                              checkable::check_active,
+                              get_current_state(),
+                              get_state_type(),
+                              start_time,
+                              end_time,
+                              get_check_command().c_str(),
+                              get_latency(),
+                              0.0,
+                              config->host_check_timeout(),
+                              false,
+                              0,
+                              nullptr,
+                              nullptr,
+                              nullptr,
+                              nullptr,
+                              nullptr);
 
   // Host check was cancel by NEB module. Reschedule check later.
   if (NEBERROR_CALLBACKCANCEL == res) {
@@ -1655,8 +1554,8 @@ int host::run_async_check(int check_options,
   nagios_macros* macros(get_global_macros());
   grab_host_macros_r(macros, this);
   std::string tmp;
-  get_raw_command_line_r(macros, get_check_command_ptr(),
-                         get_check_command().c_str(), tmp, 0);
+  get_raw_command_line_r(
+      macros, get_check_command_ptr(), get_check_command().c_str(), tmp, 0);
 
   // Time to start command.
   gettimeofday(&start_time, nullptr);
@@ -1677,12 +1576,26 @@ int host::run_async_check(int check_options,
   std::string processed_cmd(cmd->process_cmd(macros));
 
   // Send event broker.
-  broker_host_check(NEBTYPE_HOSTCHECK_INITIATE, NEBFLAG_NONE, NEBATTR_NONE,
-                    this, checkable::check_active, get_current_state(),
-                    get_state_type(), start_time, end_time,
-                    get_check_command().c_str(), get_latency(), 0.0,
-                    config->host_check_timeout(), false, 0,
-                    processed_cmd.c_str(), nullptr, nullptr, nullptr, nullptr);
+  broker_host_check(NEBTYPE_HOSTCHECK_INITIATE,
+                    NEBFLAG_NONE,
+                    NEBATTR_NONE,
+                    this,
+                    checkable::check_active,
+                    get_current_state(),
+                    get_state_type(),
+                    start_time,
+                    end_time,
+                    get_check_command().c_str(),
+                    get_latency(),
+                    0.0,
+                    config->host_check_timeout(),
+                    false,
+                    0,
+                    processed_cmd.c_str(),
+                    nullptr,
+                    nullptr,
+                    nullptr,
+                    nullptr);
 
   // Restore latency.
   set_latency(old_latency);
@@ -1698,10 +1611,18 @@ int host::run_async_check(int check_options,
   std::unique_ptr<check_result> check_result_info;
   do {
     // Init check result info.
-    check_result_info.reset(
-        new check_result(host_check, this, checkable::check_active,
-                         check_options, reschedule_check, latency, start_time,
-                         start_time, false, true, service::state_ok, ""));
+    check_result_info.reset(new check_result(host_check,
+                                             this,
+                                             checkable::check_active,
+                                             check_options,
+                                             reschedule_check,
+                                             latency,
+                                             start_time,
+                                             start_time,
+                                             false,
+                                             true,
+                                             service::state_ok,
+                                             ""));
 
     retry = false;
     try {
@@ -1711,9 +1632,11 @@ int host::run_async_check(int check_options,
       if (id != 0)
         checks::checker::instance().add_check_result(
             id, check_result_info.release());
-    } catch (com::centreon::exceptions::interruption const& e) {
+    }
+    catch (com::centreon::exceptions::interruption const& e) {
       retry = true;
-    } catch (std::exception const& e) {
+    }
+    catch (std::exception const& e) {
       // Update check result.
       timeval tv;
       gettimeofday(&tv, nullptr);
@@ -1751,11 +1674,12 @@ bool host::schedule_check(time_t check_time, int options) {
 
   logger(dbg_functions, basic) << "schedule_host_check()";
 
-  logger(dbg_checks, basic)
-      << "Scheduling a "
-      << (options & CHECK_OPTION_FORCE_EXECUTION ? "forced" : "non-forced")
-      << ", active check of host '" << get_name() << "' @ "
-      << my_ctime(&check_time);
+  logger(dbg_checks, basic) << "Scheduling a "
+                            << (options & CHECK_OPTION_FORCE_EXECUTION
+                                    ? "forced"
+                                    : "non-forced")
+                            << ", active check of host '" << get_name()
+                            << "' @ " << my_ctime(&check_time);
 
   /* don't schedule a check if active checks of this host are disabled */
   if (!get_checks_enabled() && !(options & CHECK_OPTION_FORCE_EXECUTION)) {
@@ -1767,10 +1691,10 @@ bool host::schedule_check(time_t check_time, int options) {
   use_original_event = false;
 
 #ifdef PERFORMANCE_INCREASE_BUT_VERY_BAD_IDEA_INDEED
-  /* WARNING! 1/19/07 on-demand async host checks will end up causing mutliple
-   * scheduled checks of a host to appear in the queue if the code below is
-   * skipped */
-  /* if(use_large_installation_tweaks==false)... skip code below */
+/* WARNING! 1/19/07 on-demand async host checks will end up causing mutliple
+ * scheduled checks of a host to appear in the queue if the code below is
+ * skipped */
+/* if(use_large_installation_tweaks==false)... skip code below */
 #endif
 
   /* see if there are any other scheduled checks of this host in the queue */
@@ -1842,14 +1766,18 @@ bool host::schedule_check(time_t check_time, int options) {
     set_next_check(check_time);
 
     /* place the new event in the event queue */
-    timed_event* new_event =
-        new timed_event(timed_event::EVENT_HOST_CHECK, get_next_check(), false,
-                        0L, nullptr, true, (void*)this, nullptr, options);
+    timed_event* new_event = new timed_event(timed_event::EVENT_HOST_CHECK,
+                                             get_next_check(),
+                                             false,
+                                             0L,
+                                             nullptr,
+                                             true,
+                                             (void*)this,
+                                             nullptr,
+                                             options);
 
     events::loop::instance().reschedule_event(new_event, events::loop::low);
-  }
-
-  else {
+  } else {
     /* reset the next check time (it may be out of sync) */
     if (temp_event != nullptr)
       set_next_check(temp_event->run_time);
@@ -1883,8 +1811,8 @@ void host::check_for_flapping(bool update,
 
   logger(dbg_functions, basic) << "host::check_for_flapping()";
 
-  logger(dbg_flapping, more)
-      << "Checking host '" << get_name() << "' for flapping...";
+  logger(dbg_flapping, more) << "Checking host '" << get_name()
+                             << "' for flapping...";
 
   time(&current_time);
 
@@ -1971,10 +1899,11 @@ void host::check_for_flapping(bool update,
 
   set_percent_state_change(curved_percent_change);
 
-  logger(dbg_flapping, most)
-      << com::centreon::logging::setprecision(2) << "LFT=" << low_threshold
-      << ", HFT=" << high_threshold << ", CPC=" << curved_percent_change
-      << ", PSC=" << curved_percent_change << "%";
+  logger(dbg_flapping, most) << com::centreon::logging::setprecision(2)
+                             << "LFT=" << low_threshold
+                             << ", HFT=" << high_threshold
+                             << ", CPC=" << curved_percent_change
+                             << ", PSC=" << curved_percent_change << "%";
 
   /* don't do anything if we don't have flap detection enabled on a program-wide
    * basis */
@@ -1998,13 +1927,15 @@ void host::check_for_flapping(bool update,
   else if (curved_percent_change >= high_threshold)
     is_flapping = true;
 
-  logger(dbg_flapping, more)
-      << "Host " << (is_flapping ? "is" : "is not") << " flapping ("
-      << curved_percent_change << "% state change).";
+  logger(dbg_flapping, more) << "Host " << (is_flapping ? "is" : "is not")
+                             << " flapping (" << curved_percent_change
+                             << "% state change).";
 
   /* did the host just start flapping? */
   if (is_flapping && !get_is_flapping())
-    set_flap(curved_percent_change, high_threshold, low_threshold,
+    set_flap(curved_percent_change,
+             high_threshold,
+             low_threshold,
              allow_flapstart_notification);
 
   /* did the host just stop flapping? */
@@ -2033,15 +1964,21 @@ void host::set_flap(double percent_change,
       << "Notifications for this host are being suppressed because it "
          "was detected as "
       << "having been flapping between different "
-         "states ("
-      << percent_change << "% change > " << high_threshold
+         "states (" << percent_change << "% change > " << high_threshold
       << "% threshold).  When the host state stabilizes and the "
       << "flapping stops, notifications will be re-enabled.";
 
-  std::shared_ptr<comment> com{
-      new comment(comment::host, comment::flapping, get_host_id(), 0,
-                  time(nullptr), "(Centreon Engine Process)", oss.str(), false,
-                  comment::internal, false, (time_t)0)};
+  std::shared_ptr<comment> com{new comment(comment::host,
+                                           comment::flapping,
+                                           get_host_id(),
+                                           0,
+                                           time(nullptr),
+                                           "(Centreon Engine Process)",
+                                           oss.str(),
+                                           false,
+                                           comment::internal,
+                                           false,
+                                           (time_t)0)};
 
   comment::comments.insert({com->get_comment_id(), com});
 
@@ -2052,9 +1989,15 @@ void host::set_flap(double percent_change,
   set_is_flapping(true);
 
   /* send data to event broker */
-  broker_flapping_data(NEBTYPE_FLAPPING_START, NEBFLAG_NONE, NEBATTR_NONE,
-                       HOST_FLAPPING, this, percent_change, high_threshold,
-                       low_threshold, nullptr);
+  broker_flapping_data(NEBTYPE_FLAPPING_START,
+                       NEBFLAG_NONE,
+                       NEBATTR_NONE,
+                       HOST_FLAPPING,
+                       this,
+                       percent_change,
+                       high_threshold,
+                       low_threshold,
+                       nullptr);
 
   /* send a notification */
   if (allow_flapstart_notification)
@@ -2067,8 +2010,8 @@ void host::clear_flap(double percent_change,
                       double low_threshold) {
   logger(dbg_functions, basic) << "host::clear_flap()";
 
-  logger(dbg_flapping, basic)
-      << "Host '" << get_name() << "' stopped flapping.";
+  logger(dbg_flapping, basic) << "Host '" << get_name()
+                              << "' stopped flapping.";
 
   /* log a notice - this one is parsed by the history CGI */
   logger(log_info_message, basic)
@@ -2086,9 +2029,15 @@ void host::clear_flap(double percent_change,
   set_is_flapping(false);
 
   /* send data to event broker */
-  broker_flapping_data(NEBTYPE_FLAPPING_STOP, NEBFLAG_NONE,
-                       NEBATTR_FLAPPING_STOP_NORMAL, HOST_FLAPPING, this,
-                       percent_change, high_threshold, low_threshold, nullptr);
+  broker_flapping_data(NEBTYPE_FLAPPING_STOP,
+                       NEBFLAG_NONE,
+                       NEBATTR_FLAPPING_STOP_NORMAL,
+                       HOST_FLAPPING,
+                       this,
+                       percent_change,
+                       high_threshold,
+                       low_threshold,
+                       nullptr);
 
   /* send a notification */
   notify(reason_flappingstop, "", "", notifier::notification_option_none);
@@ -2101,8 +2050,8 @@ void host::clear_flap(double percent_change,
  * @brief Updates host status info. Data are sent to event broker.
  */
 void host::update_status() {
-  broker_host_status(NEBTYPE_HOSTSTATUS_UPDATE, NEBFLAG_NONE, NEBATTR_NONE,
-                     this, nullptr);
+  broker_host_status(
+      NEBTYPE_HOSTSTATUS_UPDATE, NEBFLAG_NONE, NEBATTR_NONE, this, nullptr);
 }
 
 /**
@@ -2114,8 +2063,8 @@ void host::check_for_expired_acknowledgement() {
     if (get_acknowledgement_timeout() > 0) {
       time_t now(time(nullptr));
       if (get_last_acknowledgement() + get_acknowledgement_timeout() >= now) {
-        logger(log_info_message, basic)
-            << "Acknowledgement of host '" << get_name() << "' just expired";
+        logger(log_info_message, basic) << "Acknowledgement of host '"
+                                        << get_name() << "' just expired";
         set_problem_has_been_acknowledged(false);
         set_acknowledgement_type(ACKNOWLEDGEMENT_NONE);
         update_status();
@@ -2337,9 +2286,7 @@ bool host::verify_check_viability(int check_options,
   return result;
 }
 
-void host::grab_macros_r(nagios_macros* mac) {
-  grab_host_macros_r(mac, this);
-}
+void host::grab_macros_r(nagios_macros* mac) { grab_host_macros_r(mac, this); }
 
 /* notify a specific contact that an entire host is down or up */
 int host::notify_contact(nagios_macros* mac,
@@ -2359,8 +2306,8 @@ int host::notify_contact(nagios_macros* mac,
   int neb_result;
 
   logger(dbg_functions, basic) << "notify_contact_of_host()";
-  logger(dbg_notifications, most)
-      << "** Notifying contact '" << cntct->get_name() << "'";
+  logger(dbg_notifications, most) << "** Notifying contact '"
+                                  << cntct->get_name() << "'";
 
   /* get start time */
   gettimeofday(&start_time, nullptr);
@@ -2368,10 +2315,20 @@ int host::notify_contact(nagios_macros* mac,
   /* send data to event broker */
   end_time.tv_sec = 0L;
   end_time.tv_usec = 0L;
-  neb_result = broker_contact_notification_data(
-      NEBTYPE_CONTACTNOTIFICATION_START, NEBFLAG_NONE, NEBATTR_NONE,
-      host_notification, type, start_time, end_time, (void*)this, cntct,
-      not_author.c_str(), not_data.c_str(), escalated, nullptr);
+  neb_result =
+      broker_contact_notification_data(NEBTYPE_CONTACTNOTIFICATION_START,
+                                       NEBFLAG_NONE,
+                                       NEBATTR_NONE,
+                                       host_notification,
+                                       type,
+                                       start_time,
+                                       end_time,
+                                       (void*)this,
+                                       cntct,
+                                       not_author.c_str(),
+                                       not_data.c_str(),
+                                       escalated,
+                                       nullptr);
   if (NEBERROR_CALLBACKCANCEL == neb_result)
     return ERROR;
   else if (NEBERROR_CALLBACKOVERRIDE == neb_result)
@@ -2387,23 +2344,36 @@ int host::notify_contact(nagios_macros* mac,
     method_end_time.tv_sec = 0L;
     method_end_time.tv_usec = 0L;
     neb_result = broker_contact_notification_method_data(
-        NEBTYPE_CONTACTNOTIFICATIONMETHOD_START, NEBFLAG_NONE, NEBATTR_NONE,
-        host_notification, type, method_start_time, method_end_time,
-        (void*)this, cntct, cmd->get_command_line().c_str(), not_author.c_str(),
-        not_data.c_str(), escalated, nullptr);
+        NEBTYPE_CONTACTNOTIFICATIONMETHOD_START,
+        NEBFLAG_NONE,
+        NEBATTR_NONE,
+        host_notification,
+        type,
+        method_start_time,
+        method_end_time,
+        (void*)this,
+        cntct,
+        cmd->get_command_line().c_str(),
+        not_author.c_str(),
+        not_data.c_str(),
+        escalated,
+        nullptr);
     if (NEBERROR_CALLBACKCANCEL == neb_result)
       break;
     else if (NEBERROR_CALLBACKOVERRIDE == neb_result)
       continue;
 
     /* get the raw command line */
-    get_raw_command_line_r(mac, cmd.get(), cmd->get_command_line().c_str(),
-                           raw_command, macro_options);
+    get_raw_command_line_r(mac,
+                           cmd.get(),
+                           cmd->get_command_line().c_str(),
+                           raw_command,
+                           macro_options);
     if (raw_command.empty())
       continue;
 
-    logger(dbg_notifications, most)
-        << "Raw notification command: " << raw_command;
+    logger(dbg_notifications, most) << "Raw notification command: "
+                                    << raw_command;
 
     /* process any macros contained in the argument */
     process_macros_r(mac, raw_command, processed_command, macro_options);
@@ -2412,8 +2382,8 @@ int host::notify_contact(nagios_macros* mac,
 
     /* run the notification command... */
 
-    logger(dbg_notifications, most)
-        << "Processed notification command: " << processed_command;
+    logger(dbg_notifications, most) << "Processed notification command: "
+                                    << processed_command;
 
     /* log the notification to program log file */
     if (config->log_notifications()) {
@@ -2450,9 +2420,15 @@ int host::notify_contact(nagios_macros* mac,
     /* run the notification command */
     try {
       std::string out;
-      my_system_r(mac, processed_command, config->notification_timeout(),
-                  &early_timeout, &exectime, out, 0);
-    } catch (std::exception const& e) {
+      my_system_r(mac,
+                  processed_command,
+                  config->notification_timeout(),
+                  &early_timeout,
+                  &exectime,
+                  out,
+                  0);
+    }
+    catch (std::exception const& e) {
       logger(log_runtime_error, basic)
           << "Error: can't execute host notification '" << cntct->get_name()
           << "' : " << e.what();
@@ -2472,10 +2448,20 @@ int host::notify_contact(nagios_macros* mac,
 
     /* send data to event broker */
     broker_contact_notification_method_data(
-        NEBTYPE_CONTACTNOTIFICATIONMETHOD_END, NEBFLAG_NONE, NEBATTR_NONE,
-        host_notification, type, method_start_time, method_end_time,
-        (void*)this, cntct, cmd->get_command_line().c_str(), not_author.c_str(),
-        not_data.c_str(), escalated, nullptr);
+        NEBTYPE_CONTACTNOTIFICATIONMETHOD_END,
+        NEBFLAG_NONE,
+        NEBATTR_NONE,
+        host_notification,
+        type,
+        method_start_time,
+        method_end_time,
+        (void*)this,
+        cntct,
+        cmd->get_command_line().c_str(),
+        not_author.c_str(),
+        not_data.c_str(),
+        escalated,
+        nullptr);
   }
 
   /* get end time */
@@ -2485,10 +2471,19 @@ int host::notify_contact(nagios_macros* mac,
   cntct->set_last_host_notification(start_time.tv_sec);
 
   /* send data to event broker */
-  broker_contact_notification_data(
-      NEBTYPE_CONTACTNOTIFICATION_END, NEBFLAG_NONE, NEBATTR_NONE,
-      host_notification, type, start_time, end_time, (void*)this, cntct,
-      not_author.c_str(), not_data.c_str(), escalated, nullptr);
+  broker_contact_notification_data(NEBTYPE_CONTACTNOTIFICATION_END,
+                                   NEBFLAG_NONE,
+                                   NEBATTR_NONE,
+                                   host_notification,
+                                   type,
+                                   start_time,
+                                   end_time,
+                                   (void*)this,
+                                   cntct,
+                                   not_author.c_str(),
+                                   not_data.c_str(),
+                                   escalated,
+                                   nullptr);
 
   return OK;
 }
@@ -2507,8 +2502,8 @@ void host::disable_flap_detection() {
 
   logger(dbg_functions, basic) << "disable_host_flap_detection()";
 
-  logger(dbg_functions, more)
-      << "Disabling flap detection for host '" << get_name() << "'.";
+  logger(dbg_functions, more) << "Disabling flap detection for host '"
+                              << get_name() << "'.";
 
   /* nothing to do... */
   if (!get_flap_detection_enabled())
@@ -2521,9 +2516,14 @@ void host::disable_flap_detection() {
   set_flap_detection_enabled(false);
 
   /* send data to event broker */
-  broker_adaptive_host_data(NEBTYPE_ADAPTIVEHOST_UPDATE, NEBFLAG_NONE,
-                            NEBATTR_NONE, this, CMD_NONE, attr,
-                            get_modified_attributes(), nullptr);
+  broker_adaptive_host_data(NEBTYPE_ADAPTIVEHOST_UPDATE,
+                            NEBFLAG_NONE,
+                            NEBATTR_NONE,
+                            this,
+                            CMD_NONE,
+                            attr,
+                            get_modified_attributes(),
+                            nullptr);
 
   /* handle the details... */
   handle_flap_detection_disabled();
@@ -2535,8 +2535,8 @@ void host::enable_flap_detection() {
 
   logger(dbg_functions, basic) << "host::enable_flap_detection()";
 
-  logger(dbg_flapping, more)
-      << "Enabling flap detection for host '" << get_name() << "'.";
+  logger(dbg_flapping, more) << "Enabling flap detection for host '"
+                             << get_name() << "'.";
 
   /* nothing to do... */
   if (get_flap_detection_enabled())
@@ -2549,9 +2549,14 @@ void host::enable_flap_detection() {
   set_flap_detection_enabled(true);
 
   /* send data to event broker */
-  broker_adaptive_host_data(NEBTYPE_ADAPTIVEHOST_UPDATE, NEBFLAG_NONE,
-                            NEBATTR_NONE, this, CMD_NONE, attr,
-                            get_modified_attributes(), nullptr);
+  broker_adaptive_host_data(NEBTYPE_ADAPTIVEHOST_UPDATE,
+                            NEBFLAG_NONE,
+                            NEBATTR_NONE,
+                            this,
+                            CMD_NONE,
+                            attr,
+                            get_modified_attributes(),
+                            nullptr);
 
   /* check for flapping */
   check_for_flapping(false, false, true);
@@ -2684,10 +2689,10 @@ bool host::is_result_fresh(time_t current_time, int log_this) {
 
   /* the results for the last check of this host are stale */
   if (expiration_time < current_time) {
-    get_time_breakdown((current_time - expiration_time), &days, &hours,
-                       &minutes, &seconds);
-    get_time_breakdown(freshness_threshold, &tdays, &thours, &tminutes,
-                       &tseconds);
+    get_time_breakdown(
+        (current_time - expiration_time), &days, &hours, &minutes, &seconds);
+    get_time_breakdown(
+        freshness_threshold, &tdays, &thours, &tminutes, &tseconds);
 
     /* log a warning */
     if (log_this)
@@ -2695,22 +2700,21 @@ bool host::is_result_fresh(time_t current_time, int log_this) {
           << "Warning: The results of host '" << _name << "' are stale by "
           << days << "d " << hours << "h " << minutes << "m " << seconds
           << "s (threshold=" << tdays << "d " << thours << "h " << tminutes
-          << "m " << tseconds
-          << "s).  I'm forcing an immediate check of"
-             " the host.";
+          << "m " << tseconds << "s).  I'm forcing an immediate check of"
+                                 " the host.";
 
-    logger(dbg_checks, more)
-        << "Check results for host '" << _name << "' are stale by " << days
-        << "d " << hours << "h " << minutes << "m " << seconds
-        << "s (threshold=" << tdays << "d " << thours << "h " << tminutes
-        << "m " << tseconds
-        << "s).  "
-           "Forcing an immediate check of the host...";
+    logger(dbg_checks, more) << "Check results for host '" << _name
+                             << "' are stale by " << days << "d " << hours
+                             << "h " << minutes << "m " << seconds
+                             << "s (threshold=" << tdays << "d " << thours
+                             << "h " << tminutes << "m " << tseconds
+                             << "s).  "
+                                "Forcing an immediate check of the host...";
 
     return false;
   } else
-    logger(dbg_checks, more)
-        << "Check results for host '" << this->get_name() << "' are fresh.";
+    logger(dbg_checks, more) << "Check results for host '" << this->get_name()
+                             << "' are fresh.";
 
   return true;
 }
@@ -2735,9 +2739,15 @@ void host::handle_flap_detection_disabled() {
         << ";DISABLED; Flap detection has been disabled";
 
     /* send data to event broker */
-    broker_flapping_data(NEBTYPE_FLAPPING_STOP, NEBFLAG_NONE,
-                         NEBATTR_FLAPPING_STOP_DISABLED, HOST_FLAPPING, this,
-                         this->get_percent_state_change(), 0.0, 0.0, nullptr);
+    broker_flapping_data(NEBTYPE_FLAPPING_STOP,
+                         NEBFLAG_NONE,
+                         NEBATTR_FLAPPING_STOP_DISABLED,
+                         HOST_FLAPPING,
+                         this,
+                         this->get_percent_state_change(),
+                         0.0,
+                         0.0,
+                         nullptr);
 
     /* send a notification */
     notify(reason_flappingdisabled, "", "", notifier::notification_option_none);
@@ -2756,8 +2766,10 @@ int host::perform_on_demand_check(enum host::host_state* check_return_code,
                                   unsigned long check_timestamp_horizon) {
   logger(dbg_functions, basic) << "perform_on_demand_host_check()";
 
-  perform_on_demand_check_3x(check_return_code, check_options,
-                             use_cached_result, check_timestamp_horizon);
+  perform_on_demand_check_3x(check_return_code,
+                             check_options,
+                             use_cached_result,
+                             check_timestamp_horizon);
   return OK;
 }
 
@@ -2770,12 +2782,14 @@ int host::perform_on_demand_check_3x(host::host_state* check_result_code,
 
   logger(dbg_functions, basic) << "perform_on_demand_host_check_3x()";
 
-  logger(dbg_checks, basic)
-      << "** On-demand check for host '" << _name << "'...";
+  logger(dbg_checks, basic) << "** On-demand check for host '" << _name
+                            << "'...";
 
   /* check the status of the host */
-  result = this->run_sync_check_3x(check_result_code, check_options,
-                                   use_cached_result, check_timestamp_horizon);
+  result = this->run_sync_check_3x(check_result_code,
+                                   check_options,
+                                   use_cached_result,
+                                   check_timestamp_horizon);
   return result;
 }
 
@@ -2785,17 +2799,20 @@ int host::run_sync_check_3x(enum host::host_state* check_result_code,
                             int check_options,
                             int use_cached_result,
                             unsigned long check_timestamp_horizon) {
-  logger(dbg_functions, basic)
-      << "run_sync_host_check_3x: hst=" << this
-      << ", check_options=" << check_options
-      << ", use_cached_result=" << use_cached_result
-      << ", check_timestamp_horizon=" << check_timestamp_horizon;
+  logger(dbg_functions, basic) << "run_sync_host_check_3x: hst=" << this
+                               << ", check_options=" << check_options
+                               << ", use_cached_result=" << use_cached_result
+                               << ", check_timestamp_horizon="
+                               << check_timestamp_horizon;
 
   try {
-    checks::checker::instance().run_sync(this, check_result_code, check_options,
+    checks::checker::instance().run_sync(this,
+                                         check_result_code,
+                                         check_options,
                                          use_cached_result,
                                          check_timestamp_horizon);
-  } catch (std::exception const& e) {
+  }
+  catch (std::exception const& e) {
     logger(log_runtime_error, basic) << "Error: " << e.what();
     return ERROR;
   }
@@ -2846,9 +2863,9 @@ int host::process_check_result_3x(enum host::host_state new_state,
    * commands by getting dropped in checkresults dir */
   if (get_check_type() == check_passive) {
     if (config->log_passive_checks())
-      logger(log_passive_check, basic)
-          << "PASSIVE HOST CHECK: " << _name << ";" << new_state << ";"
-          << get_plugin_output();
+      logger(log_passive_check, basic) << "PASSIVE HOST CHECK: " << _name << ";"
+                                       << new_state << ";"
+                                       << get_plugin_output();
   }
 
   /******* HOST WAS DOWN/UNREACHABLE INITIALLY *******/
@@ -2886,12 +2903,13 @@ int host::process_check_result_3x(enum host::host_state new_state,
 
       for (host_map_unsafe::iterator it{parent_hosts.begin()},
            end{parent_hosts.end()};
-           it != end; it++) {
+           it != end;
+           it++) {
         if (!it->second)
           continue;
         if (it->second->get_current_state() != host::state_up) {
-          logger(dbg_checks, more)
-              << "Check of parent host '" << it->first << "' queued.";
+          logger(dbg_checks, more) << "Check of parent host '" << it->first
+                                   << "' queued.";
           check_hostlist.push_back(it->second);
         }
       }
@@ -2903,12 +2921,13 @@ int host::process_check_result_3x(enum host::host_state new_state,
 
       for (host_map_unsafe::iterator it{child_hosts.begin()},
            end{child_hosts.end()};
-           it != end; it++) {
+           it != end;
+           it++) {
         if (!it->second)
           continue;
         if (it->second->get_current_state() != host::state_up) {
-          logger(dbg_checks, more)
-              << "Check of child host '" << it->first << "' queued.";
+          logger(dbg_checks, more) << "Check of child host '" << it->first
+                                   << "' queued.";
           check_hostlist.push_back(it->second);
         }
       }
@@ -3027,17 +3046,19 @@ int host::process_check_result_3x(enum host::host_state new_state,
 
           for (host_map_unsafe::iterator it{parent_hosts.begin()},
                end{parent_hosts.end()};
-               it != end; it++) {
+               it != end;
+               it++) {
             if (!it->second)
               continue;
 
             has_parent = true;
 
-            logger(dbg_checks, more)
-                << "Running serial check parent host '" << it->first << "'...";
+            logger(dbg_checks, more) << "Running serial check parent host '"
+                                     << it->first << "'...";
 
             /* run an immediate check of the parent host */
-            it->second->run_sync_check_3x(&parent_state, check_options,
+            it->second->run_sync_check_3x(&parent_state,
+                                          check_options,
                                           use_cached_result,
                                           check_timestamp_horizon);
 
@@ -3084,12 +3105,13 @@ int host::process_check_result_3x(enum host::host_state new_state,
 
         for (host_map_unsafe::iterator it{child_hosts.begin()},
              end{child_hosts.end()};
-             it != end; it++) {
+             it != end;
+             it++) {
           if (!it->second)
             continue;
           if (it->second->get_current_state() != host::state_unreachable) {
-            logger(dbg_checks, more)
-                << "Check of child host '" << it->first << "' queued.";
+            logger(dbg_checks, more) << "Check of child host '" << it->first
+                                     << "' queued.";
             check_hostlist.push_back(it->second);
           }
         }
@@ -3149,13 +3171,14 @@ int host::process_check_result_3x(enum host::host_state new_state,
 
         for (host_map_unsafe::iterator it{parent_hosts.begin()},
              end{parent_hosts.end()};
-             it != end; it++) {
+             it != end;
+             it++) {
           if (it->second == nullptr)
             continue;
           if (it->second->get_current_state() == host::state_up) {
             check_hostlist.push_back(it->second);
-            logger(dbg_checks, more)
-                << "Check of host '" << it->first << "' queued.";
+            logger(dbg_checks, more) << "Check of host '" << it->first
+                                     << "' queued.";
           }
         }
 
@@ -3167,12 +3190,13 @@ int host::process_check_result_3x(enum host::host_state new_state,
 
         for (host_map_unsafe::iterator it{child_hosts.begin()},
              end{child_hosts.end()};
-             it != end; it++) {
+             it != end;
+             it++) {
           if (!it->second)
             continue;
           if (it->second->get_current_state() != host::state_unreachable) {
-            logger(dbg_checks, more)
-                << "Check of child host '" << it->first << "' queued.";
+            logger(dbg_checks, more) << "Check of child host '" << it->first
+                                     << "' queued.";
             check_hostlist.push_back(it->second);
           }
         }
@@ -3191,14 +3215,15 @@ int host::process_check_result_3x(enum host::host_state new_state,
           for (hostdependency_mmap::const_iterator
                    it{hostdependency::hostdependencies.find(_name)},
                end{hostdependency::hostdependencies.end()};
-               it != end && it->first == _name; ++it) {
+               it != end && it->first == _name;
+               ++it) {
             hostdependency* temp_dependency(it->second.get());
             if (temp_dependency->dependent_host_ptr == this &&
                 temp_dependency->master_host_ptr != nullptr) {
               master_host = (host*)temp_dependency->master_host_ptr;
-              logger(dbg_checks, more)
-                  << "Check of host '" << master_host->get_name()
-                  << "' queued.";
+              logger(dbg_checks, more) << "Check of host '"
+                                       << master_host->get_name()
+                                       << "' queued.";
               check_hostlist.push_back(master_host);
             }
           }
@@ -3246,8 +3271,8 @@ int host::process_check_result_3x(enum host::host_state new_state,
    * checks, unless overridden above) */
   bool sent = false;
   if (reschedule_check) {
-    logger(dbg_checks, more)
-        << "Rescheduling next check of host at " << my_ctime(&next_check);
+    logger(dbg_checks, more) << "Rescheduling next check of host at "
+                             << my_ctime(&next_check);
 
     /* default is to reschedule host check unless a test below fails... */
     set_should_be_scheduled(true);
@@ -3296,17 +3321,20 @@ int host::process_check_result_3x(enum host::host_state new_state,
    * cached state */
   for (std::list<host*>::iterator it{check_hostlist.begin()},
        end{check_hostlist.end()};
-       it != end; ++it) {
+       it != end;
+       ++it) {
     run_async_check = true;
     temp_host = *it;
 
-    logger(dbg_checks, most)
-        << "ASYNC CHECK OF HOST: " << temp_host->get_name()
-        << ", CURRENTTIME: " << current_time
-        << ", LASTHOSTCHECK: " << temp_host->get_last_check()
-        << ", CACHEDTIMEHORIZON: " << check_timestamp_horizon
-        << ", USECACHEDRESULT: " << use_cached_result
-        << ", ISEXECUTING: " << temp_host->get_is_executing();
+    logger(dbg_checks, most) << "ASYNC CHECK OF HOST: " << temp_host->get_name()
+                             << ", CURRENTTIME: " << current_time
+                             << ", LASTHOSTCHECK: "
+                             << temp_host->get_last_check()
+                             << ", CACHEDTIMEHORIZON: "
+                             << check_timestamp_horizon
+                             << ", USECACHEDRESULT: " << use_cached_result
+                             << ", ISEXECUTING: "
+                             << temp_host->get_is_executing();
 
     if (use_cached_result && (static_cast<unsigned long>(
                                   current_time - temp_host->get_last_check()) <=
@@ -3315,8 +3343,8 @@ int host::process_check_result_3x(enum host::host_state new_state,
     if (temp_host->get_is_executing())
       run_async_check = false;
     if (run_async_check)
-      temp_host->run_async_check(CHECK_OPTION_NONE, 0.0, false, false, nullptr,
-                                 nullptr);
+      temp_host->run_async_check(
+          CHECK_OPTION_NONE, 0.0, false, false, nullptr, nullptr);
   }
   return OK;
 }
@@ -3354,7 +3382,8 @@ enum host::host_state host::determine_host_reachability() {
   else {
     for (host_map_unsafe::iterator it{parent_hosts.begin()},
          end{parent_hosts.end()};
-         it != end; it++) {
+         it != end;
+         it++) {
       if (!it->second)
         continue;
 
@@ -3382,9 +3411,7 @@ std::list<hostgroup*> const& host::get_parent_groups() const {
   return _hostgroups;
 }
 
-std::list<hostgroup*>& host::get_parent_groups() {
-  return _hostgroups;
-}
+std::list<hostgroup*>& host::get_parent_groups() { return _hostgroups; }
 
 /**
  *  This function returns a boolean telling if the master hosts of this one
@@ -3399,7 +3426,8 @@ bool host::authorized_by_dependencies(dependency::types dependency_type) const {
 
   auto p(hostdependency::hostdependencies.equal_range(_name));
   for (hostdependency_mmap::const_iterator it{p.first}, end{p.second};
-       it != end; ++it) {
+       it != end;
+       ++it) {
     hostdependency* dep{it->second.get()};
     /* Only check dependencies of the desired type (notification or execution)
      */
@@ -3429,8 +3457,7 @@ bool host::authorized_by_dependencies(dependency::types dependency_type) const {
     if (dep->get_fail_on(state))
       return false;
 
-    if (state == host::state_up &&
-        !dep->master_host_ptr->has_been_checked() &&
+    if (state == host::state_up && !dep->master_host_ptr->has_been_checked() &&
         dep->get_fail_on_pending())
       return false;
 
@@ -3463,7 +3490,8 @@ void host::check_result_freshness() {
 
   /* check all hosts... */
   for (host_map::iterator it{host::hosts.begin()}, end{host::hosts.end()};
-       it != end; ++it) {
+       it != end;
+       ++it) {
     /* skip hosts we shouldn't be checking for freshness */
     if (!it->second->get_check_freshness())
       continue;
@@ -3549,7 +3577,8 @@ void host::check_for_orphaned() {
 
   /* check all hosts... */
   for (host_map::iterator it{host::hosts.begin()}, end{host::hosts.end()};
-       it != end; ++it) {
+       it != end;
+       ++it) {
     /* skip hosts that don't have a set check interval (on-demand checks are
      * missed by the orphan logic) */
     if (it->second->get_next_check() == (time_t)0L)
@@ -3601,9 +3630,7 @@ bool host::get_notify_on_current_state() const {
   return retval;
 }
 
-bool host::is_in_downtime() const {
-  return get_scheduled_downtime_depth() > 0;
-}
+bool host::is_in_downtime() const { return get_scheduled_downtime_depth() > 0; }
 
 /**
  *  This method resolves pointers involved in this host life. If a pointer
@@ -3618,7 +3645,8 @@ void host::resolve(int& w, int& e) {
 
   try {
     notifier::resolve(warnings, errors);
-  } catch (std::exception const& e) {
+  }
+  catch (std::exception const& e) {
     logger(log_verification_error, basic)
         << "Error: Host '" << _name
         << "' has problem in its notifier part: " << e.what();
@@ -3626,7 +3654,8 @@ void host::resolve(int& w, int& e) {
 
   for (service_map::iterator it_svc{service::services.begin()},
        end_svc{service::services.end()};
-       it_svc != end_svc; ++it_svc) {
+       it_svc != end_svc;
+       ++it_svc) {
     if (_name == it_svc->first.first)
       services.insert({it_svc->first, nullptr});
   }
@@ -3638,7 +3667,8 @@ void host::resolve(int& w, int& e) {
     ++w;
   } else {
     for (service_map_unsafe::iterator it{services.begin()}, end{services.end()};
-         it != end; ++it) {
+         it != end;
+         ++it) {
       service_map::const_iterator found{service::services.find(it->first)};
       if (found == service::services.end() || !found->second) {
         logger(log_verification_error, basic)
@@ -3654,13 +3684,14 @@ void host::resolve(int& w, int& e) {
   /* check all parent parent host */
   for (host_map_unsafe::iterator it(parent_hosts.begin()),
        end(parent_hosts.end());
-       it != end; it++) {
+       it != end;
+       it++) {
     host_map::const_iterator it_host{host::hosts.find(it->first)};
     if (it_host == host::hosts.end() || !it_host->second) {
-      logger(log_verification_error, basic) << "Error: '" << it->first
-                                            << "' is not a "
-                                               "valid parent for host '"
-                                            << _name << "'!";
+      logger(log_verification_error, basic)
+          << "Error: '" << it->first << "' is not a "
+                                        "valid parent for host '" << _name
+          << "'!";
       errors++;
     } else {
       it->second = it_host->second.get();

--- a/src/nebmods.cc
+++ b/src/nebmods.cc
@@ -39,10 +39,14 @@ using namespace com::centreon::engine::logging;
 /****************************************************************************/
 
 /* initialize module routines */
-int neb_init_modules() { return OK; }
+int neb_init_modules() {
+  return OK;
+}
 
 /* deinitialize module routines */
-int neb_deinit_modules() { return OK; }
+int neb_deinit_modules() {
+  return OK;
+}
 
 /* add a new module to module list */
 int neb_add_module(char const* filename,
@@ -55,10 +59,9 @@ int neb_add_module(char const* filename,
 
   try {
     broker::loader::instance().add_module(filename, args);
-    logger(dbg_eventbroker, basic) << "Added module: name='" << filename
-                                   << "', args='" << args << "'";
-  }
-  catch (...) {
+    logger(dbg_eventbroker, basic)
+        << "Added module: name='" << filename << "', args='" << args << "'";
+  } catch (...) {
     logger(dbg_eventbroker, basic) << "Counld not add module: name='"
                                    << filename << "', args='" << args << "'";
     return ERROR;
@@ -70,8 +73,7 @@ int neb_add_module(char const* filename,
 int neb_free_module_list() {
   try {
     logger(dbg_eventbroker, basic) << "unload all modules success.";
-  }
-  catch (...) {
+  } catch (...) {
     logger(dbg_eventbroker, basic) << "unload all modules failed.";
     return ERROR;
   }
@@ -98,12 +100,10 @@ int neb_load_all_modules() {
     for (std::list<std::shared_ptr<broker::handle> >::const_iterator
              it(modules.begin()),
          end(modules.end());
-         it != end;
-         ++it)
+         it != end; ++it)
       if (neb_load_module(&(*(*it))))
         ++unloaded;
-  }
-  catch (...) {
+  } catch (...) {
     logger(dbg_eventbroker, basic) << "Could not load all modules";
     return -1;
   }
@@ -123,19 +123,17 @@ int neb_load_module(void* mod) {
 
   try {
     module->open();
-    logger(log_info_message, basic) << "Event broker module '"
-                                    << module->get_filename()
-                                    << "' initialized successfully";
-  }
-  catch (std::exception const& e) {
-    logger(log_runtime_error, basic) << "Error: Could not load module '"
-                                     << module->get_filename()
-                                     << "': " << e.what();
+    logger(log_info_message, basic)
+        << "Event broker module '" << module->get_filename()
+        << "' initialized successfully";
+  } catch (std::exception const& e) {
+    logger(log_runtime_error, basic)
+        << "Error: Could not load module '" << module->get_filename()
+        << "': " << e.what();
     return ERROR;
-  }
-  catch (...) {
-    logger(log_runtime_error, basic) << "Error: Could not load module '"
-                                     << module->get_filename() << "'";
+  } catch (...) {
+    logger(log_runtime_error, basic)
+        << "Error: Could not load module '" << module->get_filename() << "'";
     return ERROR;
   }
   return OK;
@@ -154,20 +152,17 @@ int neb_reload_all_modules() {
       for (std::list<std::shared_ptr<broker::handle> >::const_iterator
                it(modules.begin()),
            end(modules.end());
-           it != end;
-           ++it) {
+           it != end; ++it) {
         neb_reload_module(&**it);
       }
       logger(dbg_eventbroker, basic) << "All modules got successfully reloaded";
     }
     retval = OK;
-  }
-  catch (std::exception const& e) {
-    logger(log_runtime_error, basic) << "Warning: Module reloading failed: "
-                                     << e.what();
+  } catch (std::exception const& e) {
+    logger(log_runtime_error, basic)
+        << "Warning: Module reloading failed: " << e.what();
     retval = ERROR;
-  }
-  catch (...) {
+  } catch (...) {
     logger(log_runtime_error, basic)
         << "Warning: Module reloading failed: unknown error";
     retval = ERROR;
@@ -184,11 +179,11 @@ int neb_reload_module(void* mod) {
   if (module->is_loaded() == false)
     return OK;
 
-  logger(dbg_eventbroker, basic) << "Attempting to reload module '"
-                                 << module->get_filename() << "'";
+  logger(dbg_eventbroker, basic)
+      << "Attempting to reload module '" << module->get_filename() << "'";
   module->reload();
-  logger(dbg_eventbroker, basic) << "Module '" << module->get_filename()
-                                 << "' reloaded successfully";
+  logger(dbg_eventbroker, basic)
+      << "Module '" << module->get_filename() << "' reloaded successfully";
 
   return OK;
 }
@@ -209,19 +204,16 @@ int neb_unload_all_modules(int flags, int reason) {
     for (std::list<std::shared_ptr<broker::handle> >::const_iterator
              it = modules.begin(),
              end = modules.end();
-         it != end;
-         ++it)
+         it != end; ++it)
       neb_unload_module((*it).get(), flags, reason);
     loader.unload_modules();
     logger(dbg_eventbroker, basic) << "All modules got successfully unloaded";
     retval = OK;
-  }
-  catch (std::exception const& e) {
-    logger(log_runtime_error, basic) << "Error: Module unloading failed: "
-                                     << e.what();
+  } catch (std::exception const& e) {
+    logger(log_runtime_error, basic)
+        << "Error: Module unloading failed: " << e.what();
     retval = ERROR;
-  }
-  catch (...) {
+  } catch (...) {
     logger(log_runtime_error, basic)
         << "Error: unloading of all modules failed";
     retval = ERROR;
@@ -240,20 +232,20 @@ int neb_unload_module(broker::handle* module, int flags, int reason) {
   if (!module->is_loaded())
     return OK;
 
-  logger(dbg_eventbroker, basic) << "Attempting to unload module '"
-                                 << module->get_filename() << "'";
+  logger(dbg_eventbroker, basic)
+      << "Attempting to unload module '" << module->get_filename() << "'";
 
   module->close();
 
   /* deregister all of the module's callbacks */
   neb_deregister_module_callbacks(module);
 
-  logger(dbg_eventbroker, basic) << "Module '" << module->get_filename()
-                                 << "' unloaded successfully";
+  logger(dbg_eventbroker, basic)
+      << "Module '" << module->get_filename() << "' unloaded successfully";
 
-  logger(log_info_message, basic) << "Event broker module '"
-                                  << module->get_filename()
-                                  << "' deinitialized successfully";
+  logger(log_info_message, basic)
+      << "Event broker module '" << module->get_filename()
+      << "' deinitialized successfully";
 
   return OK;
 }
@@ -302,11 +294,10 @@ int neb_set_module_info(void* handle, int type, char const* data) {
         break;
     }
 
-    logger(dbg_eventbroker, basic) << "set module info success: filename='"
-                                   << module->get_filename() << "', type='"
-                                   << type << "'";
-  }
-  catch (...) {
+    logger(dbg_eventbroker, basic)
+        << "set module info success: filename='" << module->get_filename()
+        << "', type='" << type << "'";
+  } catch (...) {
     logger(dbg_eventbroker, basic) << "Counld not set module info.";
     return ERROR;
   }
@@ -358,8 +349,7 @@ int neb_register_callback(int callback_type,
     nebcallback* last_callback(NULL);
     nebcallback* temp_callback(NULL);
     for (temp_callback = neb_callback_list[callback_type];
-         temp_callback != NULL;
-         temp_callback = temp_callback->next) {
+         temp_callback != NULL; temp_callback = temp_callback->next) {
       if (temp_callback->priority > new_callback->priority)
         break;
       last_callback = temp_callback;
@@ -388,8 +378,7 @@ int neb_deregister_module_callbacks(void* mod) {
   for (int callback_type = 0; callback_type < NEBCALLBACK_NUMITEMS;
        callback_type++) {
     for (nebcallback* temp_callback = neb_callback_list[callback_type];
-         temp_callback != nullptr;
-         temp_callback = next_callback) {
+         temp_callback != nullptr; temp_callback = next_callback) {
       next_callback = temp_callback->next;
       if ((void*)temp_callback->module_handle == (void*)mod) {
         union {
@@ -416,8 +405,7 @@ int neb_deregister_callback(int callback_type,
 
   /* find the callback to remove */
   for (temp_callback = last_callback = neb_callback_list[callback_type];
-       temp_callback != NULL;
-       temp_callback = next_callback) {
+       temp_callback != NULL; temp_callback = next_callback) {
     next_callback = temp_callback->next;
 
     /* we found it */
@@ -460,8 +448,8 @@ int neb_make_callbacks(int callback_type, void* data) {
     return ERROR;
 
   if (callback_type != NEBCALLBACK_LOG_DATA) {
-    logger(dbg_eventbroker, more) << "Making callbacks (type " << callback_type
-                                  << ")...";
+    logger(dbg_eventbroker, more)
+        << "Making callbacks (type " << callback_type << ")...";
   }
 
   /* make the callbacks... */
@@ -478,9 +466,9 @@ int neb_make_callbacks(int callback_type, void* data) {
 
     total_callbacks++;
     if (callback_type != NEBCALLBACK_LOG_DATA) {
-      logger(dbg_eventbroker, most) << "Callback #" << total_callbacks
-                                    << " (type " << callback_type
-                                    << ") return (code = " << cbresult << ")";
+      logger(dbg_eventbroker, most)
+          << "Callback #" << total_callbacks << " (type " << callback_type
+          << ") return (code = " << cbresult << ")";
     }
 
     /* module wants to cancel callbacks to other modules (and potentially cancel

--- a/src/nebmods.cc
+++ b/src/nebmods.cc
@@ -22,7 +22,6 @@
 #include <cerrno>
 #include <cstdio>
 #include <cstdlib>
-#include "com/centreon/engine/broker/handle.hh"
 #include "com/centreon/engine/broker/loader.hh"
 #include "com/centreon/engine/globals.hh"
 #include "com/centreon/engine/logging/logger.hh"
@@ -40,14 +39,10 @@ using namespace com::centreon::engine::logging;
 /****************************************************************************/
 
 /* initialize module routines */
-int neb_init_modules() {
-  return OK;
-}
+int neb_init_modules() { return OK; }
 
 /* deinitialize module routines */
-int neb_deinit_modules() {
-  return OK;
-}
+int neb_deinit_modules() { return OK; }
 
 /* add a new module to module list */
 int neb_add_module(char const* filename,
@@ -60,9 +55,10 @@ int neb_add_module(char const* filename,
 
   try {
     broker::loader::instance().add_module(filename, args);
-    logger(dbg_eventbroker, basic)
-        << "Added module: name='" << filename << "', args='" << args << "'";
-  } catch (...) {
+    logger(dbg_eventbroker, basic) << "Added module: name='" << filename
+                                   << "', args='" << args << "'";
+  }
+  catch (...) {
     logger(dbg_eventbroker, basic) << "Counld not add module: name='"
                                    << filename << "', args='" << args << "'";
     return ERROR;
@@ -74,7 +70,8 @@ int neb_add_module(char const* filename,
 int neb_free_module_list() {
   try {
     logger(dbg_eventbroker, basic) << "unload all modules success.";
-  } catch (...) {
+  }
+  catch (...) {
     logger(dbg_eventbroker, basic) << "unload all modules failed.";
     return ERROR;
   }
@@ -101,10 +98,12 @@ int neb_load_all_modules() {
     for (std::list<std::shared_ptr<broker::handle> >::const_iterator
              it(modules.begin()),
          end(modules.end());
-         it != end; ++it)
+         it != end;
+         ++it)
       if (neb_load_module(&(*(*it))))
         ++unloaded;
-  } catch (...) {
+  }
+  catch (...) {
     logger(dbg_eventbroker, basic) << "Could not load all modules";
     return -1;
   }
@@ -124,17 +123,19 @@ int neb_load_module(void* mod) {
 
   try {
     module->open();
-    logger(log_info_message, basic)
-        << "Event broker module '" << module->get_filename()
-        << "' initialized successfully";
-  } catch (std::exception const& e) {
-    logger(log_runtime_error, basic)
-        << "Error: Could not load module '" << module->get_filename()
-        << "': " << e.what();
+    logger(log_info_message, basic) << "Event broker module '"
+                                    << module->get_filename()
+                                    << "' initialized successfully";
+  }
+  catch (std::exception const& e) {
+    logger(log_runtime_error, basic) << "Error: Could not load module '"
+                                     << module->get_filename()
+                                     << "': " << e.what();
     return ERROR;
-  } catch (...) {
-    logger(log_runtime_error, basic)
-        << "Error: Could not load module '" << module->get_filename() << "'";
+  }
+  catch (...) {
+    logger(log_runtime_error, basic) << "Error: Could not load module '"
+                                     << module->get_filename() << "'";
     return ERROR;
   }
   return OK;
@@ -153,17 +154,20 @@ int neb_reload_all_modules() {
       for (std::list<std::shared_ptr<broker::handle> >::const_iterator
                it(modules.begin()),
            end(modules.end());
-           it != end; ++it) {
+           it != end;
+           ++it) {
         neb_reload_module(&**it);
       }
       logger(dbg_eventbroker, basic) << "All modules got successfully reloaded";
     }
     retval = OK;
-  } catch (std::exception const& e) {
-    logger(log_runtime_error, basic)
-        << "Warning: Module reloading failed: " << e.what();
+  }
+  catch (std::exception const& e) {
+    logger(log_runtime_error, basic) << "Warning: Module reloading failed: "
+                                     << e.what();
     retval = ERROR;
-  } catch (...) {
+  }
+  catch (...) {
     logger(log_runtime_error, basic)
         << "Warning: Module reloading failed: unknown error";
     retval = ERROR;
@@ -180,11 +184,11 @@ int neb_reload_module(void* mod) {
   if (module->is_loaded() == false)
     return OK;
 
-  logger(dbg_eventbroker, basic)
-      << "Attempting to reload module '" << module->get_filename() << "'";
+  logger(dbg_eventbroker, basic) << "Attempting to reload module '"
+                                 << module->get_filename() << "'";
   module->reload();
-  logger(dbg_eventbroker, basic)
-      << "Module '" << module->get_filename() << "' reloaded successfully";
+  logger(dbg_eventbroker, basic) << "Module '" << module->get_filename()
+                                 << "' reloaded successfully";
 
   return OK;
 }
@@ -200,24 +204,24 @@ int neb_reload_module(void* mod) {
 int neb_unload_all_modules(int flags, int reason) {
   int retval;
   try {
-    broker::loader* loader(&broker::loader::instance());
-    if (loader) {
-      std::list<std::shared_ptr<broker::handle> > modules(
-          loader->get_modules());
-      for (std::list<std::shared_ptr<broker::handle> >::const_iterator
-               it(modules.begin()),
-           end(modules.end());
-           it != end; ++it)
-        neb_unload_module(&**it, flags, reason);
-      loader->unload_modules();
-      logger(dbg_eventbroker, basic) << "All modules got successfully unloaded";
-    }
+    broker::loader& loader(broker::loader::instance());
+    std::list<std::shared_ptr<broker::handle> > modules(loader.get_modules());
+    for (std::list<std::shared_ptr<broker::handle> >::const_iterator
+             it = modules.begin(),
+             end = modules.end();
+         it != end;
+         ++it)
+      neb_unload_module((*it).get(), flags, reason);
+    loader.unload_modules();
+    logger(dbg_eventbroker, basic) << "All modules got successfully unloaded";
     retval = OK;
-  } catch (std::exception const& e) {
-    logger(log_runtime_error, basic)
-        << "Error: Module unloading failed: " << e.what();
+  }
+  catch (std::exception const& e) {
+    logger(log_runtime_error, basic) << "Error: Module unloading failed: "
+                                     << e.what();
     retval = ERROR;
-  } catch (...) {
+  }
+  catch (...) {
     logger(log_runtime_error, basic)
         << "Error: unloading of all modules failed";
     retval = ERROR;
@@ -226,32 +230,30 @@ int neb_unload_all_modules(int flags, int reason) {
 }
 
 /* close (unload) a particular module */
-int neb_unload_module(void* mod, int flags, int reason) {
+int neb_unload_module(broker::handle* module, int flags, int reason) {
   (void)flags;
   (void)reason;
 
-  if (mod == NULL)
+  if (module == nullptr)
     return ERROR;
 
-  broker::handle* module = static_cast<broker::handle*>(mod);
-
-  if (module->is_loaded() == false)
+  if (!module->is_loaded())
     return OK;
 
-  logger(dbg_eventbroker, basic)
-      << "Attempting to unload module '" << module->get_filename() << "'";
+  logger(dbg_eventbroker, basic) << "Attempting to unload module '"
+                                 << module->get_filename() << "'";
 
   module->close();
 
   /* deregister all of the module's callbacks */
   neb_deregister_module_callbacks(module);
 
-  logger(dbg_eventbroker, basic)
-      << "Module '" << module->get_filename() << "' unloaded successfully";
+  logger(dbg_eventbroker, basic) << "Module '" << module->get_filename()
+                                 << "' unloaded successfully";
 
-  logger(log_info_message, basic)
-      << "Event broker module '" << module->get_filename()
-      << "' deinitialized successfully";
+  logger(log_info_message, basic) << "Event broker module '"
+                                  << module->get_filename()
+                                  << "' deinitialized successfully";
 
   return OK;
 }
@@ -300,10 +302,11 @@ int neb_set_module_info(void* handle, int type, char const* data) {
         break;
     }
 
-    logger(dbg_eventbroker, basic)
-        << "set module info success: filename='" << module->get_filename()
-        << "', type='" << type << "'";
-  } catch (...) {
+    logger(dbg_eventbroker, basic) << "set module info success: filename='"
+                                   << module->get_filename() << "', type='"
+                                   << type << "'";
+  }
+  catch (...) {
     logger(dbg_eventbroker, basic) << "Counld not set module info.";
     return ERROR;
   }
@@ -355,7 +358,8 @@ int neb_register_callback(int callback_type,
     nebcallback* last_callback(NULL);
     nebcallback* temp_callback(NULL);
     for (temp_callback = neb_callback_list[callback_type];
-         temp_callback != NULL; temp_callback = temp_callback->next) {
+         temp_callback != NULL;
+         temp_callback = temp_callback->next) {
       if (temp_callback->priority > new_callback->priority)
         break;
       last_callback = temp_callback;
@@ -376,17 +380,16 @@ int neb_register_callback(int callback_type,
 
 /* dregisters all callback functions for a given module */
 int neb_deregister_module_callbacks(void* mod) {
-  nebcallback* temp_callback;
-  nebcallback* next_callback{NULL};
-  int callback_type;
+  nebcallback* next_callback{nullptr};
 
   if (!mod)
     return NEBERROR_NOMODULE;
 
-  for (callback_type = 0; callback_type < NEBCALLBACK_NUMITEMS;
+  for (int callback_type = 0; callback_type < NEBCALLBACK_NUMITEMS;
        callback_type++) {
-    for (temp_callback = neb_callback_list[callback_type];
-         temp_callback != NULL; temp_callback = next_callback) {
+    for (nebcallback* temp_callback = neb_callback_list[callback_type];
+         temp_callback != nullptr;
+         temp_callback = next_callback) {
       next_callback = temp_callback->next;
       if ((void*)temp_callback->module_handle == (void*)mod) {
         union {
@@ -413,7 +416,8 @@ int neb_deregister_callback(int callback_type,
 
   /* find the callback to remove */
   for (temp_callback = last_callback = neb_callback_list[callback_type];
-       temp_callback != NULL; temp_callback = next_callback) {
+       temp_callback != NULL;
+       temp_callback = next_callback) {
     next_callback = temp_callback->next;
 
     /* we found it */
@@ -429,13 +433,13 @@ int neb_deregister_callback(int callback_type,
   }
 
   /* we couldn't find the callback */
-  if (temp_callback == NULL)
+  if (temp_callback == nullptr)
     return NEBERROR_CALLBACKNOTFOUND;
 
   else {
     /* only one item in the list */
     if (temp_callback != last_callback->next)
-      neb_callback_list[callback_type] = NULL;
+      neb_callback_list[callback_type] = nullptr;
     else
       last_callback->next = next_callback;
     delete temp_callback;
@@ -456,8 +460,8 @@ int neb_make_callbacks(int callback_type, void* data) {
     return ERROR;
 
   if (callback_type != NEBCALLBACK_LOG_DATA) {
-    logger(dbg_eventbroker, more)
-        << "Making callbacks (type " << callback_type << ")...";
+    logger(dbg_eventbroker, more) << "Making callbacks (type " << callback_type
+                                  << ")...";
   }
 
   /* make the callbacks... */
@@ -472,13 +476,11 @@ int neb_make_callbacks(int callback_type, void* data) {
     neb.data = temp_callback->callback_func;
     cbresult = (*neb.func)(callback_type, data);
 
-    temp_callback = next_callback;
-
     total_callbacks++;
     if (callback_type != NEBCALLBACK_LOG_DATA) {
-      logger(dbg_eventbroker, most)
-          << "Callback #" << total_callbacks << " (type " << callback_type
-          << ") return (code = " << cbresult << ")";
+      logger(dbg_eventbroker, most) << "Callback #" << total_callbacks
+                                    << " (type " << callback_type
+                                    << ") return (code = " << cbresult << ")";
     }
 
     /* module wants to cancel callbacks to other modules (and potentially cancel

--- a/src/notifier.cc
+++ b/src/notifier.cc
@@ -38,20 +38,28 @@ using namespace com::centreon::engine;
 using namespace com::centreon::engine::logging;
 using namespace com::centreon::engine::configuration::applier;
 
-std::array<std::string, 9> const notifier::tab_notification_str{
-    {"NORMAL",        "RECOVERY",     "ACKNOWLEDGEMENT",
-     "FLAPPINGSTART", "FLAPPINGSTOP", "FLAPPINGDISABLED",
-     "DOWNTIMESTART", "DOWNTIMEEND",  "DOWNTIMECANCELLED", }};
+std::array<std::string, 9> const notifier::tab_notification_str{{
+    "NORMAL",
+    "RECOVERY",
+    "ACKNOWLEDGEMENT",
+    "FLAPPINGSTART",
+    "FLAPPINGSTOP",
+    "FLAPPINGDISABLED",
+    "DOWNTIMESTART",
+    "DOWNTIMEEND",
+    "DOWNTIMECANCELLED",
+}};
 
 std::array<std::string, 2> const notifier::tab_state_type{{"SOFT", "HARD"}};
 
-std::array<notifier::is_viable, 6> const notifier::_is_notification_viable{
-    {&notifier::_is_notification_viable_normal,
-     &notifier::_is_notification_viable_recovery,
-     &notifier::_is_notification_viable_acknowledgement,
-     &notifier::_is_notification_viable_flapping,
-     &notifier::_is_notification_viable_downtime,
-     &notifier::_is_notification_viable_custom, }};
+std::array<notifier::is_viable, 6> const notifier::_is_notification_viable{{
+    &notifier::_is_notification_viable_normal,
+    &notifier::_is_notification_viable_recovery,
+    &notifier::_is_notification_viable_acknowledgement,
+    &notifier::_is_notification_viable_flapping,
+    &notifier::_is_notification_viable_downtime,
+    &notifier::_is_notification_viable_custom,
+}};
 
 uint64_t notifier::_next_notification_id{1L};
 
@@ -88,15 +96,28 @@ notifier::notifier(notifier::notifier_type notifier_type,
                    bool retain_status_information,
                    bool retain_nonstatus_information,
                    bool is_volatile)
-    : checkable{
-          display_name,           check_command,       checks_enabled,
-          accept_passive_checks,  check_interval,      retry_interval,
-          max_attempts,           check_period,        event_handler,
-          event_handler_enabled,  notes,               notes_url,
-          action_url,             icon_image,          icon_image_alt,
-          flap_detection_enabled, low_flap_threshold,  high_flap_threshold,
-          check_freshness,        freshness_threshold, obsess_over,
-          timezone},
+    : checkable{display_name,
+                check_command,
+                checks_enabled,
+                accept_passive_checks,
+                check_interval,
+                retry_interval,
+                max_attempts,
+                check_period,
+                event_handler,
+                event_handler_enabled,
+                notes,
+                notes_url,
+                action_url,
+                icon_image,
+                icon_image_alt,
+                flap_detection_enabled,
+                low_flap_threshold,
+                high_flap_threshold,
+                check_freshness,
+                freshness_threshold,
+                obsess_over,
+                timezone},
       _notifier_type{notifier_type},
       _stalk_type{stalk},
       _flap_type{0},
@@ -143,7 +164,9 @@ notifier::notifier(notifier::notifier_type notifier_type,
   }
 }
 
-notifier::~notifier() { checks::checker::forget(this); }
+notifier::~notifier() {
+  checks::checker::forget(this);
+}
 
 unsigned long notifier::get_current_event_id() const {
   return _current_event_id;
@@ -502,9 +525,9 @@ bool notifier::_is_notification_viable_flapping(reason_type type,
     f = flappingdisabled;
 
   if (!get_notify_on(f)) {
-    logger(dbg_notifications, more) << "We shouldn't notify about "
-                                    << tab_notification_str[type]
-                                    << " events for this notifier.";
+    logger(dbg_notifications, more)
+        << "We shouldn't notify about " << tab_notification_str[type]
+        << " events for this notifier.";
     return false;
   }
 
@@ -530,9 +553,9 @@ bool notifier::_is_notification_viable_flapping(reason_type type,
   /* Don't send a notification if the same has already been sent previously. */
   if (_notification[cat_flapping] &&
       _notification[cat_flapping]->get_reason() == type) {
-    logger(dbg_notifications, more) << "We shouldn't notify about a "
-                                    << tab_notification_str[type]
-                                    << " event: already sent.";
+    logger(dbg_notifications, more)
+        << "We shouldn't notify about a " << tab_notification_str[type]
+        << " event: already sent.";
     return false;
   }
 
@@ -671,13 +694,11 @@ std::unordered_set<contact*> notifier::get_contacts_to_notify(
       for (contactgroup_map_unsafe::const_iterator
                cgit{e->get_contactgroups().begin()},
            cgend{e->get_contactgroups().end()};
-           cgit != cgend;
-           ++cgit) {
+           cgit != cgend; ++cgit) {
         for (contact_map_unsafe::const_iterator
                  cit{cgit->second->get_members().begin()},
              cend{cgit->second->get_members().end()};
-             cit != cend;
-             ++cit) {
+             cit != cend; ++cit) {
           assert(cit->second);
           if (cit->second->should_be_notified(cat, type, *this))
             retval.insert(cit->second);
@@ -691,8 +712,7 @@ std::unordered_set<contact*> notifier::get_contacts_to_notify(
      * for the moment if those contacts accept notification. */
     for (contact_map_unsafe::const_iterator it{get_contacts().begin()},
          end{get_contacts().end()};
-         it != end;
-         ++it) {
+         it != end; ++it) {
       assert(it->second);
       if (it->second->should_be_notified(cat, type, *this))
         retval.insert(it->second);
@@ -702,13 +722,11 @@ std::unordered_set<contact*> notifier::get_contacts_to_notify(
     for (contactgroup_map_unsafe::const_iterator
              it{get_contactgroups().begin()},
          end{get_contactgroups().end()};
-         it != end;
-         ++it) {
+         it != end; ++it) {
       for (contact_map_unsafe::const_iterator
                cit{it->second->get_members().begin()},
            cend{it->second->get_members().end()};
-           cit != cend;
-           ++cit) {
+           cit != cend; ++cit) {
         assert(cit->second);
         if (cit->second->should_be_notified(cat, type, *this))
           retval.insert(cit->second);
@@ -758,15 +776,9 @@ int notifier::notify(notifier::reason_type type,
       get_contacts_to_notify(cat, type, notification_interval, escalated)};
 
   _current_notification_id = _next_notification_id++;
-  std::unique_ptr<notification> notif{new notification(this,
-                                                       type,
-                                                       not_author,
-                                                       not_data,
-                                                       options,
-                                                       _current_notification_id,
-                                                       _notification_number,
-                                                       notification_interval,
-                                                       escalated)};
+  std::unique_ptr<notification> notif{new notification(
+      this, type, not_author, not_data, options, _current_notification_id,
+      _notification_number, notification_interval, escalated)};
 
   /* Let's make the notification. */
   int retval{notif->execute(to_notify)};
@@ -937,7 +949,9 @@ bool notifier::get_flap_detection_on(notification_flag type) const noexcept {
   return _flap_type & type;
 }
 
-uint32_t notifier::get_flap_detection_on() const noexcept { return _flap_type; }
+uint32_t notifier::get_flap_detection_on() const noexcept {
+  return _flap_type;
+}
 
 void notifier::set_flap_detection_on(uint32_t type) noexcept {
   _flap_type = type;
@@ -951,9 +965,13 @@ bool notifier::get_stalk_on(notification_flag type) const noexcept {
   return _stalk_type & type;
 }
 
-uint32_t notifier::get_stalk_on() const noexcept { return _stalk_type; }
+uint32_t notifier::get_stalk_on() const noexcept {
+  return _stalk_type;
+}
 
-void notifier::set_stalk_on(uint32_t type) noexcept { _stalk_type = type; }
+void notifier::set_stalk_on(uint32_t type) noexcept {
+  _stalk_type = type;
+}
 
 void notifier::add_stalk_on(notification_flag type) noexcept {
   _stalk_type |= type;
@@ -987,7 +1005,9 @@ void notifier::set_flapping_comment_id(uint64_t comment_id) noexcept {
   _flapping_comment_id = comment_id;
 }
 
-int notifier::get_check_options(void) const noexcept { return _check_options; }
+int notifier::get_check_options(void) const noexcept {
+  return _check_options;
+}
 
 void notifier::set_check_options(int option) noexcept {
   _check_options = option;
@@ -1053,7 +1073,9 @@ int notifier::get_notification_number() const noexcept {
  *
  * @return a long unsigned integer.
  */
-uint64_t notifier::get_next_notification_id() { return _next_notification_id; }
+uint64_t notifier::get_next_notification_id() {
+  return _next_notification_id;
+}
 
 notifier::notifier_type notifier::get_notifier_type() const noexcept {
   return _notifier_type;
@@ -1063,8 +1085,8 @@ std::unordered_map<std::string, contact*>& notifier::get_contacts() noexcept {
   return _contacts;
 }
 
-std::unordered_map<std::string, contact*> const& notifier::get_contacts() const
-    noexcept {
+std::unordered_map<std::string, contact*> const& notifier::get_contacts()
+    const noexcept {
   return _contacts;
 }
 
@@ -1092,16 +1114,14 @@ bool is_contact_for_notifier(com::centreon::engine::notifier* notif,
   // Search all individual contacts of this host.
   for (contact_map_unsafe::const_iterator it{notif->get_contacts().begin()},
        end{notif->get_contacts().end()};
-       it != end;
-       ++it)
+       it != end; ++it)
     if (it->second == cntct)
       return true;
 
   for (contactgroup_map_unsafe::const_iterator
            it{notif->get_contactgroups().begin()},
        end{notif->get_contactgroups().end()};
-       it != end;
-       ++it) {
+       it != end; ++it) {
     assert(it->second);
     if (it->second->get_members().find(cntct->get_name()) ==
         it->second->get_members().end())
@@ -1187,8 +1207,7 @@ void notifier::resolve(int& w, int& e) {
   /* check all contacts */
   for (contact_map_unsafe::iterator it{get_contacts().begin()},
        end{get_contacts().end()};
-       it != end;
-       ++it) {
+       it != end; ++it) {
     contact_map::const_iterator found_it{contact::contacts.find(it->first)};
     if (found_it == contact::contacts.end() || !found_it->second.get()) {
       logger(log_verification_error, basic)
@@ -1203,8 +1222,7 @@ void notifier::resolve(int& w, int& e) {
   /* check all contact groups */
   for (contactgroup_map_unsafe::iterator it{get_contactgroups().begin()},
        end{get_contactgroups().end()};
-       it != end;
-       ++it) {
+       it != end; ++it) {
     // Find the contact group.
     contactgroup_map::const_iterator found_it{
         contactgroup::contactgroups.find(it->first)};
@@ -1336,7 +1354,8 @@ time_t notifier::get_next_notification_time(time_t offset) {
     set_no_more_notifications(false);
 
   logger(dbg_notifications, most) << "Interval used for calculating next valid "
-                                     "notification time: " << interval_to_use;
+                                     "notification time: "
+                                  << interval_to_use;
 
   /* calculate next notification time */
   time_t next_notification{
@@ -1346,7 +1365,9 @@ time_t notifier::get_next_notification_time(time_t offset) {
   return next_notification;
 }
 
-void notifier::set_flap_type(uint32_t type) noexcept { _flap_type = type; }
+void notifier::set_flap_type(uint32_t type) noexcept {
+  _flap_type = type;
+}
 
 timeperiod* notifier::get_notification_period_ptr() const noexcept {
   return _notification_period_ptr;
@@ -1495,18 +1516,15 @@ void notifier::set_notification(int32_t idx, std::string const& value) {
     }
   }
 
-  _notification[idx].reset(new notification(this,
-                                            type,
-                                            author,
-                                            "",
-                                            options,
-                                            id,
-                                            number,
-                                            interval,
-                                            escalated,
+  _notification[idx].reset(new notification(this, type, author, "", options, id,
+                                            number, interval, escalated,
                                             contacts));
 }
 
-bool notifier::get_is_volatile() const noexcept { return _is_volatile; }
+bool notifier::get_is_volatile() const noexcept {
+  return _is_volatile;
+}
 
-void notifier::set_is_volatile(bool vol) { _is_volatile = vol; }
+void notifier::set_is_volatile(bool vol) {
+  _is_volatile = vol;
+}

--- a/src/retention/dump.cc
+++ b/src/retention/dump.cc
@@ -47,8 +47,7 @@ using namespace com::centreon::engine::retention;
  */
 std::ostream& dump::comment(std::ostream& os,
                             com::centreon::engine::comment const& obj) {
-  logger(dbg_functions, basic)
-    << "dump::comment()";
+  logger(dbg_functions, basic) << "dump::comment()";
   char const* host_name;
   char const* service_description;
   if (obj.get_comment_type() == com::centreon::engine::comment::host) {
@@ -58,9 +57,9 @@ std::ostream& dump::comment(std::ostream& os,
     host_name = it->second->get_name().c_str();
     service_description = "";
     os << "hostcomment {\n";
-  }
-  else {
-    auto it = service::services_by_id.find({obj.get_host_id(), obj.get_service_id()});
+  } else {
+    auto it =
+        service::services_by_id.find({obj.get_host_id(), obj.get_service_id()});
     if (it == service::services_by_id.end())
       return os;
     host_name = it->second->get_hostname().c_str();
@@ -72,29 +71,19 @@ std::ostream& dump::comment(std::ostream& os,
     os << "service_description=" << service_description << "\n";
   os << "author=" << obj.get_author()
      << "\n"
-        "comment_data="
-     << obj.get_comment_data()
+        "comment_data=" << obj.get_comment_data()
      << "\n"
-        "comment_id="
-     << obj.get_comment_id()
+        "comment_id=" << obj.get_comment_id()
      << "\n"
-        "entry_time="
-     << static_cast<unsigned long>(obj.get_entry_time())
+        "entry_time=" << static_cast<unsigned long>(obj.get_entry_time())
      << "\n"
-        "expire_time="
-     << static_cast<unsigned long>(obj.get_expire_time())
+        "expire_time=" << static_cast<unsigned long>(obj.get_expire_time())
      << "\n"
-        "expires="
-     << obj.get_expires()
+        "expires=" << obj.get_expires() << "\n"
+                                           "persistent=" << obj.get_persistent()
      << "\n"
-        "persistent="
-     << obj.get_persistent()
-     << "\n"
-        "source="
-     << obj.get_source()
-     << "\n"
-        "entry_type="
-     << obj.get_entry_type()
+        "source=" << obj.get_source() << "\n"
+                                         "entry_type=" << obj.get_entry_type()
      << "\n"
         "}\n";
   return os;
@@ -108,11 +97,11 @@ std::ostream& dump::comment(std::ostream& os,
  *  @return The output stream.
  */
 std::ostream& dump::comments(std::ostream& os) {
-  logger(dbg_functions, basic)
-    << "dump::comments()";
+  logger(dbg_functions, basic) << "dump::comments()";
   for (comment_map::iterator it(comment::comments.begin()),
        end(comment::comments.end());
-       it != end; ++it)
+       it != end;
+       ++it)
     dump::comment(os, *it->second);
   return os;
 }
@@ -128,14 +117,11 @@ std::ostream& dump::comments(std::ostream& os) {
 std::ostream& dump::contact(std::ostream& os,
                             com::centreon::engine::contact const& obj) {
   os << "contact {\n"
-        "contact_name="
-     << obj.get_name()
+        "contact_name=" << obj.get_name()
      << "\n"
-        "host_notification_period="
-     << obj.get_host_notification_period()
+        "host_notification_period=" << obj.get_host_notification_period()
      << "\n"
-        "host_notifications_enabled="
-     << obj.get_host_notifications_enabled()
+        "host_notifications_enabled=" << obj.get_host_notifications_enabled()
      << "\n"
         "last_host_notification="
      << static_cast<unsigned long>(obj.get_last_host_notification())
@@ -143,8 +129,7 @@ std::ostream& dump::contact(std::ostream& os,
         "last_service_notification="
      << static_cast<unsigned long>(obj.get_last_service_notification())
      << "\n"
-        "modified_attributes="
-     << (obj.get_modified_attributes() & ~0L)
+        "modified_attributes=" << (obj.get_modified_attributes() & ~0L)
      << "\n"
         "modified_host_attributes="
      << (obj.get_modified_host_attributes() &
@@ -154,8 +139,7 @@ std::ostream& dump::contact(std::ostream& os,
      << (obj.get_modified_service_attributes() &
          ~config->retained_contact_service_attribute_mask())
      << "\n"
-        "service_notification_period="
-     << obj.get_service_notification_period()
+        "service_notification_period=" << obj.get_service_notification_period()
      << "\n"
         "service_notifications_enabled="
      << obj.get_service_notifications_enabled() << "\n";
@@ -174,7 +158,8 @@ std::ostream& dump::contact(std::ostream& os,
 std::ostream& dump::contacts(std::ostream& os) {
   for (contact_map::const_iterator it{contact::contacts.begin()},
        end{contact::contacts.end()};
-       it != end; ++it)
+       it != end;
+       ++it)
     dump::contact(os, *it->second.get());
 
   return os;
@@ -198,7 +183,7 @@ std::ostream& dump::customvariables(std::ostream& os,
 
 std::ostream& dump::notifications(
     std::ostream& os,
-    std::array<std::shared_ptr<notification>, 6> const& obj) {
+    std::array<std::unique_ptr<notification>, 6> const& obj) {
   for (int i = 0; i < 6; i++)
     if (obj[i])
       os << "notification_" << i << "=" << *obj[i];
@@ -214,8 +199,7 @@ std::ostream& dump::notifications(
  *  @return The output stream.
  */
 std::ostream& dump::scheduled_downtime(std::ostream& os, downtime const& obj) {
-  logger(dbg_functions, basic)
-    << "dump::scheduled_downtime()";
+  logger(dbg_functions, basic) << "dump::scheduled_downtime()";
   obj.retention(os);
   return os;
 }
@@ -228,9 +212,8 @@ std::ostream& dump::scheduled_downtime(std::ostream& os, downtime const& obj) {
  *  @return The output stream.
  */
 std::ostream& dump::downtimes(std::ostream& os) {
-  logger(dbg_functions, basic)
-    << "dump::downtimes()";
-  for (std::pair<time_t, std::shared_ptr<downtime>> const& obj :
+  logger(dbg_functions, basic) << "dump::downtimes()";
+  for (std::pair<time_t, std::shared_ptr<downtime> > const& obj :
        downtimes::downtime_manager::instance().get_scheduled_downtimes())
     dump::scheduled_downtime(os, *obj.second);
   return os;
@@ -264,80 +247,55 @@ std::ostream& dump::header(std::ostream& os) {
 std::ostream& dump::host(std::ostream& os,
                          com::centreon::engine::host const& obj) {
   os << "host {\n"
-        "host_name="
-     << obj.get_name()
+        "host_name=" << obj.get_name() << "\n"
+                                          "host_id=" << obj.get_host_id()
      << "\n"
-        "host_id="
-     << obj.get_host_id()
+        "acknowledgement_type=" << obj.get_acknowledgement_type()
      << "\n"
-        "acknowledgement_type="
-     << obj.get_acknowledgement_type()
+        "active_checks_enabled=" << obj.get_checks_enabled()
      << "\n"
-        "active_checks_enabled="
-     << obj.get_checks_enabled()
+        "check_command=" << obj.get_check_command()
      << "\n"
-        "check_command="
-     << obj.get_check_command()
+        "check_execution_time=" << std::setprecision(3) << std::fixed
+     << obj.get_execution_time() << "\n"
+                                    "check_latency=" << std::setprecision(3)
+     << std::fixed << obj.get_latency()
      << "\n"
-        "check_execution_time="
-     << std::setprecision(3) << std::fixed << obj.get_execution_time()
+        "check_options=" << obj.get_check_options()
      << "\n"
-        "check_latency="
-     << std::setprecision(3) << std::fixed << obj.get_latency()
+        "check_period=" << obj.get_check_period()
      << "\n"
-        "check_options="
-     << obj.get_check_options()
+        "check_type=" << obj.get_check_type()
      << "\n"
-        "check_period="
-     << obj.get_check_period()
+        "current_attempt=" << obj.get_current_attempt()
      << "\n"
-        "check_type="
-     << obj.get_check_type()
+        "current_event_id=" << obj.get_current_event_id()
      << "\n"
-        "current_attempt="
-     << obj.get_current_attempt()
+        "current_notification_id=" << obj.get_current_notification_id()
      << "\n"
-        "current_event_id="
-     << obj.get_current_event_id()
+        "current_notification_number=" << obj.get_notification_number()
      << "\n"
-        "current_notification_id="
-     << obj.get_current_notification_id()
+        "current_problem_id=" << obj.get_current_problem_id()
      << "\n"
-        "current_notification_number="
-     << obj.get_notification_number()
+        "current_state=" << obj.get_current_state()
      << "\n"
-        "current_problem_id="
-     << obj.get_current_problem_id()
+        "event_handler=" << obj.get_event_handler()
      << "\n"
-        "current_state="
-     << obj.get_current_state()
+        "event_handler_enabled=" << obj.get_event_handler_enabled()
      << "\n"
-        "event_handler="
-     << obj.get_event_handler()
+        "flap_detection_enabled=" << obj.get_flap_detection_enabled()
      << "\n"
-        "event_handler_enabled="
-     << obj.get_event_handler_enabled()
+        "has_been_checked=" << obj.has_been_checked()
      << "\n"
-        "flap_detection_enabled="
-     << obj.get_flap_detection_enabled()
+        "is_flapping=" << obj.get_is_flapping()
      << "\n"
-        "has_been_checked="
-     << obj.has_been_checked()
+        "last_acknowledgement=" << obj.get_last_acknowledgement()
      << "\n"
-        "is_flapping="
-     << obj.get_is_flapping()
+        "last_check=" << static_cast<unsigned long>(obj.get_last_check())
      << "\n"
-        "last_acknowledgement="
-     << obj.get_last_acknowledgement()
+        "last_event_id=" << obj.get_last_event_id()
      << "\n"
-        "last_check="
-     << static_cast<unsigned long>(obj.get_last_check())
-     << "\n"
-        "last_event_id="
-     << obj.get_last_event_id()
-     << "\n"
-        "last_hard_state="
-     << obj.get_last_hard_state()
+        "last_hard_state=" << obj.get_last_hard_state()
      << "\n"
         "last_hard_state_change="
      << static_cast<unsigned long>(obj.get_last_hard_state_change())
@@ -345,13 +303,10 @@ std::ostream& dump::host(std::ostream& os,
         "last_notification="
      << static_cast<unsigned long>(obj.get_last_notification())
      << "\n"
-        "last_problem_id="
-     << obj.get_last_problem_id()
+        "last_problem_id=" << obj.get_last_problem_id()
      << "\n"
-        "last_state="
-     << obj.get_last_state()
-     << "\n"
-        "last_state_change="
+        "last_state=" << obj.get_last_state() << "\n"
+                                                 "last_state_change="
      << static_cast<unsigned long>(obj.get_last_state_change())
      << "\n"
         "last_time_down="
@@ -360,69 +315,52 @@ std::ostream& dump::host(std::ostream& os,
         "last_time_unreachable="
      << static_cast<unsigned long>(obj.get_last_time_unreachable())
      << "\n"
-        "last_time_up="
-     << static_cast<unsigned long>(obj.get_last_time_up())
+        "last_time_up=" << static_cast<unsigned long>(obj.get_last_time_up())
      << "\n"
-        "long_plugin_output="
-     << obj.get_long_plugin_output()
+        "long_plugin_output=" << obj.get_long_plugin_output()
      << "\n"
-        "max_attempts="
-     << obj.get_max_attempts()
+        "max_attempts=" << obj.get_max_attempts()
      << "\n"
-        "modified_attributes="
-     << (obj.get_modified_attributes() &
-         ~config->retained_host_attribute_mask())
+        "modified_attributes=" << (obj.get_modified_attributes() &
+                                   ~config->retained_host_attribute_mask())
      << "\n"
-        "next_check="
-     << static_cast<unsigned long>(obj.get_next_check())
+        "next_check=" << static_cast<unsigned long>(obj.get_next_check())
      << "\n"
-        "normal_check_interval="
-     << obj.get_check_interval()
+        "normal_check_interval=" << obj.get_check_interval()
      << "\n"
-        "notification_period="
-     << obj.get_notification_period()
+        "notification_period=" << obj.get_notification_period()
      << "\n"
-        "notifications_enabled="
-     << obj.get_notifications_enabled()
+        "notifications_enabled=" << obj.get_notifications_enabled()
      << "\n"
-        "notified_on_down="
-     << obj.get_notified_on(notifier::down)
+        "notified_on_down=" << obj.get_notified_on(notifier::down)
      << "\n"
-        "notified_on_unreachable="
-     << obj.get_notified_on(notifier::unreachable)
+        "notified_on_unreachable=" << obj.get_notified_on(notifier::unreachable)
      << "\n"
-        "obsess_over_host="
-     << obj.get_obsess_over()
+        "obsess_over_host=" << obj.get_obsess_over()
      << "\n"
-        "passive_checks_enabled="
-     << obj.get_accept_passive_checks()
+        "passive_checks_enabled=" << obj.get_accept_passive_checks()
      << "\n"
-        "percent_state_change="
-     << std::setprecision(2) << std::fixed << obj.get_percent_state_change()
+        "percent_state_change=" << std::setprecision(2) << std::fixed
+     << obj.get_percent_state_change()
      << "\n"
-        "performance_data="
-     << obj.get_perf_data()
+        "performance_data=" << obj.get_perf_data()
      << "\n"
-        "plugin_output="
-     << obj.get_plugin_output()
+        "plugin_output=" << obj.get_plugin_output()
      << "\n"
         "problem_has_been_acknowledged="
      << obj.get_problem_has_been_acknowledged()
      << "\n"
-        "process_performance_data="
-     << obj.get_process_performance_data()
+        "process_performance_data=" << obj.get_process_performance_data()
      << "\n"
-        "retry_check_interval="
-     << obj.get_check_interval()
+        "retry_check_interval=" << obj.get_check_interval()
      << "\n"
-        "state_type="
-     << obj.get_state_type() << "\n";
+        "state_type=" << obj.get_state_type() << "\n";
 
   os << "state_history=";
   for (unsigned int x(0); x < obj.get_state_history().size(); ++x)
     os << (x > 0 ? "," : "")
-       << obj.get_state_history()[(x + obj.get_state_history_index()) %
-                                  MAX_STATE_HISTORY_ENTRIES];
+       << obj.get_state_history()
+              [(x + obj.get_state_history_index()) % MAX_STATE_HISTORY_ENTRIES];
   os << "\n";
 
   dump::notifications(os, obj.get_current_notifications());
@@ -441,7 +379,8 @@ std::ostream& dump::host(std::ostream& os,
 std::ostream& dump::hosts(std::ostream& os) {
   for (host_map::iterator it(com::centreon::engine::host::hosts.begin()),
        end(com::centreon::engine::host::hosts.end());
-       it != end; ++it)
+       it != end;
+       ++it)
     dump::host(os, *it->second);
   return os;
 }
@@ -455,10 +394,8 @@ std::ostream& dump::hosts(std::ostream& os) {
  */
 std::ostream& dump::info(std::ostream& os) {
   os << "info {\n"
-        "created="
-     << static_cast<unsigned long>(time(NULL))
-     << "\n"
-        "}\n";
+        "created=" << static_cast<unsigned long>(time(NULL)) << "\n"
+                                                                "}\n";
   return os;
 }
 
@@ -471,26 +408,19 @@ std::ostream& dump::info(std::ostream& os) {
  */
 std::ostream& dump::program(std::ostream& os) {
   os << "program {\n"
-        "active_host_checks_enabled="
-     << config->execute_host_checks()
+        "active_host_checks_enabled=" << config->execute_host_checks()
      << "\n"
-        "active_service_checks_enabled="
-     << config->execute_service_checks()
+        "active_service_checks_enabled=" << config->execute_service_checks()
      << "\n"
-        "check_host_freshness="
-     << config->check_host_freshness()
+        "check_host_freshness=" << config->check_host_freshness()
      << "\n"
-        "check_service_freshness="
-     << config->check_service_freshness()
+        "check_service_freshness=" << config->check_service_freshness()
      << "\n"
-        "enable_event_handlers="
-     << config->enable_event_handlers()
+        "enable_event_handlers=" << config->enable_event_handlers()
      << "\n"
-        "enable_flap_detection="
-     << config->enable_flap_detection()
+        "enable_flap_detection=" << config->enable_flap_detection()
      << "\n"
-        "enable_notifications="
-     << config->enable_notifications()
+        "enable_notifications=" << config->enable_notifications()
      << "\n"
         "global_host_event_handler="
      << config->global_host_event_handler().c_str()
@@ -506,32 +436,24 @@ std::ostream& dump::program(std::ostream& os) {
      << (modified_service_process_attributes &
          ~config->retained_process_host_attribute_mask())
      << "\n"
-        "next_comment_id="
-     << comment::get_next_comment_id()
+        "next_comment_id=" << comment::get_next_comment_id()
      << "\n"
-        "next_event_id="
-     << next_event_id
+        "next_event_id=" << next_event_id
      << "\n"
-        "next_notification_id="
-     << next_notification_id
+        "next_notification_id=" << next_notification_id
      << "\n"
-        "next_problem_id="
-     << next_problem_id
+        "next_problem_id=" << next_problem_id
      << "\n"
-        "obsess_over_hosts="
-     << config->obsess_over_hosts()
+        "obsess_over_hosts=" << config->obsess_over_hosts()
      << "\n"
-        "obsess_over_services="
-     << config->obsess_over_services()
+        "obsess_over_services=" << config->obsess_over_services()
      << "\n"
-        "passive_host_checks_enabled="
-     << config->accept_passive_host_checks()
+        "passive_host_checks_enabled=" << config->accept_passive_host_checks()
      << "\n"
         "passive_service_checks_enabled="
      << config->accept_passive_service_checks()
      << "\n"
-        "process_performance_data="
-     << config->process_performance_data()
+        "process_performance_data=" << config->process_performance_data()
      << "\n"
         "}\n";
   return os;
@@ -549,8 +471,8 @@ bool dump::save(std::string const& path) {
     return true;
 
   // send data to event broker
-  broker_retention_data(NEBTYPE_RETENTIONDATA_STARTSAVE, NEBFLAG_NONE,
-                        NEBATTR_NONE, NULL);
+  broker_retention_data(
+      NEBTYPE_RETENTIONDATA_STARTSAVE, NEBFLAG_NONE, NEBATTR_NONE, NULL);
 
   bool ret(false);
   try {
@@ -568,13 +490,14 @@ bool dump::save(std::string const& path) {
     dump::downtimes(stream);
 
     ret = true;
-  } catch (std::exception const& e) {
+  }
+  catch (std::exception const& e) {
     logger(log_runtime_error, basic) << e.what();
   }
 
   // send data to event broker.
-  broker_retention_data(NEBTYPE_RETENTIONDATA_ENDSAVE, NEBFLAG_NONE,
-                        NEBATTR_NONE, NULL);
+  broker_retention_data(
+      NEBTYPE_RETENTIONDATA_ENDSAVE, NEBFLAG_NONE, NEBATTR_NONE, NULL);
   return ret;
 }
 
@@ -592,89 +515,63 @@ std::ostream& dump::service(std::ostream& os, class service const& obj) {
     hostname = obj.get_host_ptr()->get_name();
 
   os << "service {\n"
-        "host_name="
-     << obj.get_hostname()
+        "host_name=" << obj.get_hostname()
      << "\n"
-        "service_description="
-     << obj.get_description()
-     << "\n"
-        "host_id="
+        "service_description=" << obj.get_description() << "\n"
+                                                           "host_id="
      << service::services[{hostname, obj.get_description()}]->get_host_id()
      << "\n"
         "service_id="
      << service::services[{hostname, obj.get_description()}]->get_service_id()
      << "\n"
-        "acknowledgement_type="
-     << obj.get_acknowledgement_type()
+        "acknowledgement_type=" << obj.get_acknowledgement_type()
      << "\n"
-        "active_checks_enabled="
-     << obj.get_checks_enabled()
+        "active_checks_enabled=" << obj.get_checks_enabled()
      << "\n"
-        "check_command="
-     << obj.get_check_command()
+        "check_command=" << obj.get_check_command()
      << "\n"
-        "check_execution_time="
-     << std::setprecision(3) << std::fixed << obj.get_execution_time()
-     << "\n"
-        "check_flapping_recovery_notification="
+        "check_execution_time=" << std::setprecision(3) << std::fixed
+     << obj.get_execution_time() << "\n"
+                                    "check_flapping_recovery_notification="
      << obj.get_check_flapping_recovery_notification()
      << "\n"
-        "check_latency="
-     << std::setprecision(3) << std::fixed << obj.get_latency()
+        "check_latency=" << std::setprecision(3) << std::fixed
+     << obj.get_latency() << "\n"
+                             "check_options=" << obj.get_check_options()
      << "\n"
-        "check_options="
-     << obj.get_check_options()
+        "check_period=" << obj.get_check_period()
      << "\n"
-        "check_period="
-     << obj.get_check_period()
+        "check_type=" << obj.get_check_type()
      << "\n"
-        "check_type="
-     << obj.get_check_type()
+        "current_attempt=" << obj.get_current_attempt()
      << "\n"
-        "current_attempt="
-     << obj.get_current_attempt()
+        "current_event_id=" << obj.get_current_event_id()
      << "\n"
-        "current_event_id="
-     << obj.get_current_event_id()
+        "current_notification_id=" << obj.get_current_notification_id()
      << "\n"
-        "current_notification_id="
-     << obj.get_current_notification_id()
+        "current_notification_number=" << obj.get_notification_number()
      << "\n"
-        "current_notification_number="
-     << obj.get_notification_number()
+        "current_problem_id=" << obj.get_current_problem_id()
      << "\n"
-        "current_problem_id="
-     << obj.get_current_problem_id()
+        "current_state=" << obj.get_current_state()
      << "\n"
-        "current_state="
-     << obj.get_current_state()
+        "event_handler=" << obj.get_event_handler()
      << "\n"
-        "event_handler="
-     << obj.get_event_handler()
+        "event_handler_enabled=" << obj.get_event_handler_enabled()
      << "\n"
-        "event_handler_enabled="
-     << obj.get_event_handler_enabled()
+        "flap_detection_enabled=" << obj.get_flap_detection_enabled()
      << "\n"
-        "flap_detection_enabled="
-     << obj.get_flap_detection_enabled()
+        "has_been_checked=" << obj.has_been_checked()
      << "\n"
-        "has_been_checked="
-     << obj.has_been_checked()
+        "is_flapping=" << obj.get_is_flapping()
      << "\n"
-        "is_flapping="
-     << obj.get_is_flapping()
+        "last_acknowledgement=" << obj.get_last_acknowledgement()
      << "\n"
-        "last_acknowledgement="
-     << obj.get_last_acknowledgement()
+        "last_check=" << static_cast<unsigned long>(obj.get_last_check())
      << "\n"
-        "last_check="
-     << static_cast<unsigned long>(obj.get_last_check())
+        "last_event_id=" << obj.get_last_event_id()
      << "\n"
-        "last_event_id="
-     << obj.get_last_event_id()
-     << "\n"
-        "last_hard_state="
-     << obj.get_last_hard_state()
+        "last_hard_state=" << obj.get_last_hard_state()
      << "\n"
         "last_hard_state_change="
      << static_cast<unsigned long>(obj.get_last_hard_state_change())
@@ -682,20 +579,16 @@ std::ostream& dump::service(std::ostream& os, class service const& obj) {
         "last_notification="
      << static_cast<unsigned long>(obj.get_last_notification())
      << "\n"
-        "last_problem_id="
-     << obj.get_last_problem_id()
+        "last_problem_id=" << obj.get_last_problem_id()
      << "\n"
-        "last_state="
-     << obj.get_last_state()
-     << "\n"
-        "last_state_change="
+        "last_state=" << obj.get_last_state() << "\n"
+                                                 "last_state_change="
      << static_cast<unsigned long>(obj.get_last_state_change())
      << "\n"
         "last_time_critical="
      << static_cast<unsigned long>(obj.get_last_time_critical())
      << "\n"
-        "last_time_ok="
-     << static_cast<unsigned long>(obj.get_last_time_ok())
+        "last_time_ok=" << static_cast<unsigned long>(obj.get_last_time_ok())
      << "\n"
         "last_time_unknown="
      << static_cast<unsigned long>(obj.get_last_time_unknown())
@@ -703,69 +596,52 @@ std::ostream& dump::service(std::ostream& os, class service const& obj) {
         "last_time_warning="
      << static_cast<unsigned long>(obj.get_last_time_warning())
      << "\n"
-        "long_plugin_output="
-     << obj.get_long_plugin_output()
+        "long_plugin_output=" << obj.get_long_plugin_output()
      << "\n"
-        "max_attempts="
-     << obj.get_max_attempts()
+        "max_attempts=" << obj.get_max_attempts()
      << "\n"
-        "modified_attributes="
-     << (obj.get_modified_attributes() &
-         ~config->retained_host_attribute_mask())
+        "modified_attributes=" << (obj.get_modified_attributes() &
+                                   ~config->retained_host_attribute_mask())
      << "\n"
-        "next_check="
-     << static_cast<unsigned long>(obj.get_next_check())
+        "next_check=" << static_cast<unsigned long>(obj.get_next_check())
      << "\n"
-        "normal_check_interval="
-     << obj.get_check_interval()
+        "normal_check_interval=" << obj.get_check_interval()
      << "\n"
-        "notification_period="
-     << obj.get_notification_period()
+        "notification_period=" << obj.get_notification_period()
      << "\n"
-        "notifications_enabled="
-     << obj.get_notifications_enabled()
+        "notifications_enabled=" << obj.get_notifications_enabled()
      << "\n"
-        "notified_on_critical="
-     << obj.get_notified_on(notifier::critical)
+        "notified_on_critical=" << obj.get_notified_on(notifier::critical)
      << "\n"
-        "notified_on_unknown="
-     << obj.get_notified_on(notifier::unknown)
+        "notified_on_unknown=" << obj.get_notified_on(notifier::unknown)
      << "\n"
-        "notified_on_warning="
-     << obj.get_notified_on(notifier::warning)
+        "notified_on_warning=" << obj.get_notified_on(notifier::warning)
      << "\n"
-        "obsess_over_service="
-     << obj.get_obsess_over()
+        "obsess_over_service=" << obj.get_obsess_over()
      << "\n"
-        "passive_checks_enabled="
-     << obj.get_accept_passive_checks()
+        "passive_checks_enabled=" << obj.get_accept_passive_checks()
      << "\n"
-        "percent_state_change="
-     << std::setprecision(2) << std::fixed << obj.get_percent_state_change()
+        "percent_state_change=" << std::setprecision(2) << std::fixed
+     << obj.get_percent_state_change()
      << "\n"
-        "performance_data="
-     << obj.get_perf_data()
+        "performance_data=" << obj.get_perf_data()
      << "\n"
-        "plugin_output="
-     << obj.get_plugin_output()
+        "plugin_output=" << obj.get_plugin_output()
      << "\n"
         "problem_has_been_acknowledged="
      << obj.get_problem_has_been_acknowledged()
      << "\n"
-        "process_performance_data="
-     << obj.get_process_performance_data()
+        "process_performance_data=" << obj.get_process_performance_data()
      << "\n"
-        "retry_check_interval="
-     << obj.get_retry_interval()
+        "retry_check_interval=" << obj.get_retry_interval()
      << "\n"
-        "state_type="
-     << obj.get_state_type() << "\n";
+        "state_type=" << obj.get_state_type() << "\n";
 
   os << "state_history=";
   for (unsigned int x(0); x < MAX_STATE_HISTORY_ENTRIES; ++x)
     os << (x > 0 ? "," : "")
-       << obj.get_state_history()[(x + obj.get_state_history_index()) %
-                                  MAX_STATE_HISTORY_ENTRIES];
+       << obj.get_state_history()
+              [(x + obj.get_state_history_index()) % MAX_STATE_HISTORY_ENTRIES];
   os << "\n";
 
   dump::notifications(os, obj.get_current_notifications());
@@ -784,7 +660,8 @@ std::ostream& dump::service(std::ostream& os, class service const& obj) {
 std::ostream& dump::services(std::ostream& os) {
   for (service_map::iterator it(service::services.begin()),
        end(service::services.end());
-       it != end; ++it)
+       it != end;
+       ++it)
     dump::service(os, *it->second);
   return os;
 }

--- a/src/retention/dump.cc
+++ b/src/retention/dump.cc
@@ -71,19 +71,29 @@ std::ostream& dump::comment(std::ostream& os,
     os << "service_description=" << service_description << "\n";
   os << "author=" << obj.get_author()
      << "\n"
-        "comment_data=" << obj.get_comment_data()
+        "comment_data="
+     << obj.get_comment_data()
      << "\n"
-        "comment_id=" << obj.get_comment_id()
+        "comment_id="
+     << obj.get_comment_id()
      << "\n"
-        "entry_time=" << static_cast<unsigned long>(obj.get_entry_time())
+        "entry_time="
+     << static_cast<unsigned long>(obj.get_entry_time())
      << "\n"
-        "expire_time=" << static_cast<unsigned long>(obj.get_expire_time())
+        "expire_time="
+     << static_cast<unsigned long>(obj.get_expire_time())
      << "\n"
-        "expires=" << obj.get_expires() << "\n"
-                                           "persistent=" << obj.get_persistent()
+        "expires="
+     << obj.get_expires()
      << "\n"
-        "source=" << obj.get_source() << "\n"
-                                         "entry_type=" << obj.get_entry_type()
+        "persistent="
+     << obj.get_persistent()
+     << "\n"
+        "source="
+     << obj.get_source()
+     << "\n"
+        "entry_type="
+     << obj.get_entry_type()
      << "\n"
         "}\n";
   return os;
@@ -100,8 +110,7 @@ std::ostream& dump::comments(std::ostream& os) {
   logger(dbg_functions, basic) << "dump::comments()";
   for (comment_map::iterator it(comment::comments.begin()),
        end(comment::comments.end());
-       it != end;
-       ++it)
+       it != end; ++it)
     dump::comment(os, *it->second);
   return os;
 }
@@ -117,11 +126,14 @@ std::ostream& dump::comments(std::ostream& os) {
 std::ostream& dump::contact(std::ostream& os,
                             com::centreon::engine::contact const& obj) {
   os << "contact {\n"
-        "contact_name=" << obj.get_name()
+        "contact_name="
+     << obj.get_name()
      << "\n"
-        "host_notification_period=" << obj.get_host_notification_period()
+        "host_notification_period="
+     << obj.get_host_notification_period()
      << "\n"
-        "host_notifications_enabled=" << obj.get_host_notifications_enabled()
+        "host_notifications_enabled="
+     << obj.get_host_notifications_enabled()
      << "\n"
         "last_host_notification="
      << static_cast<unsigned long>(obj.get_last_host_notification())
@@ -129,7 +141,8 @@ std::ostream& dump::contact(std::ostream& os,
         "last_service_notification="
      << static_cast<unsigned long>(obj.get_last_service_notification())
      << "\n"
-        "modified_attributes=" << (obj.get_modified_attributes() & ~0L)
+        "modified_attributes="
+     << (obj.get_modified_attributes() & ~0L)
      << "\n"
         "modified_host_attributes="
      << (obj.get_modified_host_attributes() &
@@ -139,7 +152,8 @@ std::ostream& dump::contact(std::ostream& os,
      << (obj.get_modified_service_attributes() &
          ~config->retained_contact_service_attribute_mask())
      << "\n"
-        "service_notification_period=" << obj.get_service_notification_period()
+        "service_notification_period="
+     << obj.get_service_notification_period()
      << "\n"
         "service_notifications_enabled="
      << obj.get_service_notifications_enabled() << "\n";
@@ -158,8 +172,7 @@ std::ostream& dump::contact(std::ostream& os,
 std::ostream& dump::contacts(std::ostream& os) {
   for (contact_map::const_iterator it{contact::contacts.begin()},
        end{contact::contacts.end()};
-       it != end;
-       ++it)
+       it != end; ++it)
     dump::contact(os, *it->second.get());
 
   return os;
@@ -247,55 +260,80 @@ std::ostream& dump::header(std::ostream& os) {
 std::ostream& dump::host(std::ostream& os,
                          com::centreon::engine::host const& obj) {
   os << "host {\n"
-        "host_name=" << obj.get_name() << "\n"
-                                          "host_id=" << obj.get_host_id()
+        "host_name="
+     << obj.get_name()
      << "\n"
-        "acknowledgement_type=" << obj.get_acknowledgement_type()
+        "host_id="
+     << obj.get_host_id()
      << "\n"
-        "active_checks_enabled=" << obj.get_checks_enabled()
+        "acknowledgement_type="
+     << obj.get_acknowledgement_type()
      << "\n"
-        "check_command=" << obj.get_check_command()
+        "active_checks_enabled="
+     << obj.get_checks_enabled()
      << "\n"
-        "check_execution_time=" << std::setprecision(3) << std::fixed
-     << obj.get_execution_time() << "\n"
-                                    "check_latency=" << std::setprecision(3)
-     << std::fixed << obj.get_latency()
+        "check_command="
+     << obj.get_check_command()
      << "\n"
-        "check_options=" << obj.get_check_options()
+        "check_execution_time="
+     << std::setprecision(3) << std::fixed << obj.get_execution_time()
      << "\n"
-        "check_period=" << obj.get_check_period()
+        "check_latency="
+     << std::setprecision(3) << std::fixed << obj.get_latency()
      << "\n"
-        "check_type=" << obj.get_check_type()
+        "check_options="
+     << obj.get_check_options()
      << "\n"
-        "current_attempt=" << obj.get_current_attempt()
+        "check_period="
+     << obj.get_check_period()
      << "\n"
-        "current_event_id=" << obj.get_current_event_id()
+        "check_type="
+     << obj.get_check_type()
      << "\n"
-        "current_notification_id=" << obj.get_current_notification_id()
+        "current_attempt="
+     << obj.get_current_attempt()
      << "\n"
-        "current_notification_number=" << obj.get_notification_number()
+        "current_event_id="
+     << obj.get_current_event_id()
      << "\n"
-        "current_problem_id=" << obj.get_current_problem_id()
+        "current_notification_id="
+     << obj.get_current_notification_id()
      << "\n"
-        "current_state=" << obj.get_current_state()
+        "current_notification_number="
+     << obj.get_notification_number()
      << "\n"
-        "event_handler=" << obj.get_event_handler()
+        "current_problem_id="
+     << obj.get_current_problem_id()
      << "\n"
-        "event_handler_enabled=" << obj.get_event_handler_enabled()
+        "current_state="
+     << obj.get_current_state()
      << "\n"
-        "flap_detection_enabled=" << obj.get_flap_detection_enabled()
+        "event_handler="
+     << obj.get_event_handler()
      << "\n"
-        "has_been_checked=" << obj.has_been_checked()
+        "event_handler_enabled="
+     << obj.get_event_handler_enabled()
      << "\n"
-        "is_flapping=" << obj.get_is_flapping()
+        "flap_detection_enabled="
+     << obj.get_flap_detection_enabled()
      << "\n"
-        "last_acknowledgement=" << obj.get_last_acknowledgement()
+        "has_been_checked="
+     << obj.has_been_checked()
      << "\n"
-        "last_check=" << static_cast<unsigned long>(obj.get_last_check())
+        "is_flapping="
+     << obj.get_is_flapping()
      << "\n"
-        "last_event_id=" << obj.get_last_event_id()
+        "last_acknowledgement="
+     << obj.get_last_acknowledgement()
      << "\n"
-        "last_hard_state=" << obj.get_last_hard_state()
+        "last_check="
+     << static_cast<unsigned long>(obj.get_last_check())
+     << "\n"
+        "last_event_id="
+     << obj.get_last_event_id()
+     << "\n"
+        "last_hard_state="
+     << obj.get_last_hard_state()
      << "\n"
         "last_hard_state_change="
      << static_cast<unsigned long>(obj.get_last_hard_state_change())
@@ -303,10 +341,13 @@ std::ostream& dump::host(std::ostream& os,
         "last_notification="
      << static_cast<unsigned long>(obj.get_last_notification())
      << "\n"
-        "last_problem_id=" << obj.get_last_problem_id()
+        "last_problem_id="
+     << obj.get_last_problem_id()
      << "\n"
-        "last_state=" << obj.get_last_state() << "\n"
-                                                 "last_state_change="
+        "last_state="
+     << obj.get_last_state()
+     << "\n"
+        "last_state_change="
      << static_cast<unsigned long>(obj.get_last_state_change())
      << "\n"
         "last_time_down="
@@ -315,52 +356,69 @@ std::ostream& dump::host(std::ostream& os,
         "last_time_unreachable="
      << static_cast<unsigned long>(obj.get_last_time_unreachable())
      << "\n"
-        "last_time_up=" << static_cast<unsigned long>(obj.get_last_time_up())
+        "last_time_up="
+     << static_cast<unsigned long>(obj.get_last_time_up())
      << "\n"
-        "long_plugin_output=" << obj.get_long_plugin_output()
+        "long_plugin_output="
+     << obj.get_long_plugin_output()
      << "\n"
-        "max_attempts=" << obj.get_max_attempts()
+        "max_attempts="
+     << obj.get_max_attempts()
      << "\n"
-        "modified_attributes=" << (obj.get_modified_attributes() &
-                                   ~config->retained_host_attribute_mask())
+        "modified_attributes="
+     << (obj.get_modified_attributes() &
+         ~config->retained_host_attribute_mask())
      << "\n"
-        "next_check=" << static_cast<unsigned long>(obj.get_next_check())
+        "next_check="
+     << static_cast<unsigned long>(obj.get_next_check())
      << "\n"
-        "normal_check_interval=" << obj.get_check_interval()
+        "normal_check_interval="
+     << obj.get_check_interval()
      << "\n"
-        "notification_period=" << obj.get_notification_period()
+        "notification_period="
+     << obj.get_notification_period()
      << "\n"
-        "notifications_enabled=" << obj.get_notifications_enabled()
+        "notifications_enabled="
+     << obj.get_notifications_enabled()
      << "\n"
-        "notified_on_down=" << obj.get_notified_on(notifier::down)
+        "notified_on_down="
+     << obj.get_notified_on(notifier::down)
      << "\n"
-        "notified_on_unreachable=" << obj.get_notified_on(notifier::unreachable)
+        "notified_on_unreachable="
+     << obj.get_notified_on(notifier::unreachable)
      << "\n"
-        "obsess_over_host=" << obj.get_obsess_over()
+        "obsess_over_host="
+     << obj.get_obsess_over()
      << "\n"
-        "passive_checks_enabled=" << obj.get_accept_passive_checks()
+        "passive_checks_enabled="
+     << obj.get_accept_passive_checks()
      << "\n"
-        "percent_state_change=" << std::setprecision(2) << std::fixed
-     << obj.get_percent_state_change()
+        "percent_state_change="
+     << std::setprecision(2) << std::fixed << obj.get_percent_state_change()
      << "\n"
-        "performance_data=" << obj.get_perf_data()
+        "performance_data="
+     << obj.get_perf_data()
      << "\n"
-        "plugin_output=" << obj.get_plugin_output()
+        "plugin_output="
+     << obj.get_plugin_output()
      << "\n"
         "problem_has_been_acknowledged="
      << obj.get_problem_has_been_acknowledged()
      << "\n"
-        "process_performance_data=" << obj.get_process_performance_data()
+        "process_performance_data="
+     << obj.get_process_performance_data()
      << "\n"
-        "retry_check_interval=" << obj.get_check_interval()
+        "retry_check_interval="
+     << obj.get_check_interval()
      << "\n"
-        "state_type=" << obj.get_state_type() << "\n";
+        "state_type="
+     << obj.get_state_type() << "\n";
 
   os << "state_history=";
   for (unsigned int x(0); x < obj.get_state_history().size(); ++x)
     os << (x > 0 ? "," : "")
-       << obj.get_state_history()
-              [(x + obj.get_state_history_index()) % MAX_STATE_HISTORY_ENTRIES];
+       << obj.get_state_history()[(x + obj.get_state_history_index()) %
+                                  MAX_STATE_HISTORY_ENTRIES];
   os << "\n";
 
   dump::notifications(os, obj.get_current_notifications());
@@ -379,8 +437,7 @@ std::ostream& dump::host(std::ostream& os,
 std::ostream& dump::hosts(std::ostream& os) {
   for (host_map::iterator it(com::centreon::engine::host::hosts.begin()),
        end(com::centreon::engine::host::hosts.end());
-       it != end;
-       ++it)
+       it != end; ++it)
     dump::host(os, *it->second);
   return os;
 }
@@ -394,8 +451,10 @@ std::ostream& dump::hosts(std::ostream& os) {
  */
 std::ostream& dump::info(std::ostream& os) {
   os << "info {\n"
-        "created=" << static_cast<unsigned long>(time(NULL)) << "\n"
-                                                                "}\n";
+        "created="
+     << static_cast<unsigned long>(time(NULL))
+     << "\n"
+        "}\n";
   return os;
 }
 
@@ -408,19 +467,26 @@ std::ostream& dump::info(std::ostream& os) {
  */
 std::ostream& dump::program(std::ostream& os) {
   os << "program {\n"
-        "active_host_checks_enabled=" << config->execute_host_checks()
+        "active_host_checks_enabled="
+     << config->execute_host_checks()
      << "\n"
-        "active_service_checks_enabled=" << config->execute_service_checks()
+        "active_service_checks_enabled="
+     << config->execute_service_checks()
      << "\n"
-        "check_host_freshness=" << config->check_host_freshness()
+        "check_host_freshness="
+     << config->check_host_freshness()
      << "\n"
-        "check_service_freshness=" << config->check_service_freshness()
+        "check_service_freshness="
+     << config->check_service_freshness()
      << "\n"
-        "enable_event_handlers=" << config->enable_event_handlers()
+        "enable_event_handlers="
+     << config->enable_event_handlers()
      << "\n"
-        "enable_flap_detection=" << config->enable_flap_detection()
+        "enable_flap_detection="
+     << config->enable_flap_detection()
      << "\n"
-        "enable_notifications=" << config->enable_notifications()
+        "enable_notifications="
+     << config->enable_notifications()
      << "\n"
         "global_host_event_handler="
      << config->global_host_event_handler().c_str()
@@ -436,24 +502,32 @@ std::ostream& dump::program(std::ostream& os) {
      << (modified_service_process_attributes &
          ~config->retained_process_host_attribute_mask())
      << "\n"
-        "next_comment_id=" << comment::get_next_comment_id()
+        "next_comment_id="
+     << comment::get_next_comment_id()
      << "\n"
-        "next_event_id=" << next_event_id
+        "next_event_id="
+     << next_event_id
      << "\n"
-        "next_notification_id=" << next_notification_id
+        "next_notification_id="
+     << next_notification_id
      << "\n"
-        "next_problem_id=" << next_problem_id
+        "next_problem_id="
+     << next_problem_id
      << "\n"
-        "obsess_over_hosts=" << config->obsess_over_hosts()
+        "obsess_over_hosts="
+     << config->obsess_over_hosts()
      << "\n"
-        "obsess_over_services=" << config->obsess_over_services()
+        "obsess_over_services="
+     << config->obsess_over_services()
      << "\n"
-        "passive_host_checks_enabled=" << config->accept_passive_host_checks()
+        "passive_host_checks_enabled="
+     << config->accept_passive_host_checks()
      << "\n"
         "passive_service_checks_enabled="
      << config->accept_passive_service_checks()
      << "\n"
-        "process_performance_data=" << config->process_performance_data()
+        "process_performance_data="
+     << config->process_performance_data()
      << "\n"
         "}\n";
   return os;
@@ -471,8 +545,8 @@ bool dump::save(std::string const& path) {
     return true;
 
   // send data to event broker
-  broker_retention_data(
-      NEBTYPE_RETENTIONDATA_STARTSAVE, NEBFLAG_NONE, NEBATTR_NONE, NULL);
+  broker_retention_data(NEBTYPE_RETENTIONDATA_STARTSAVE, NEBFLAG_NONE,
+                        NEBATTR_NONE, NULL);
 
   bool ret(false);
   try {
@@ -490,14 +564,13 @@ bool dump::save(std::string const& path) {
     dump::downtimes(stream);
 
     ret = true;
-  }
-  catch (std::exception const& e) {
+  } catch (std::exception const& e) {
     logger(log_runtime_error, basic) << e.what();
   }
 
   // send data to event broker.
-  broker_retention_data(
-      NEBTYPE_RETENTIONDATA_ENDSAVE, NEBFLAG_NONE, NEBATTR_NONE, NULL);
+  broker_retention_data(NEBTYPE_RETENTIONDATA_ENDSAVE, NEBFLAG_NONE,
+                        NEBATTR_NONE, NULL);
   return ret;
 }
 
@@ -515,63 +588,89 @@ std::ostream& dump::service(std::ostream& os, class service const& obj) {
     hostname = obj.get_host_ptr()->get_name();
 
   os << "service {\n"
-        "host_name=" << obj.get_hostname()
+        "host_name="
+     << obj.get_hostname()
      << "\n"
-        "service_description=" << obj.get_description() << "\n"
-                                                           "host_id="
+        "service_description="
+     << obj.get_description()
+     << "\n"
+        "host_id="
      << service::services[{hostname, obj.get_description()}]->get_host_id()
      << "\n"
         "service_id="
      << service::services[{hostname, obj.get_description()}]->get_service_id()
      << "\n"
-        "acknowledgement_type=" << obj.get_acknowledgement_type()
+        "acknowledgement_type="
+     << obj.get_acknowledgement_type()
      << "\n"
-        "active_checks_enabled=" << obj.get_checks_enabled()
+        "active_checks_enabled="
+     << obj.get_checks_enabled()
      << "\n"
-        "check_command=" << obj.get_check_command()
+        "check_command="
+     << obj.get_check_command()
      << "\n"
-        "check_execution_time=" << std::setprecision(3) << std::fixed
-     << obj.get_execution_time() << "\n"
-                                    "check_flapping_recovery_notification="
+        "check_execution_time="
+     << std::setprecision(3) << std::fixed << obj.get_execution_time()
+     << "\n"
+        "check_flapping_recovery_notification="
      << obj.get_check_flapping_recovery_notification()
      << "\n"
-        "check_latency=" << std::setprecision(3) << std::fixed
-     << obj.get_latency() << "\n"
-                             "check_options=" << obj.get_check_options()
+        "check_latency="
+     << std::setprecision(3) << std::fixed << obj.get_latency()
      << "\n"
-        "check_period=" << obj.get_check_period()
+        "check_options="
+     << obj.get_check_options()
      << "\n"
-        "check_type=" << obj.get_check_type()
+        "check_period="
+     << obj.get_check_period()
      << "\n"
-        "current_attempt=" << obj.get_current_attempt()
+        "check_type="
+     << obj.get_check_type()
      << "\n"
-        "current_event_id=" << obj.get_current_event_id()
+        "current_attempt="
+     << obj.get_current_attempt()
      << "\n"
-        "current_notification_id=" << obj.get_current_notification_id()
+        "current_event_id="
+     << obj.get_current_event_id()
      << "\n"
-        "current_notification_number=" << obj.get_notification_number()
+        "current_notification_id="
+     << obj.get_current_notification_id()
      << "\n"
-        "current_problem_id=" << obj.get_current_problem_id()
+        "current_notification_number="
+     << obj.get_notification_number()
      << "\n"
-        "current_state=" << obj.get_current_state()
+        "current_problem_id="
+     << obj.get_current_problem_id()
      << "\n"
-        "event_handler=" << obj.get_event_handler()
+        "current_state="
+     << obj.get_current_state()
      << "\n"
-        "event_handler_enabled=" << obj.get_event_handler_enabled()
+        "event_handler="
+     << obj.get_event_handler()
      << "\n"
-        "flap_detection_enabled=" << obj.get_flap_detection_enabled()
+        "event_handler_enabled="
+     << obj.get_event_handler_enabled()
      << "\n"
-        "has_been_checked=" << obj.has_been_checked()
+        "flap_detection_enabled="
+     << obj.get_flap_detection_enabled()
      << "\n"
-        "is_flapping=" << obj.get_is_flapping()
+        "has_been_checked="
+     << obj.has_been_checked()
      << "\n"
-        "last_acknowledgement=" << obj.get_last_acknowledgement()
+        "is_flapping="
+     << obj.get_is_flapping()
      << "\n"
-        "last_check=" << static_cast<unsigned long>(obj.get_last_check())
+        "last_acknowledgement="
+     << obj.get_last_acknowledgement()
      << "\n"
-        "last_event_id=" << obj.get_last_event_id()
+        "last_check="
+     << static_cast<unsigned long>(obj.get_last_check())
      << "\n"
-        "last_hard_state=" << obj.get_last_hard_state()
+        "last_event_id="
+     << obj.get_last_event_id()
+     << "\n"
+        "last_hard_state="
+     << obj.get_last_hard_state()
      << "\n"
         "last_hard_state_change="
      << static_cast<unsigned long>(obj.get_last_hard_state_change())
@@ -579,16 +678,20 @@ std::ostream& dump::service(std::ostream& os, class service const& obj) {
         "last_notification="
      << static_cast<unsigned long>(obj.get_last_notification())
      << "\n"
-        "last_problem_id=" << obj.get_last_problem_id()
+        "last_problem_id="
+     << obj.get_last_problem_id()
      << "\n"
-        "last_state=" << obj.get_last_state() << "\n"
-                                                 "last_state_change="
+        "last_state="
+     << obj.get_last_state()
+     << "\n"
+        "last_state_change="
      << static_cast<unsigned long>(obj.get_last_state_change())
      << "\n"
         "last_time_critical="
      << static_cast<unsigned long>(obj.get_last_time_critical())
      << "\n"
-        "last_time_ok=" << static_cast<unsigned long>(obj.get_last_time_ok())
+        "last_time_ok="
+     << static_cast<unsigned long>(obj.get_last_time_ok())
      << "\n"
         "last_time_unknown="
      << static_cast<unsigned long>(obj.get_last_time_unknown())
@@ -596,52 +699,69 @@ std::ostream& dump::service(std::ostream& os, class service const& obj) {
         "last_time_warning="
      << static_cast<unsigned long>(obj.get_last_time_warning())
      << "\n"
-        "long_plugin_output=" << obj.get_long_plugin_output()
+        "long_plugin_output="
+     << obj.get_long_plugin_output()
      << "\n"
-        "max_attempts=" << obj.get_max_attempts()
+        "max_attempts="
+     << obj.get_max_attempts()
      << "\n"
-        "modified_attributes=" << (obj.get_modified_attributes() &
-                                   ~config->retained_host_attribute_mask())
+        "modified_attributes="
+     << (obj.get_modified_attributes() &
+         ~config->retained_host_attribute_mask())
      << "\n"
-        "next_check=" << static_cast<unsigned long>(obj.get_next_check())
+        "next_check="
+     << static_cast<unsigned long>(obj.get_next_check())
      << "\n"
-        "normal_check_interval=" << obj.get_check_interval()
+        "normal_check_interval="
+     << obj.get_check_interval()
      << "\n"
-        "notification_period=" << obj.get_notification_period()
+        "notification_period="
+     << obj.get_notification_period()
      << "\n"
-        "notifications_enabled=" << obj.get_notifications_enabled()
+        "notifications_enabled="
+     << obj.get_notifications_enabled()
      << "\n"
-        "notified_on_critical=" << obj.get_notified_on(notifier::critical)
+        "notified_on_critical="
+     << obj.get_notified_on(notifier::critical)
      << "\n"
-        "notified_on_unknown=" << obj.get_notified_on(notifier::unknown)
+        "notified_on_unknown="
+     << obj.get_notified_on(notifier::unknown)
      << "\n"
-        "notified_on_warning=" << obj.get_notified_on(notifier::warning)
+        "notified_on_warning="
+     << obj.get_notified_on(notifier::warning)
      << "\n"
-        "obsess_over_service=" << obj.get_obsess_over()
+        "obsess_over_service="
+     << obj.get_obsess_over()
      << "\n"
-        "passive_checks_enabled=" << obj.get_accept_passive_checks()
+        "passive_checks_enabled="
+     << obj.get_accept_passive_checks()
      << "\n"
-        "percent_state_change=" << std::setprecision(2) << std::fixed
-     << obj.get_percent_state_change()
+        "percent_state_change="
+     << std::setprecision(2) << std::fixed << obj.get_percent_state_change()
      << "\n"
-        "performance_data=" << obj.get_perf_data()
+        "performance_data="
+     << obj.get_perf_data()
      << "\n"
-        "plugin_output=" << obj.get_plugin_output()
+        "plugin_output="
+     << obj.get_plugin_output()
      << "\n"
         "problem_has_been_acknowledged="
      << obj.get_problem_has_been_acknowledged()
      << "\n"
-        "process_performance_data=" << obj.get_process_performance_data()
+        "process_performance_data="
+     << obj.get_process_performance_data()
      << "\n"
-        "retry_check_interval=" << obj.get_retry_interval()
+        "retry_check_interval="
+     << obj.get_retry_interval()
      << "\n"
-        "state_type=" << obj.get_state_type() << "\n";
+        "state_type="
+     << obj.get_state_type() << "\n";
 
   os << "state_history=";
   for (unsigned int x(0); x < MAX_STATE_HISTORY_ENTRIES; ++x)
     os << (x > 0 ? "," : "")
-       << obj.get_state_history()
-              [(x + obj.get_state_history_index()) % MAX_STATE_HISTORY_ENTRIES];
+       << obj.get_state_history()[(x + obj.get_state_history_index()) %
+                                  MAX_STATE_HISTORY_ENTRIES];
   os << "\n";
 
   dump::notifications(os, obj.get_current_notifications());
@@ -660,8 +780,7 @@ std::ostream& dump::service(std::ostream& os, class service const& obj) {
 std::ostream& dump::services(std::ostream& os) {
   for (service_map::iterator it(service::services.begin()),
        end(service::services.end());
-       it != end;
-       ++it)
+       it != end; ++it)
     dump::service(os, *it->second);
   return os;
 }

--- a/src/retention/host.cc
+++ b/src/retention/host.cc
@@ -20,12 +20,12 @@
 #include "com/centreon/engine/retention/host.hh"
 #include <array>
 #include "com/centreon/engine/common.hh"
-#include "com/centreon/engine/string.hh"
 #include "com/centreon/engine/logging.hh"
 #include "com/centreon/engine/logging/logger.hh"
+#include "com/centreon/engine/string.hh"
 
-using com::centreon::engine::opt;
 using com::centreon::engine::map_customvar;
+using com::centreon::engine::opt;
 using namespace com::centreon::engine::logging;
 using namespace com::centreon::engine::retention;
 
@@ -108,7 +108,9 @@ host::host() : object(object::host) {}
  *
  *  @param[in] right Object to copy.
  */
-host::host(host const& right) : object(right) { operator=(right); }
+host::host(host const& right) : object(right) {
+  operator=(right);
+}
 
 /**
  *  Destructor.
@@ -341,7 +343,9 @@ opt<double> const& host::check_latency() const throw() {
  *
  *  @return The check_options.
  */
-opt<int> const& host::check_options() const throw() { return _check_options; }
+opt<int> const& host::check_options() const throw() {
+  return _check_options;
+}
 
 /**
  *  Get check_period.
@@ -357,7 +361,9 @@ opt<std::string> const& host::check_period() const throw() {
  *
  *  @return The check_type.
  */
-opt<int> const& host::check_type() const throw() { return _check_type; }
+opt<int> const& host::check_type() const throw() {
+  return _check_type;
+}
 
 /**
  *  Get current_attempt.
@@ -409,7 +415,9 @@ opt<uint64_t> const& host::current_problem_id() const throw() {
  *
  *  @return The current_state.
  */
-opt<int> const& host::current_state() const throw() { return _current_state; }
+opt<int> const& host::current_state() const throw() {
+  return _current_state;
+}
 
 /**
  *  Get customvariables.
@@ -461,21 +469,27 @@ opt<bool> const& host::has_been_checked() const throw() {
  *
  *  @return The host_id.
  */
-uint64_t host::host_id() const throw() { return _host_id; }
+uint64_t host::host_id() const throw() {
+  return _host_id;
+}
 
 /**
  *  Get host_name.
  *
  *  @return The host_name.
  */
-std::string const& host::host_name() const throw() { return _host_name; }
+std::string const& host::host_name() const throw() {
+  return _host_name;
+}
 
 /**
  *  Get is_flapping.
  *
  *  @return The is_flapping.
  */
-opt<bool> const& host::is_flapping() const throw() { return _is_flapping; }
+opt<bool> const& host::is_flapping() const throw() {
+  return _is_flapping;
+}
 
 /**
  *  Get last_acknowledgement.
@@ -491,7 +505,9 @@ opt<time_t> const& host::last_acknowledgement() const throw() {
  *
  *  @return The last_check.
  */
-opt<time_t> const& host::last_check() const throw() { return _last_check; }
+opt<time_t> const& host::last_check() const throw() {
+  return _last_check;
+}
 
 /**
  *  Get last_event_id.
@@ -543,7 +559,9 @@ opt<uint64_t> const& host::last_problem_id() const throw() {
  *
  *  @return The last_state.
  */
-opt<time_t> const& host::last_state() const throw() { return _last_state; }
+opt<time_t> const& host::last_state() const throw() {
+  return _last_state;
+}
 
 /**
  *  Get last_state_change.
@@ -577,7 +595,9 @@ opt<time_t> const& host::last_time_unreachable() const throw() {
  *
  *  @return The last_time_up.
  */
-opt<time_t> const& host::last_time_up() const throw() { return _last_time_up; }
+opt<time_t> const& host::last_time_up() const throw() {
+  return _last_time_up;
+}
 
 /**
  *  Get long_plugin_output.
@@ -611,7 +631,9 @@ opt<unsigned long> const& host::modified_attributes() const throw() {
  *
  *  @return The next_check.
  */
-opt<time_t> const& host::next_check() const throw() { return _next_check; }
+opt<time_t> const& host::next_check() const throw() {
+  return _next_check;
+}
 
 /**
  *  Get normal_check_interval.
@@ -744,7 +766,9 @@ opt<std::vector<int> > const& host::state_history() const throw() {
  *
  *  @return The state_type.
  */
-opt<int> const& host::state_type() const throw() { return _state_type; }
+opt<int> const& host::state_type() const throw() {
+  return _state_type;
+}
 
 /**
  *  Set acknowledgement_type.
@@ -1093,7 +1117,8 @@ bool host::_set_last_time_unreachable(time_t value) {
   if (value > now) {
     logger(log_verification_error, basic)
         << "Warning: Host last time unreachable cannot be in the future (bad "
-           "value: " << value << ")";
+           "value: "
+        << value << ")";
     value = now;
   }
   _last_time_unreachable = value;
@@ -1313,8 +1338,7 @@ bool host::_set_state_history(std::string const& value) noexcept {
   std::vector<int>& state_history(*_state_history);
   for (std::list<std::string>::const_iterator it(lst_history.begin()),
        end(lst_history.end());
-       it != end && x < MAX_STATE_HISTORY_ENTRIES;
-       ++it) {
+       it != end && x < MAX_STATE_HISTORY_ENTRIES; ++it) {
     int state(0);
     if (!string::to(it->c_str(), state)) {
       _state_history.reset();

--- a/src/retention/host.cc
+++ b/src/retention/host.cc
@@ -108,9 +108,7 @@ host::host() : object(object::host) {}
  *
  *  @param[in] right Object to copy.
  */
-host::host(host const& right) : object(right) {
-  operator=(right);
-}
+host::host(host const& right) : object(right) { operator=(right); }
 
 /**
  *  Destructor.
@@ -195,62 +193,63 @@ host& host::operator=(host const& right) {
  *  @return True if is the same object, otherwise false.
  */
 bool host::operator==(host const& right) const noexcept {
-  return
-      object::operator==(right) &&
-      _acknowledgement_type == right._acknowledgement_type &&
-      _active_checks_enabled == right._active_checks_enabled &&
-      _check_command == right._check_command &&
-      _check_execution_time == right._check_execution_time &&
-      _check_flapping_recovery_notification ==
-          right._check_flapping_recovery_notification &&
-      _check_latency == right._check_latency &&
-      _check_options == right._check_options &&
-      _check_period == right._check_period &&
-      _check_type == right._check_type &&
-      _current_attempt == right._current_attempt &&
-      _current_event_id == right._current_event_id &&
-      _current_notification_id == right._current_notification_id &&
-      _current_notification_number == right._current_notification_number &&
-      _current_problem_id == right._current_problem_id &&
-      _current_state == right._current_state &&
-      std::operator==(_customvariables, right._customvariables) &&
-      _event_handler == right._event_handler &&
-      _event_handler_enabled == right._event_handler_enabled &&
-      _flap_detection_enabled == right._flap_detection_enabled &&
-      _has_been_checked == right._has_been_checked &&
-      _host_id == right._host_id && _host_name == right._host_name &&
-      _is_flapping == right._is_flapping &&
-      _last_acknowledgement == right._last_acknowledgement &&
-      _last_check == right._last_check &&
-      _last_event_id == right._last_event_id &&
-      _last_hard_state == right._last_hard_state &&
-      _last_hard_state_change == right._last_hard_state_change &&
-      _last_notification == right._last_notification &&
-      _last_problem_id == right._last_problem_id &&
-      _last_state == right._last_state &&
-      _last_state_change == right._last_state_change &&
-      _last_time_down == right._last_time_down &&
-      _last_time_unreachable == right._last_time_unreachable &&
-      _last_time_up == right._last_time_up &&
-      _long_plugin_output == right._long_plugin_output &&
-      _max_attempts == right._max_attempts &&
-      _modified_attributes == right._modified_attributes &&
-      _next_check == right._next_check &&
-      _normal_check_interval == right._normal_check_interval &&
-      _notification_period == right._notification_period &&
-      _notifications_enabled == right._notifications_enabled &&
-      _notified_on_down == right._notified_on_down &&
-      _notified_on_unreachable == right._notified_on_unreachable &&
-      _obsess_over_host == right._obsess_over_host &&
-      _passive_checks_enabled == right._passive_checks_enabled &&
-      _percent_state_change == right._percent_state_change &&
-      _performance_data == right._performance_data &&
-      _plugin_output == right._plugin_output &&
-      _problem_has_been_acknowledged == right._problem_has_been_acknowledged &&
-      _process_performance_data == right._process_performance_data &&
-      _retry_check_interval == right._retry_check_interval &&
-      _state_history == right._state_history &&
-      _state_type == right._state_type && _notification == right._notification;
+  return object::operator==(right) &&
+         _acknowledgement_type == right._acknowledgement_type &&
+         _active_checks_enabled == right._active_checks_enabled &&
+         _check_command == right._check_command &&
+         _check_execution_time == right._check_execution_time &&
+         _check_flapping_recovery_notification ==
+             right._check_flapping_recovery_notification &&
+         _check_latency == right._check_latency &&
+         _check_options == right._check_options &&
+         _check_period == right._check_period &&
+         _check_type == right._check_type &&
+         _current_attempt == right._current_attempt &&
+         _current_event_id == right._current_event_id &&
+         _current_notification_id == right._current_notification_id &&
+         _current_notification_number == right._current_notification_number &&
+         _current_problem_id == right._current_problem_id &&
+         _current_state == right._current_state &&
+         std::operator==(_customvariables, right._customvariables) &&
+         _event_handler == right._event_handler &&
+         _event_handler_enabled == right._event_handler_enabled &&
+         _flap_detection_enabled == right._flap_detection_enabled &&
+         _has_been_checked == right._has_been_checked &&
+         _host_id == right._host_id && _host_name == right._host_name &&
+         _is_flapping == right._is_flapping &&
+         _last_acknowledgement == right._last_acknowledgement &&
+         _last_check == right._last_check &&
+         _last_event_id == right._last_event_id &&
+         _last_hard_state == right._last_hard_state &&
+         _last_hard_state_change == right._last_hard_state_change &&
+         _last_notification == right._last_notification &&
+         _last_problem_id == right._last_problem_id &&
+         _last_state == right._last_state &&
+         _last_state_change == right._last_state_change &&
+         _last_time_down == right._last_time_down &&
+         _last_time_unreachable == right._last_time_unreachable &&
+         _last_time_up == right._last_time_up &&
+         _long_plugin_output == right._long_plugin_output &&
+         _max_attempts == right._max_attempts &&
+         _modified_attributes == right._modified_attributes &&
+         _next_check == right._next_check &&
+         _normal_check_interval == right._normal_check_interval &&
+         _notification_period == right._notification_period &&
+         _notifications_enabled == right._notifications_enabled &&
+         _notified_on_down == right._notified_on_down &&
+         _notified_on_unreachable == right._notified_on_unreachable &&
+         _obsess_over_host == right._obsess_over_host &&
+         _passive_checks_enabled == right._passive_checks_enabled &&
+         _percent_state_change == right._percent_state_change &&
+         _performance_data == right._performance_data &&
+         _plugin_output == right._plugin_output &&
+         _problem_has_been_acknowledged ==
+             right._problem_has_been_acknowledged &&
+         _process_performance_data == right._process_performance_data &&
+         _retry_check_interval == right._retry_check_interval &&
+         _state_history == right._state_history &&
+         _state_type == right._state_type &&
+         _notification == right._notification;
 }
 
 /**
@@ -342,9 +341,7 @@ opt<double> const& host::check_latency() const throw() {
  *
  *  @return The check_options.
  */
-opt<int> const& host::check_options() const throw() {
-  return _check_options;
-}
+opt<int> const& host::check_options() const throw() { return _check_options; }
 
 /**
  *  Get check_period.
@@ -360,9 +357,7 @@ opt<std::string> const& host::check_period() const throw() {
  *
  *  @return The check_type.
  */
-opt<int> const& host::check_type() const throw() {
-  return _check_type;
-}
+opt<int> const& host::check_type() const throw() { return _check_type; }
 
 /**
  *  Get current_attempt.
@@ -414,9 +409,7 @@ opt<uint64_t> const& host::current_problem_id() const throw() {
  *
  *  @return The current_state.
  */
-opt<int> const& host::current_state() const throw() {
-  return _current_state;
-}
+opt<int> const& host::current_state() const throw() { return _current_state; }
 
 /**
  *  Get customvariables.
@@ -468,27 +461,21 @@ opt<bool> const& host::has_been_checked() const throw() {
  *
  *  @return The host_id.
  */
-uint64_t host::host_id() const throw() {
-  return _host_id;
-}
+uint64_t host::host_id() const throw() { return _host_id; }
 
 /**
  *  Get host_name.
  *
  *  @return The host_name.
  */
-std::string const& host::host_name() const throw() {
-  return _host_name;
-}
+std::string const& host::host_name() const throw() { return _host_name; }
 
 /**
  *  Get is_flapping.
  *
  *  @return The is_flapping.
  */
-opt<bool> const& host::is_flapping() const throw() {
-  return _is_flapping;
-}
+opt<bool> const& host::is_flapping() const throw() { return _is_flapping; }
 
 /**
  *  Get last_acknowledgement.
@@ -504,9 +491,7 @@ opt<time_t> const& host::last_acknowledgement() const throw() {
  *
  *  @return The last_check.
  */
-opt<time_t> const& host::last_check() const throw() {
-  return _last_check;
-}
+opt<time_t> const& host::last_check() const throw() { return _last_check; }
 
 /**
  *  Get last_event_id.
@@ -558,9 +543,7 @@ opt<uint64_t> const& host::last_problem_id() const throw() {
  *
  *  @return The last_state.
  */
-opt<time_t> const& host::last_state() const throw() {
-  return _last_state;
-}
+opt<time_t> const& host::last_state() const throw() { return _last_state; }
 
 /**
  *  Get last_state_change.
@@ -594,9 +577,7 @@ opt<time_t> const& host::last_time_unreachable() const throw() {
  *
  *  @return The last_time_up.
  */
-opt<time_t> const& host::last_time_up() const throw() {
-  return _last_time_up;
-}
+opt<time_t> const& host::last_time_up() const throw() { return _last_time_up; }
 
 /**
  *  Get long_plugin_output.
@@ -630,9 +611,7 @@ opt<unsigned long> const& host::modified_attributes() const throw() {
  *
  *  @return The next_check.
  */
-opt<time_t> const& host::next_check() const throw() {
-  return _next_check;
-}
+opt<time_t> const& host::next_check() const throw() { return _next_check; }
 
 /**
  *  Get normal_check_interval.
@@ -765,9 +744,7 @@ opt<std::vector<int> > const& host::state_history() const throw() {
  *
  *  @return The state_type.
  */
-opt<int> const& host::state_type() const throw() {
-  return _state_type;
-}
+opt<int> const& host::state_type() const throw() { return _state_type; }
 
 /**
  *  Set acknowledgement_type.
@@ -1097,8 +1074,9 @@ bool host::_set_last_state_change(time_t value) {
 bool host::_set_last_time_down(time_t value) {
   time_t now = time(nullptr);
   if (value > now) {
-    logger(log_runtime_warning, basic)
-        << "Warning: Host last time down cannot be in the future (bad value: " << value << ")";
+    logger(log_verification_error, basic)
+        << "Warning: Host last time down cannot be in the future (bad value: "
+        << value << ")";
     value = now;
   }
   _last_time_down = value;
@@ -1113,8 +1091,9 @@ bool host::_set_last_time_down(time_t value) {
 bool host::_set_last_time_unreachable(time_t value) {
   time_t now = time(nullptr);
   if (value > now) {
-    logger(log_runtime_warning, basic)
-        << "Warning: Host last time unreachable cannot be in the future (bad value: " << value << ")";
+    logger(log_verification_error, basic)
+        << "Warning: Host last time unreachable cannot be in the future (bad "
+           "value: " << value << ")";
     value = now;
   }
   _last_time_unreachable = value;
@@ -1129,8 +1108,9 @@ bool host::_set_last_time_unreachable(time_t value) {
 bool host::_set_last_time_up(time_t value) {
   time_t now = time(nullptr);
   if (value > now) {
-    logger(log_runtime_warning, basic)
-        << "Warning: Host last time up cannot be in the future (bad value: " << value << ")";
+    logger(log_verification_error, basic)
+        << "Warning: Host last time up cannot be in the future (bad value: "
+        << value << ")";
     value = now;
   }
   _last_time_up = value;
@@ -1333,7 +1313,8 @@ bool host::_set_state_history(std::string const& value) noexcept {
   std::vector<int>& state_history(*_state_history);
   for (std::list<std::string>::const_iterator it(lst_history.begin()),
        end(lst_history.end());
-       it != end && x < MAX_STATE_HISTORY_ENTRIES; ++it) {
+       it != end && x < MAX_STATE_HISTORY_ENTRIES;
+       ++it) {
     int state(0);
     if (!string::to(it->c_str(), state)) {
       _state_history.reset();

--- a/src/retention/host.cc
+++ b/src/retention/host.cc
@@ -21,8 +21,12 @@
 #include <array>
 #include "com/centreon/engine/common.hh"
 #include "com/centreon/engine/string.hh"
+#include "com/centreon/engine/logging.hh"
+#include "com/centreon/engine/logging/logger.hh"
 
-using namespace com::centreon::engine;
+using com::centreon::engine::opt;
+using com::centreon::engine::map_customvar;
+using namespace com::centreon::engine::logging;
 using namespace com::centreon::engine::retention;
 
 #define SETTER(type, method) &object::setter<host, type, &host::method>::generic
@@ -1091,6 +1095,12 @@ bool host::_set_last_state_change(time_t value) {
  *  @param[in] value The new last_time_down.
  */
 bool host::_set_last_time_down(time_t value) {
+  time_t now = time(nullptr);
+  if (value > now) {
+    logger(log_runtime_warning, basic)
+        << "Warning: Host last time down cannot be in the future (bad value: " << value << ")";
+    value = now;
+  }
   _last_time_down = value;
   return true;
 }
@@ -1101,6 +1111,12 @@ bool host::_set_last_time_down(time_t value) {
  *  @param[in] value The new last_time_unreachable.
  */
 bool host::_set_last_time_unreachable(time_t value) {
+  time_t now = time(nullptr);
+  if (value > now) {
+    logger(log_runtime_warning, basic)
+        << "Warning: Host last time unreachable cannot be in the future (bad value: " << value << ")";
+    value = now;
+  }
   _last_time_unreachable = value;
   return true;
 }
@@ -1111,6 +1127,12 @@ bool host::_set_last_time_unreachable(time_t value) {
  *  @param[in] value The new last_time_up.
  */
 bool host::_set_last_time_up(time_t value) {
+  time_t now = time(nullptr);
+  if (value > now) {
+    logger(log_runtime_warning, basic)
+        << "Warning: Host last time up cannot be in the future (bad value: " << value << ")";
+    value = now;
+  }
   _last_time_up = value;
   return true;
 }

--- a/src/retention/service.cc
+++ b/src/retention/service.cc
@@ -114,9 +114,7 @@ service::service() : object(object::service), _next_setter(_setters) {}
  *
  *  @param[in] right Object to copy.
  */
-service::service(service const& right) : object(right) {
-  operator=(right);
-}
+service::service(service const& right) : object(right) { operator=(right); }
 
 /**
  *  Destructor.
@@ -398,9 +396,7 @@ opt<std::string> const& service::check_period() const throw() {
  *
  *  @return The check_type.
  */
-opt<int> const& service::check_type() const throw() {
-  return _check_type;
-}
+opt<int> const& service::check_type() const throw() { return _check_type; }
 
 /**
  *  Get current_attempt.
@@ -506,27 +502,21 @@ opt<bool> const& service::has_been_checked() const throw() {
  *
  *  @return The host_id.
  */
-uint64_t service::host_id() const throw() {
-  return _host_id;
-}
+uint64_t service::host_id() const throw() { return _host_id; }
 
 /**
  *  Get host_name.
  *
  *  @return The host_name.
  */
-std::string const& service::host_name() const throw() {
-  return _host_name;
-}
+std::string const& service::host_name() const throw() { return _host_name; }
 
 /**
  *  Get is_flapping.
  *
  *  @return The is_flapping.
  */
-opt<bool> const& service::is_flapping() const throw() {
-  return _is_flapping;
-}
+opt<bool> const& service::is_flapping() const throw() { return _is_flapping; }
 
 /**
  *  Get last_acknowledgement.
@@ -542,9 +532,7 @@ opt<time_t> const& service::last_acknowledgement() const throw() {
  *
  *  @return The last_check.
  */
-opt<time_t> const& service::last_check() const throw() {
-  return _last_check;
-}
+opt<time_t> const& service::last_check() const throw() { return _last_check; }
 
 /**
  *  Get last_event_id.
@@ -596,9 +584,7 @@ opt<uint64_t> const& service::last_problem_id() const throw() {
  *
  *  @return The last_state.
  */
-opt<time_t> const& service::last_state() const throw() {
-  return _last_state;
-}
+opt<time_t> const& service::last_state() const throw() { return _last_state; }
 
 /**
  *  Get last_state_change.
@@ -677,9 +663,7 @@ opt<unsigned long> const& service::modified_attributes() const throw() {
  *
  *  @return The next_check.
  */
-opt<time_t> const& service::next_check() const throw() {
-  return _next_check;
-}
+opt<time_t> const& service::next_check() const throw() { return _next_check; }
 
 /**
  *  Get normal_check_interval.
@@ -812,9 +796,7 @@ opt<unsigned int> const& service::retry_check_interval() const throw() {
  *
  *  @return The service_id.
  */
-uint64_t service::service_id() const throw() {
-  return _service_id;
-}
+uint64_t service::service_id() const throw() { return _service_id; }
 
 /**
  *  Get service_description.
@@ -839,9 +821,7 @@ opt<std::vector<int> > const& service::state_history() const throw() {
  *
  *  @return The state_type.
  */
-opt<int> const& service::state_type() const throw() {
-  return _state_type;
-}
+opt<int> const& service::state_type() const throw() { return _state_type; }
 
 /**
  *  Set acknowledgement_type.
@@ -1171,8 +1151,9 @@ bool service::_set_last_state_change(time_t value) {
 bool service::_set_last_time_critical(time_t value) {
   time_t now = time(nullptr);
   if (value > now) {
-    logger(log_runtime_warning, basic)
-        << "Warning: Service last time critical cannot be in the future (bad value: " << value << ")";
+    logger(log_verification_error, basic) << "Warning: Service last time "
+                                             "critical cannot be in the future "
+                                             "(bad value: " << value << ")";
     value = now;
   }
   _last_time_critical = value;
@@ -1187,8 +1168,9 @@ bool service::_set_last_time_critical(time_t value) {
 bool service::_set_last_time_ok(time_t value) {
   time_t now = time(nullptr);
   if (value > now) {
-    logger(log_runtime_warning, basic)
-        << "Warning: Service last time ok cannot be in the future (bad value: " << value << ")";
+    logger(log_verification_error, basic)
+        << "Warning: Service last time ok cannot be in the future (bad value: "
+        << value << ")";
     value = now;
   }
   _last_time_ok = value;
@@ -1203,8 +1185,9 @@ bool service::_set_last_time_ok(time_t value) {
 bool service::_set_last_time_unknown(time_t value) {
   time_t now = time(nullptr);
   if (value > now) {
-    logger(log_runtime_warning, basic)
-        << "Warning: Service last time unknown cannot be in the future (bad value: " << value << ")";
+    logger(log_verification_error, basic) << "Warning: Service last time "
+                                             "unknown cannot be in the future "
+                                             "(bad value: " << value << ")";
     value = now;
   }
   _last_time_unknown = value;
@@ -1219,8 +1202,9 @@ bool service::_set_last_time_unknown(time_t value) {
 bool service::_set_last_time_warning(time_t value) {
   time_t now = time(nullptr);
   if (value > now) {
-    logger(log_runtime_warning, basic)
-        << "Warning: Service last time warning cannot be in the future (bad value: " << value << ")";
+    logger(log_verification_error, basic) << "Warning: Service last time "
+                                             "warning cannot be in the future "
+                                             "(bad value: " << value << ")";
     value = now;
   }
   _last_time_warning = value;

--- a/src/retention/service.cc
+++ b/src/retention/service.cc
@@ -18,11 +18,15 @@
 */
 
 #include "com/centreon/engine/retention/service.hh"
+#include "com/centreon/engine/logging/logger.hh"
 #include <array>
 #include "com/centreon/engine/common.hh"
+#include "com/centreon/engine/logging.hh"
 #include "com/centreon/engine/string.hh"
 
-using namespace com::centreon::engine;
+using com::centreon::engine::opt;
+using com::centreon::engine::map_customvar;
+using namespace com::centreon::engine::logging;
 using namespace com::centreon::engine::retention;
 
 #define SETTER(type, method) \
@@ -1165,6 +1169,12 @@ bool service::_set_last_state_change(time_t value) {
  *  @param[in] value The new last_time_critical.
  */
 bool service::_set_last_time_critical(time_t value) {
+  time_t now = time(nullptr);
+  if (value > now) {
+    logger(log_runtime_warning, basic)
+        << "Warning: Service last time critical cannot be in the future (bad value: " << value << ")";
+    value = now;
+  }
   _last_time_critical = value;
   return true;
 }
@@ -1175,6 +1185,12 @@ bool service::_set_last_time_critical(time_t value) {
  *  @param[in] value The new last_time_ok.
  */
 bool service::_set_last_time_ok(time_t value) {
+  time_t now = time(nullptr);
+  if (value > now) {
+    logger(log_runtime_warning, basic)
+        << "Warning: Service last time ok cannot be in the future (bad value: " << value << ")";
+    value = now;
+  }
   _last_time_ok = value;
   return true;
 }
@@ -1185,6 +1201,12 @@ bool service::_set_last_time_ok(time_t value) {
  *  @param[in] value The new last_time_unknown.
  */
 bool service::_set_last_time_unknown(time_t value) {
+  time_t now = time(nullptr);
+  if (value > now) {
+    logger(log_runtime_warning, basic)
+        << "Warning: Service last time unknown cannot be in the future (bad value: " << value << ")";
+    value = now;
+  }
   _last_time_unknown = value;
   return true;
 }
@@ -1195,6 +1217,12 @@ bool service::_set_last_time_unknown(time_t value) {
  *  @param[in] value The new last_time_warning.
  */
 bool service::_set_last_time_warning(time_t value) {
+  time_t now = time(nullptr);
+  if (value > now) {
+    logger(log_runtime_warning, basic)
+        << "Warning: Service last time warning cannot be in the future (bad value: " << value << ")";
+    value = now;
+  }
   _last_time_warning = value;
   return true;
 }

--- a/src/retention/service.cc
+++ b/src/retention/service.cc
@@ -18,14 +18,14 @@
 */
 
 #include "com/centreon/engine/retention/service.hh"
-#include "com/centreon/engine/logging/logger.hh"
 #include <array>
 #include "com/centreon/engine/common.hh"
 #include "com/centreon/engine/logging.hh"
+#include "com/centreon/engine/logging/logger.hh"
 #include "com/centreon/engine/string.hh"
 
-using com::centreon::engine::opt;
 using com::centreon::engine::map_customvar;
+using com::centreon::engine::opt;
 using namespace com::centreon::engine::logging;
 using namespace com::centreon::engine::retention;
 
@@ -114,7 +114,9 @@ service::service() : object(object::service), _next_setter(_setters) {}
  *
  *  @param[in] right Object to copy.
  */
-service::service(service const& right) : object(right) { operator=(right); }
+service::service(service const& right) : object(right) {
+  operator=(right);
+}
 
 /**
  *  Destructor.
@@ -396,7 +398,9 @@ opt<std::string> const& service::check_period() const throw() {
  *
  *  @return The check_type.
  */
-opt<int> const& service::check_type() const throw() { return _check_type; }
+opt<int> const& service::check_type() const throw() {
+  return _check_type;
+}
 
 /**
  *  Get current_attempt.
@@ -502,21 +506,27 @@ opt<bool> const& service::has_been_checked() const throw() {
  *
  *  @return The host_id.
  */
-uint64_t service::host_id() const throw() { return _host_id; }
+uint64_t service::host_id() const throw() {
+  return _host_id;
+}
 
 /**
  *  Get host_name.
  *
  *  @return The host_name.
  */
-std::string const& service::host_name() const throw() { return _host_name; }
+std::string const& service::host_name() const throw() {
+  return _host_name;
+}
 
 /**
  *  Get is_flapping.
  *
  *  @return The is_flapping.
  */
-opt<bool> const& service::is_flapping() const throw() { return _is_flapping; }
+opt<bool> const& service::is_flapping() const throw() {
+  return _is_flapping;
+}
 
 /**
  *  Get last_acknowledgement.
@@ -532,7 +542,9 @@ opt<time_t> const& service::last_acknowledgement() const throw() {
  *
  *  @return The last_check.
  */
-opt<time_t> const& service::last_check() const throw() { return _last_check; }
+opt<time_t> const& service::last_check() const throw() {
+  return _last_check;
+}
 
 /**
  *  Get last_event_id.
@@ -584,7 +596,9 @@ opt<uint64_t> const& service::last_problem_id() const throw() {
  *
  *  @return The last_state.
  */
-opt<time_t> const& service::last_state() const throw() { return _last_state; }
+opt<time_t> const& service::last_state() const throw() {
+  return _last_state;
+}
 
 /**
  *  Get last_state_change.
@@ -663,7 +677,9 @@ opt<unsigned long> const& service::modified_attributes() const throw() {
  *
  *  @return The next_check.
  */
-opt<time_t> const& service::next_check() const throw() { return _next_check; }
+opt<time_t> const& service::next_check() const throw() {
+  return _next_check;
+}
 
 /**
  *  Get normal_check_interval.
@@ -796,7 +812,9 @@ opt<unsigned int> const& service::retry_check_interval() const throw() {
  *
  *  @return The service_id.
  */
-uint64_t service::service_id() const throw() { return _service_id; }
+uint64_t service::service_id() const throw() {
+  return _service_id;
+}
 
 /**
  *  Get service_description.
@@ -821,7 +839,9 @@ opt<std::vector<int> > const& service::state_history() const throw() {
  *
  *  @return The state_type.
  */
-opt<int> const& service::state_type() const throw() { return _state_type; }
+opt<int> const& service::state_type() const throw() {
+  return _state_type;
+}
 
 /**
  *  Set acknowledgement_type.
@@ -1153,7 +1173,8 @@ bool service::_set_last_time_critical(time_t value) {
   if (value > now) {
     logger(log_verification_error, basic) << "Warning: Service last time "
                                              "critical cannot be in the future "
-                                             "(bad value: " << value << ")";
+                                             "(bad value: "
+                                          << value << ")";
     value = now;
   }
   _last_time_critical = value;
@@ -1187,7 +1208,8 @@ bool service::_set_last_time_unknown(time_t value) {
   if (value > now) {
     logger(log_verification_error, basic) << "Warning: Service last time "
                                              "unknown cannot be in the future "
-                                             "(bad value: " << value << ")";
+                                             "(bad value: "
+                                          << value << ")";
     value = now;
   }
   _last_time_unknown = value;
@@ -1204,7 +1226,8 @@ bool service::_set_last_time_warning(time_t value) {
   if (value > now) {
     logger(log_verification_error, basic) << "Warning: Service last time "
                                              "warning cannot be in the future "
-                                             "(bad value: " << value << ")";
+                                             "(bad value: "
+                                          << value << ")";
     value = now;
   }
   _last_time_warning = value;

--- a/src/service.cc
+++ b/src/service.cc
@@ -17,6 +17,7 @@
 ** <http://www.gnu.org/licenses/>.
 */
 
+#include <cassert>
 #include "com/centreon/engine/service.hh"
 
 #include <iomanip>
@@ -148,6 +149,7 @@ time_t service::get_last_time_ok() const {
 }
 
 void service::set_last_time_ok(time_t last_time) {
+  assert(last_time < 2000000000);
   _last_time_ok = last_time;
 }
 
@@ -156,6 +158,7 @@ time_t service::get_last_time_warning() const {
 }
 
 void service::set_last_time_warning(time_t last_time) {
+  assert(last_time < 2000000000);
   _last_time_warning = last_time;
 }
 
@@ -164,6 +167,7 @@ time_t service::get_last_time_unknown() const {
 }
 
 void service::set_last_time_unknown(time_t last_time) {
+  assert(last_time < 2000000000);
   _last_time_unknown = last_time;
 }
 
@@ -172,6 +176,7 @@ time_t service::get_last_time_critical() const {
 }
 
 void service::set_last_time_critical(time_t last_time) {
+  assert(last_time < 2000000000);
   _last_time_critical = last_time;
 }
 

--- a/src/service.cc
+++ b/src/service.cc
@@ -91,23 +91,39 @@ service::service(std::string const& hostname,
                  int freshness_threshold,
                  bool obsess_over,
                  std::string const& timezone)
-    : notifier{service_notification,     display_name,
-               check_command,            checks_enabled,
-               accept_passive_checks,    check_interval,
-               retry_interval,           notification_interval,
-               max_attempts,             0u,  // notify
-               0u,                            // stalk
-               first_notification_delay, recovery_notification_delay,
-               notification_period,      notifications_enabled,
-               check_period,             event_handler,
-               event_handler_enabled,    notes,
-               notes_url,                action_url,
-               icon_image,               icon_image_alt,
-               flap_detection_enabled,   low_flap_threshold,
-               high_flap_threshold,      check_freshness,
-               freshness_threshold,      obsess_over,
-               timezone,                 0,
-               0,                        is_volatile},
+    : notifier{service_notification,
+               display_name,
+               check_command,
+               checks_enabled,
+               accept_passive_checks,
+               check_interval,
+               retry_interval,
+               notification_interval,
+               max_attempts,
+               0u,  // notify
+               0u,  // stalk
+               first_notification_delay,
+               recovery_notification_delay,
+               notification_period,
+               notifications_enabled,
+               check_period,
+               event_handler,
+               event_handler_enabled,
+               notes,
+               notes_url,
+               action_url,
+               icon_image,
+               icon_image_alt,
+               flap_detection_enabled,
+               low_flap_threshold,
+               high_flap_threshold,
+               check_freshness,
+               freshness_threshold,
+               obsess_over,
+               timezone,
+               0,
+               0,
+               is_volatile},
       _host_id{0},
       _service_id{0},
       _hostname{hostname},
@@ -127,23 +143,33 @@ service::service(std::string const& hostname,
   set_current_attempt(initial_state == service::state_ok ? 1 : max_attempts);
 }
 
-time_t service::get_last_time_ok() const { return _last_time_ok; }
+time_t service::get_last_time_ok() const {
+  return _last_time_ok;
+}
 
-void service::set_last_time_ok(time_t last_time) { _last_time_ok = last_time; }
+void service::set_last_time_ok(time_t last_time) {
+  _last_time_ok = last_time;
+}
 
-time_t service::get_last_time_warning() const { return _last_time_warning; }
+time_t service::get_last_time_warning() const {
+  return _last_time_warning;
+}
 
 void service::set_last_time_warning(time_t last_time) {
   _last_time_warning = last_time;
 }
 
-time_t service::get_last_time_unknown() const { return _last_time_unknown; }
+time_t service::get_last_time_unknown() const {
+  return _last_time_unknown;
+}
 
 void service::set_last_time_unknown(time_t last_time) {
   _last_time_unknown = last_time;
 }
 
-time_t service::get_last_time_critical() const { return _last_time_critical; }
+time_t service::get_last_time_critical() const {
+  return _last_time_critical;
+}
 
 void service::set_last_time_critical(time_t last_time) {
   _last_time_critical = last_time;
@@ -197,7 +223,9 @@ void service::set_check_flapping_recovery_notification(bool check) {
   _check_flapping_recovery_notification = check;
 }
 
-bool service::recovered() const { return _current_state == service::state_ok; }
+bool service::recovered() const {
+  return _current_state == service::state_ok;
+}
 
 int service::get_current_state_int() const {
   return static_cast<int>(_current_state);
@@ -213,8 +241,7 @@ int service::get_current_state_int() const {
  */
 std::ostream& operator<<(std::ostream& os, service_map_unsafe const& obj) {
   for (service_map_unsafe::const_iterator it(obj.begin()), end(obj.end());
-       it != end;
-       ++it)
+       it != end; ++it)
     os << "(" << it->first.first << ", " << it->first.second
        << (std::next(it) != obj.end() ? "), " : ")");
   return os;
@@ -276,27 +303,38 @@ std::ostream& operator<<(std::ostream& os,
   }
 
   os << "service {\n"
-        "  host_name:                            " << obj.get_hostname()
+        "  host_name:                            "
+     << obj.get_hostname()
      << "\n"
-        "  description:                          " << obj.get_description()
+        "  description:                          "
+     << obj.get_description()
      << "\n"
-        "  display_name:                         " << obj.get_display_name()
+        "  display_name:                         "
+     << obj.get_display_name()
      << "\n"
-        "  service_check_command:                " << obj.get_check_command()
+        "  service_check_command:                "
+     << obj.get_check_command()
      << "\n"
-        "  event_handler:                        " << obj.get_event_handler()
+        "  event_handler:                        "
+     << obj.get_event_handler()
      << "\n"
-        "  initial_state:                        " << obj.get_initial_state()
+        "  initial_state:                        "
+     << obj.get_initial_state()
      << "\n"
-        "  check_interval:                       " << obj.get_check_interval()
+        "  check_interval:                       "
+     << obj.get_check_interval()
      << "\n"
-        "  retry_interval:                       " << obj.get_retry_interval()
+        "  retry_interval:                       "
+     << obj.get_retry_interval()
      << "\n"
-        "  max_attempts:                         " << obj.get_max_attempts()
+        "  max_attempts:                         "
+     << obj.get_max_attempts()
      << "\n"
-        "  contact_groups:                       " << cg_oss
+        "  contact_groups:                       "
+     << cg_oss
      << "\n"
-        "  contacts:                             " << c_oss
+        "  contacts:                             "
+     << c_oss
      << "\n"
         "  notification_interval:                "
      << obj.get_notification_interval()
@@ -343,10 +381,12 @@ std::ostream& operator<<(std::ostream& os,
         "  stalk_on_critical:                    "
      << obj.get_stalk_on(notifier::critical)
      << "\n"
-        "  is_volatile:                          " << obj.get_is_volatile()
+        "  is_volatile:                          "
+     << obj.get_is_volatile()
      << "\n"
         "  notification_period:                  "
-     << obj.get_notification_period() << "\n" << notifications
+     << obj.get_notification_period() << "\n"
+     << notifications
      << "  check_period:                         " << obj.get_check_period()
      << "\n"
         "  flap_detection_enabled:               "
@@ -373,7 +413,8 @@ std::ostream& operator<<(std::ostream& os,
         "  process_performance_data:             "
      << obj.get_process_performance_data()
      << "\n"
-        "  check_freshness:                      " << obj.get_check_freshness()
+        "  check_freshness:                      "
+     << obj.get_check_freshness()
      << "\n"
         "  freshness_threshold:                  "
      << obj.get_freshness_threshold()
@@ -633,22 +674,22 @@ com::centreon::engine::service* add_service(
     logger(log_config_error, basic) << "Error: Service description is not set";
     return nullptr;
   } else if (host_name.empty()) {
-    logger(log_config_error, basic) << "Error: Host name of service '"
-                                    << description << "' is not set";
+    logger(log_config_error, basic)
+        << "Error: Host name of service '" << description << "' is not set";
     return nullptr;
   } else if (check_command.empty()) {
-    logger(log_config_error, basic) << "Error: Check command of service '"
-                                    << description << "' on host '" << host_name
-                                    << "' is not set";
+    logger(log_config_error, basic)
+        << "Error: Check command of service '" << description << "' on host '"
+        << host_name << "' is not set";
     return nullptr;
   }
 
   uint64_t hid = get_host_id(host_name);
   if (!host_id) {
-    logger(log_config_error, basic) << "Error: The service '" << description
-                                    << "' cannot be created because"
-                                    << " host '" << host_name
-                                    << "' does not exist (host_id is null)";
+    logger(log_config_error, basic)
+        << "Error: The service '" << description
+        << "' cannot be created because"
+        << " host '" << host_name << "' does not exist (host_id is null)";
     return nullptr;
   } else if (host_id != hid) {
     logger(log_config_error, basic)
@@ -663,52 +704,30 @@ com::centreon::engine::service* add_service(
       notification_interval < 0) {
     logger(log_config_error, basic)
         << "Error: Invalid max_attempts, check_interval, retry_interval"
-           ", or notification_interval value for service '" << description
-        << "' on host '" << host_name << "'";
+           ", or notification_interval value for service '"
+        << description << "' on host '" << host_name << "'";
     return nullptr;
   }
   // Check if the service is already exist.
   std::pair<uint64_t, uint64_t> id(std::make_pair(host_id, service_id));
   if (is_service_exist(id)) {
-    logger(log_config_error, basic) << "Error: Service '" << description
-                                    << "' on host '" << host_name
-                                    << "' has already been defined";
+    logger(log_config_error, basic)
+        << "Error: Service '" << description << "' on host '" << host_name
+        << "' has already been defined";
     return nullptr;
   }
 
   // Allocate memory.
   std::shared_ptr<service> obj{std::make_shared<service>(
-      host_name,
-      description,
-      display_name.empty() ? description : display_name,
-      check_command,
-      checks_enabled,
-      accept_passive_checks,
-      initial_state,
-      check_interval,
-      retry_interval,
-      notification_interval,
-      max_attempts,
-      first_notification_delay,
-      recovery_notification_delay,
-      notification_period,
-      notifications_enabled,
-      is_volatile,
-      check_period,
-      event_handler,
-      event_handler_enabled,
-      notes,
-      notes_url,
-      action_url,
-      icon_image,
-      icon_image_alt,
-      flap_detection_enabled,
-      low_flap_threshold,
-      high_flap_threshold,
-      check_freshness,
-      freshness_threshold,
-      obsess_over_service,
-      timezone)};
+      host_name, description, display_name.empty() ? description : display_name,
+      check_command, checks_enabled, accept_passive_checks, initial_state,
+      check_interval, retry_interval, notification_interval, max_attempts,
+      first_notification_delay, recovery_notification_delay,
+      notification_period, notifications_enabled, is_volatile, check_period,
+      event_handler, event_handler_enabled, notes, notes_url, action_url,
+      icon_image, icon_image_alt, flap_detection_enabled, low_flap_threshold,
+      high_flap_threshold, check_freshness, freshness_threshold,
+      obsess_over_service, timezone)};
   try {
     obj->set_acknowledgement_type(ACKNOWLEDGEMENT_NONE);
     obj->set_check_options(CHECK_OPTION_NONE);
@@ -754,8 +773,7 @@ com::centreon::engine::service* add_service(
     // Add new items to the list.
     service::services[{obj->get_hostname(), obj->get_description()}] = obj;
     service::services_by_id[{host_id, service_id}] = obj;
-  }
-  catch (...) {
+  } catch (...) {
     obj.reset();
   }
 
@@ -771,10 +789,10 @@ void service::check_for_expired_acknowledgement() {
     if (get_acknowledgement_timeout() > 0) {
       time_t now(time(nullptr));
       if (get_last_acknowledgement() + get_acknowledgement_timeout() >= now) {
-        logger(log_info_message, basic) << "Acknowledgement of service '"
-                                        << get_description() << "' on host '"
-                                        << this->get_host_ptr()->get_name()
-                                        << "' just expired";
+        logger(log_info_message, basic)
+            << "Acknowledgement of service '" << get_description()
+            << "' on host '" << this->get_host_ptr()->get_name()
+            << "' just expired";
         set_problem_has_been_acknowledged(false);
         this->set_acknowledgement_type(ACKNOWLEDGEMENT_NONE);
         update_status();
@@ -827,8 +845,8 @@ std::pair<uint64_t, uint64_t> engine::get_host_and_service_id(
     std::string const& svc) {
   service_map::const_iterator found = service::services.find({host, svc});
   return found != service::services.end()
-      ? std::pair<uint64_t, uint64_t>{found->second->get_host_id(),
-                                      found->second->get_service_id()}
+             ? std::pair<uint64_t, uint64_t>{found->second->get_host_id(),
+                                             found->second->get_service_id()}
              : std::pair<uint64_t, uint64_t>{0u, 0u};
 }
 
@@ -854,43 +872,53 @@ void service::schedule_acknowledgement_expiration() {
       get_last_acknowledgement() != (time_t)0) {
     timed_event* evt = new timed_event(
         timed_event::EVENT_EXPIRE_SERVICE_ACK,
-        get_last_acknowledgement() + get_acknowledgement_timeout(),
-        false,
-        0,
-        nullptr,
-        true,
-        this,
-        nullptr,
-        0);
+        get_last_acknowledgement() + get_acknowledgement_timeout(), false, 0,
+        nullptr, true, this, nullptr, 0);
     events::loop::instance().schedule(evt, false);
   }
 }
 
-void service::set_host_id(uint64_t host_id) { _host_id = host_id; }
+void service::set_host_id(uint64_t host_id) {
+  _host_id = host_id;
+}
 
-uint64_t service::get_host_id() const { return _host_id; }
+uint64_t service::get_host_id() const {
+  return _host_id;
+}
 
-void service::set_service_id(uint64_t service_id) { _service_id = service_id; }
+void service::set_service_id(uint64_t service_id) {
+  _service_id = service_id;
+}
 
-uint64_t service::get_service_id() const { return _service_id; }
+uint64_t service::get_service_id() const {
+  return _service_id;
+}
 
-void service::set_hostname(std::string const& name) { _hostname = name; }
+void service::set_hostname(std::string const& name) {
+  _hostname = name;
+}
 
 /**
  * @brief Get the hostname of the host associated with this downtime.
  *
  * @return A string reference to the host name.
  */
-std::string const& service::get_hostname() const { return _hostname; }
+std::string const& service::get_hostname() const {
+  return _hostname;
+}
 
-void service::set_description(std::string const& desc) { _description = desc; }
+void service::set_description(std::string const& desc) {
+  _description = desc;
+}
 
 /**
  * @brief Get the description of the service.
  *
  * @return A string reference to the description.
  */
-std::string const& service::get_description() const { return _description; }
+std::string const& service::get_description() const {
+  return _description;
+}
 
 /**
  * @brief set the event handler arguments
@@ -965,9 +993,9 @@ int service::handle_async_check_result(check_result* queued_check_result) {
   if (execution_time < 0.0)
     execution_time = 0.0;
 
-  logger(dbg_checks, basic) << "** Handling check result for service '"
-                            << _description << "' on host '" << _hostname
-                            << "'...";
+  logger(dbg_checks, basic)
+      << "** Handling check result for service '" << _description
+      << "' on host '" << _hostname << "'...";
   logger(dbg_checks, more)
       << "HOST: " << _hostname << ", SERVICE: " << _description
       << ", CHECK TYPE: "
@@ -1067,10 +1095,9 @@ int service::handle_async_check_result(check_result* queued_check_result) {
    * shouldn't be happening)
    */
   if (!queued_check_result->get_exited_ok()) {
-    logger(log_runtime_warning, basic) << "Warning:  Check of service '"
-                                       << _description << "' on host '"
-                                       << _hostname
-                                       << "' did not exit properly!";
+    logger(log_runtime_warning, basic)
+        << "Warning:  Check of service '" << _description << "' on host '"
+        << _hostname << "' did not exit properly!";
 
     set_plugin_output("(Service check did not exit properly)");
     _current_state = service::state_unknown;
@@ -1096,7 +1123,8 @@ int service::handle_async_check_result(check_result* queued_check_result) {
                 ? " - plugin may not be executable"
                 : (queued_check_result->get_return_code() == 127
                        ? " - plugin may be missing"
-                       : "")) << ')';
+                       : ""))
+        << ')';
 
     set_plugin_output(oss.str());
     _current_state = service::state_unknown;
@@ -1111,8 +1139,8 @@ int service::handle_async_check_result(check_result* queued_check_result) {
     std::string plugin_output;
     std::string long_plugin_output;
     std::string perf_data;
-    parse_check_output(
-        output, plugin_output, long_plugin_output, perf_data, true, false);
+    parse_check_output(output, plugin_output, long_plugin_output, perf_data,
+                       true, false);
 
     set_long_plugin_output(long_plugin_output);
     set_perf_data(perf_data);
@@ -1135,7 +1163,8 @@ int service::handle_async_check_result(check_result* queued_check_result) {
         << (get_plugin_output().empty() ? "NULL" : get_plugin_output()) << "\n"
         << "Long Output:\n"
         << (get_long_plugin_output().empty() ? "NULL"
-                                             : get_long_plugin_output()) << "\n"
+                                             : get_long_plugin_output())
+        << "\n"
         << "Perf Data:\n"
         << (get_perf_data().empty() ? "NULL" : get_perf_data());
 
@@ -1172,10 +1201,9 @@ int service::handle_async_check_result(check_result* queued_check_result) {
    */
   if (get_check_type() == check_passive) {
     if (config->log_passive_checks())
-      logger(log_passive_check, basic) << "PASSIVE SERVICE CHECK: " << _hostname
-                                       << ";" << _description << ";"
-                                       << _current_state << ";"
-                                       << get_plugin_output();
+      logger(log_passive_check, basic)
+          << "PASSIVE SERVICE CHECK: " << _hostname << ";" << _description
+          << ";" << _current_state << ";" << get_plugin_output();
   }
 
   host* hst{get_host_ptr()};
@@ -1192,8 +1220,8 @@ int service::handle_async_check_result(check_result* queued_check_result) {
       /* set a flag to remember that we launched a check */
       first_host_check_initiated = true;
 
-      hst->run_async_check(
-          CHECK_OPTION_NONE, 0.0, false, false, nullptr, nullptr);
+      hst->run_async_check(CHECK_OPTION_NONE, 0.0, false, false, nullptr,
+                           nullptr);
     }
   }
 
@@ -1350,16 +1378,16 @@ int service::handle_async_check_result(check_result* queued_check_result) {
             hst->has_been_checked() &&
             (static_cast<unsigned long>(current_time - hst->get_last_check()) <=
              config->cached_host_check_horizon())) {
-          logger(dbg_checks, more) << "* Using cached host state: "
-                                   << hst->get_current_state();
+          logger(dbg_checks, more)
+              << "* Using cached host state: " << hst->get_current_state();
           update_check_stats(ACTIVE_ONDEMAND_HOST_CHECK_STATS, current_time);
           update_check_stats(ACTIVE_CACHED_HOST_CHECK_STATS, current_time);
         }
 
         /* else launch an async (parallel) check of the host */
         else
-          hst->run_async_check(
-              CHECK_OPTION_NONE, 0.0, false, false, nullptr, nullptr);
+          hst->run_async_check(CHECK_OPTION_NONE, 0.0, false, false, nullptr,
+                               nullptr);
       }
     }
 
@@ -1457,8 +1485,8 @@ int service::handle_async_check_result(check_result* queued_check_result) {
            config->cached_host_check_horizon())) {
         /* use current host state as route result */
         route_result = hst->get_current_state();
-        logger(dbg_checks, more) << "* Using cached host state: "
-                                 << hst->get_current_state();
+        logger(dbg_checks, more)
+            << "* Using cached host state: " << hst->get_current_state();
         update_check_stats(ACTIVE_ONDEMAND_HOST_CHECK_STATS, current_time);
         update_check_stats(ACTIVE_CACHED_HOST_CHECK_STATS, current_time);
       }
@@ -1469,16 +1497,16 @@ int service::handle_async_check_result(check_result* queued_check_result) {
       else if (state_change) {
         /* use current host state as route result */
         route_result = hst->get_current_state();
-        hst->run_async_check(
-            CHECK_OPTION_NONE, 0.0, false, false, nullptr, nullptr);
+        hst->run_async_check(CHECK_OPTION_NONE, 0.0, false, false, nullptr,
+                             nullptr);
       }
 
       /* ADDED 02/15/08 */
       /* else assume same host state */
       else {
         route_result = hst->get_current_state();
-        logger(dbg_checks, more) << "* Using last known host state: "
-                                 << hst->get_current_state();
+        logger(dbg_checks, more)
+            << "* Using last known host state: " << hst->get_current_state();
         update_check_stats(ACTIVE_ONDEMAND_HOST_CHECK_STATS, current_time);
         update_check_stats(ACTIVE_CACHED_HOST_CHECK_STATS, current_time);
       }
@@ -1498,8 +1526,8 @@ int service::handle_async_check_result(check_result* queued_check_result) {
         /* previous logic was to simply run a sync (serial) host check */
         /* use current host state as route result */
         route_result = hst->get_current_state();
-        hst->run_async_check(
-            CHECK_OPTION_NONE, 0.0, false, false, nullptr, nullptr);
+        hst->run_async_check(CHECK_OPTION_NONE, 0.0, false, false, nullptr,
+                             nullptr);
         /*perform_on_demand_host_check(hst,&route_result,CHECK_OPTION_NONE,true,config->cached_host_check_horizon());
          */
       }
@@ -1575,9 +1603,9 @@ int service::handle_async_check_result(check_result* queued_check_result) {
         set_current_attempt(1);
     }
 
-    logger(dbg_checks, more) << "Current/Max Attempt(s): "
-                             << get_current_attempt() << '/'
-                             << get_max_attempts();
+    logger(dbg_checks, more)
+        << "Current/Max Attempt(s): " << get_current_attempt() << '/'
+        << get_max_attempts();
 
     /* if we should retry the service check, do so (except it the host is down
      * or unreachable!) */
@@ -1640,18 +1668,16 @@ int service::handle_async_check_result(check_result* queued_check_result) {
         std::pair<std::string, std::string> id({_hostname, _description});
         auto p(servicedependency::servicedependencies.equal_range(id));
         for (servicedependency_mmap::const_iterator it{p.first}, end{p.second};
-             it != end;
-             ++it) {
+             it != end; ++it) {
           servicedependency* temp_dependency{it->second.get()};
 
           if (temp_dependency->dependent_service_ptr == this &&
               temp_dependency->master_service_ptr) {
             master_service = temp_dependency->master_service_ptr;
-            logger(dbg_checks, most) << "Predictive check of service '"
-                                     << master_service->get_description()
-                                     << "' on host '"
-                                     << master_service->get_hostname()
-                                     << "' queued.";
+            logger(dbg_checks, most)
+                << "Predictive check of service '"
+                << master_service->get_description() << "' on host '"
+                << master_service->get_hostname() << "' queued.";
             check_servicelist.push_back(master_service);
           }
         }
@@ -1742,8 +1768,8 @@ int service::handle_async_check_result(check_result* queued_check_result) {
     {
       timezone_locker lock(get_timezone());
       preferred_time = get_next_check();
-      get_next_valid_time(
-          preferred_time, &next_valid_time, this->check_period_ptr);
+      get_next_valid_time(preferred_time, &next_valid_time,
+                          this->check_period_ptr);
       set_next_check(next_valid_time);
     }
 
@@ -1781,21 +1807,13 @@ int service::handle_async_check_result(check_result* queued_check_result) {
   }
 
   /* send data to event broker */
-  broker_service_check(NEBTYPE_SERVICECHECK_PROCESSED,
-                       NEBFLAG_NONE,
-                       NEBATTR_NONE,
-                       this,
-                       get_check_type(),
-                       queued_check_result->get_start_time(),
-                       queued_check_result->get_finish_time(),
-                       nullptr,
-                       get_latency(),
-                       get_execution_time(),
-                       config->service_check_timeout(),
-                       queued_check_result->get_early_timeout(),
-                       queued_check_result->get_return_code(),
-                       nullptr,
-                       nullptr);
+  broker_service_check(
+      NEBTYPE_SERVICECHECK_PROCESSED, NEBFLAG_NONE, NEBATTR_NONE, this,
+      get_check_type(), queued_check_result->get_start_time(),
+      queued_check_result->get_finish_time(), nullptr, get_latency(),
+      get_execution_time(), config->service_check_timeout(),
+      queued_check_result->get_early_timeout(),
+      queued_check_result->get_return_code(), nullptr, nullptr);
 
   if (!(reschedule_check && get_should_be_scheduled() && has_been_checked()) ||
       !get_checks_enabled()) {
@@ -1833,8 +1851,8 @@ int service::handle_async_check_result(check_result* queued_check_result) {
       run_async_check = false;
 
     if (run_async_check)
-      svc->run_async_check(
-          CHECK_OPTION_NONE, 0.0, false, false, nullptr, nullptr);
+      svc->run_async_check(CHECK_OPTION_NONE, 0.0, false, false, nullptr,
+                           nullptr);
   }
   return OK;
 }
@@ -1860,10 +1878,10 @@ int service::log_event() {
   }
   std::string const& state_type{tab_state_type[get_state_type()]};
 
-  logger(log_options, basic) << "SERVICE ALERT: " << _hostname << ";"
-                             << _description << ";" << state << ";"
-                             << state_type << ";" << get_current_attempt()
-                             << ";" << get_plugin_output();
+  logger(log_options, basic)
+      << "SERVICE ALERT: " << _hostname << ";" << _description << ";" << state
+      << ";" << state_type << ";" << get_current_attempt() << ";"
+      << get_plugin_output();
   return OK;
 }
 
@@ -1888,9 +1906,9 @@ void service::check_for_flapping(bool update,
 
   logger(dbg_functions, basic) << "check_for_flapping()";
 
-  logger(dbg_flapping, more) << "Checking service '" << _description
-                             << "' on host '" << _hostname
-                             << "' for flapping...";
+  logger(dbg_flapping, more)
+      << "Checking service '" << _description << "' on host '" << _hostname
+      << "' for flapping...";
 
   /* if this is a soft service state and not a soft recovery, don't record this
    * in the history */
@@ -1964,11 +1982,10 @@ void service::check_for_flapping(bool update,
 
   set_percent_state_change(curved_percent_change);
 
-  logger(dbg_flapping, most) << com::centreon::logging::setprecision(2)
-                             << "LFT=" << low_threshold
-                             << ", HFT=" << high_threshold
-                             << ", CPC=" << curved_percent_change
-                             << ", PSC=" << curved_percent_change << "%";
+  logger(dbg_flapping, most)
+      << com::centreon::logging::setprecision(2) << "LFT=" << low_threshold
+      << ", HFT=" << high_threshold << ", CPC=" << curved_percent_change
+      << ", PSC=" << curved_percent_change << "%";
 
   /* don't do anything if we don't have flap detection enabled on a program-wide
    * basis */
@@ -1993,16 +2010,14 @@ void service::check_for_flapping(bool update,
   else if (curved_percent_change >= high_threshold)
     is_flapping = true;
 
-  logger(dbg_flapping, more) << com::centreon::logging::setprecision(2)
-                             << "Service " << (is_flapping ? "is" : "is not")
-                             << " flapping (" << curved_percent_change
-                             << "% state change).";
+  logger(dbg_flapping, more)
+      << com::centreon::logging::setprecision(2) << "Service "
+      << (is_flapping ? "is" : "is not") << " flapping ("
+      << curved_percent_change << "% state change).";
 
   /* did the service just start flapping? */
   if (is_flapping && !get_is_flapping())
-    set_flap(curved_percent_change,
-             high_threshold,
-             low_threshold,
+    set_flap(curved_percent_change, high_threshold, low_threshold,
              allow_flapstart_notification);
 
   /* did the service just stop flapping? */
@@ -2017,16 +2032,10 @@ int service::handle_service_event() {
   logger(dbg_functions, basic) << "handle_service_event()";
 
   /* send event data to broker */
-  broker_statechange_data(NEBTYPE_STATECHANGE_END,
-                          NEBFLAG_NONE,
-                          NEBATTR_NONE,
-                          SERVICE_STATECHANGE,
-                          (void*)this,
-                          _current_state,
-                          get_state_type(),
-                          get_current_attempt(),
-                          get_max_attempts(),
-                          nullptr);
+  broker_statechange_data(NEBTYPE_STATECHANGE_END, NEBFLAG_NONE, NEBATTR_NONE,
+                          SERVICE_STATECHANGE, (void*)this, _current_state,
+                          get_state_type(), get_current_attempt(),
+                          get_max_attempts(), nullptr);
 
   /* bail out if we shouldn't be running event handlers */
   if (!config->enable_event_handlers())
@@ -2051,14 +2060,9 @@ int service::handle_service_event() {
   clear_volatile_macros_r(mac);
 
   /* send data to event broker */
-  broker_external_command(NEBTYPE_EXTERNALCOMMAND_CHECK,
-                          NEBFLAG_NONE,
-                          NEBATTR_NONE,
-                          CMD_NONE,
-                          time(nullptr),
-                          nullptr,
-                          nullptr,
-                          nullptr);
+  broker_external_command(NEBTYPE_EXTERNALCOMMAND_CHECK, NEBFLAG_NONE,
+                          NEBATTR_NONE, CMD_NONE, time(nullptr), nullptr,
+                          nullptr, nullptr);
 
   return OK;
 }
@@ -2095,18 +2099,16 @@ int service::obsessive_compulsive_service_check_processor() {
   grab_service_macros_r(mac, this);
 
   /* get the raw command line */
-  get_raw_command_line_r(mac,
-                         ocsp_command_ptr,
-                         config->ocsp_command().c_str(),
-                         raw_command,
-                         macro_options);
+  get_raw_command_line_r(mac, ocsp_command_ptr, config->ocsp_command().c_str(),
+                         raw_command, macro_options);
   if (raw_command.empty()) {
     clear_volatile_macros_r(mac);
     return ERROR;
   }
 
   logger(dbg_checks, most) << "Raw obsessive compulsive service processor "
-                              "command line: " << raw_command;
+                              "command line: "
+                           << raw_command;
 
   /* process any macros in the raw command line */
   process_macros_r(mac, raw_command, processed_command, macro_options);
@@ -2116,20 +2118,15 @@ int service::obsessive_compulsive_service_check_processor() {
   }
 
   logger(dbg_checks, most) << "Processed obsessive compulsive service "
-                              "processor command line: " << processed_command;
+                              "processor command line: "
+                           << processed_command;
 
   /* run the command */
   try {
     std::string tmp;
-    my_system_r(mac,
-                processed_command,
-                config->ocsp_timeout(),
-                &early_timeout,
-                &exectime,
-                tmp,
-                0);
-  }
-  catch (std::exception const& e) {
+    my_system_r(mac, processed_command, config->ocsp_timeout(), &early_timeout,
+                &exectime, tmp, 0);
+  } catch (std::exception const& e) {
     logger(log_runtime_error, basic)
         << "Error: can't execute compulsive service processor command line '"
         << processed_command << "' : " << e.what();
@@ -2139,11 +2136,10 @@ int service::obsessive_compulsive_service_check_processor() {
 
   /* check to see if the command timed out */
   if (early_timeout == true)
-    logger(log_runtime_warning, basic) << "Warning: OCSP command '"
-                                       << processed_command << "' for service '"
-                                       << _description << "' on host '"
-                                       << _hostname << "' timed out after "
-                                       << config->ocsp_timeout() << " seconds";
+    logger(log_runtime_warning, basic)
+        << "Warning: OCSP command '" << processed_command << "' for service '"
+        << _description << "' on host '" << _hostname << "' timed out after "
+        << config->ocsp_timeout() << " seconds";
 
   return OK;
 }
@@ -2172,14 +2168,14 @@ int service::run_scheduled_check(int check_options, double latency) {
   bool time_is_valid = true;
 
   logger(dbg_functions, basic) << "run_scheduled_service_check()";
-  logger(dbg_checks, basic) << "Attempting to run scheduled check of service '"
-                            << _description << "' on host '" << _hostname
-                            << "': check options=" << check_options
-                            << ", latency=" << latency;
+  logger(dbg_checks, basic)
+      << "Attempting to run scheduled check of service '" << _description
+      << "' on host '" << _hostname << "': check options=" << check_options
+      << ", latency=" << latency;
 
   /* attempt to run the check */
-  result = run_async_check(
-      check_options, latency, true, true, &time_is_valid, &preferred_time);
+  result = run_async_check(check_options, latency, true, true, &time_is_valid,
+                           &preferred_time);
 
   /* an error occurred, so reschedule the check */
   if (result == ERROR) {
@@ -2207,13 +2203,13 @@ int service::run_scheduled_check(int check_options, double latency) {
       // Make sure we rescheduled the next service check at a valid time.
       {
         timezone_locker lock(get_timezone());
-        get_next_valid_time(
-            preferred_time, &next_valid_time, this->check_period_ptr);
+        get_next_valid_time(preferred_time, &next_valid_time,
+                            this->check_period_ptr);
 
         // The service could not be rescheduled properly.
         // Set the next check time for next week.
         if (!time_is_valid && !check_time_against_period(
-                                   next_valid_time, this->check_period_ptr)) {
+                                  next_valid_time, this->check_period_ptr)) {
           set_next_check((time_t)(next_valid_time + 60 * 60 * 24 * 7));
           logger(log_runtime_warning, basic)
               << "Warning: Check of service '" << _description << "' on host '"
@@ -2261,10 +2257,10 @@ int service::run_async_check(int check_options,
                              bool reschedule_check,
                              bool* time_is_valid,
                              time_t* preferred_time) noexcept {
-  logger(dbg_functions, basic) << "service::run_async_check, check_options="
-                               << check_options << ", latency=" << latency
-                               << ", scheduled_check=" << scheduled_check
-                               << ", reschedule_check=" << reschedule_check;
+  logger(dbg_functions, basic)
+      << "service::run_async_check, check_options=" << check_options
+      << ", latency=" << latency << ", scheduled_check=" << scheduled_check
+      << ", reschedule_check=" << reschedule_check;
 
   // Preamble.
   if (!get_check_command_ptr()) {
@@ -2275,9 +2271,9 @@ int service::run_async_check(int check_options,
     return ERROR;
   }
 
-  logger(dbg_checks, basic) << "** Running async check of service '"
-                            << get_description() << "' on host '"
-                            << get_hostname() << "'...";
+  logger(dbg_checks, basic)
+      << "** Running async check of service '" << get_description()
+      << "' on host '" << get_hostname() << "'...";
 
   // Check if the service is viable now.
   if (!verify_check_viability(check_options, time_is_valid, preferred_time))
@@ -2286,21 +2282,11 @@ int service::run_async_check(int check_options,
   // Send broker event.
   timeval start_time = {0, 0};
   timeval end_time = {0, 0};
-  int res = broker_service_check(NEBTYPE_SERVICECHECK_ASYNC_PRECHECK,
-                                 NEBFLAG_NONE,
-                                 NEBATTR_NONE,
-                                 this,
-                                 checkable::check_active,
-                                 start_time,
-                                 end_time,
-                                 get_check_command().c_str(),
-                                 get_latency(),
-                                 0.0,
-                                 0,
-                                 false,
-                                 0,
-                                 nullptr,
-                                 nullptr);
+  int res =
+      broker_service_check(NEBTYPE_SERVICECHECK_ASYNC_PRECHECK, NEBFLAG_NONE,
+                           NEBATTR_NONE, this, checkable::check_active,
+                           start_time, end_time, get_check_command().c_str(),
+                           get_latency(), 0.0, 0, false, 0, nullptr, nullptr);
 
   // Service check was cancelled by NEB module. reschedule check later.
   if (NEBERROR_CALLBACKCANCEL == res) {
@@ -2337,16 +2323,16 @@ int service::run_async_check(int check_options,
   grab_host_macros_r(macros, get_host_ptr());
   grab_service_macros_r(macros, this);
   std::string tmp;
-  get_raw_command_line_r(
-      macros, get_check_command_ptr(), get_check_command().c_str(), tmp, 0);
+  get_raw_command_line_r(macros, get_check_command_ptr(),
+                         get_check_command().c_str(), tmp, 0);
 
   // Time to start command.
   gettimeofday(&start_time, nullptr);
 
   // Update the number of running service checks.
   ++currently_running_service_checks;
-  logger(dbg_checks, basic) << "Current running service checks: "
-                            << currently_running_service_checks;
+  logger(dbg_checks, basic)
+      << "Current running service checks: " << currently_running_service_checks;
 
   // Set the execution flag.
   set_is_executing(true);
@@ -2356,21 +2342,12 @@ int service::run_async_check(int check_options,
   std::string processed_cmd(cmd->process_cmd(macros));
 
   // Send event broker.
-  res = broker_service_check(NEBTYPE_SERVICECHECK_INITIATE,
-                             NEBFLAG_NONE,
-                             NEBATTR_NONE,
-                             this,
-                             checkable::check_active,
-                             start_time,
-                             end_time,
-                             get_check_command().c_str(),
-                             get_latency(),
-                             0.0,
-                             config->service_check_timeout(),
-                             false,
-                             0,
-                             processed_cmd.c_str(),
-                             nullptr);
+  res =
+      broker_service_check(NEBTYPE_SERVICECHECK_INITIATE, NEBFLAG_NONE,
+                           NEBATTR_NONE, this, checkable::check_active,
+                           start_time, end_time, get_check_command().c_str(),
+                           get_latency(), 0.0, config->service_check_timeout(),
+                           false, 0, processed_cmd.c_str(), nullptr);
 
   // Restore latency.
   set_latency(old_latency);
@@ -2390,18 +2367,10 @@ int service::run_async_check(int check_options,
   std::unique_ptr<check_result> check_result_info;
   do {
     // Init check result info.
-    check_result_info.reset(new check_result(service_check,
-                                             this,
-                                             checkable::check_active,
-                                             check_options,
-                                             reschedule_check,
-                                             latency,
-                                             start_time,
-                                             start_time,
-                                             false,
-                                             true,
-                                             service::state_ok,
-                                             ""));
+    check_result_info.reset(
+        new check_result(service_check, this, checkable::check_active,
+                         check_options, reschedule_check, latency, start_time,
+                         start_time, false, true, service::state_ok, ""));
 
     retry = false;
     try {
@@ -2411,11 +2380,9 @@ int service::run_async_check(int check_options,
       if (id != 0)
         checks::checker::instance().add_check_result(
             id, check_result_info.release());
-    }
-    catch (com::centreon::exceptions::interruption const& e) {
+    } catch (com::centreon::exceptions::interruption const& e) {
       retry = true;
-    }
-    catch (std::exception const& e) {
+    } catch (std::exception const& e) {
       // Update check result.
       timeval tv;
       gettimeofday(&tv, nullptr);
@@ -2451,13 +2418,11 @@ int service::run_async_check(int check_options,
 bool service::schedule_check(time_t check_time, int options) {
   logger(dbg_functions, basic) << "schedule_service_check()";
 
-  logger(dbg_checks, basic) << "Scheduling a "
-                            << (options & CHECK_OPTION_FORCE_EXECUTION
-                                    ? "forced"
-                                    : "non-forced")
-                            << ", active check of service '" << _description
-                            << "' on host '" << _hostname << "' @ "
-                            << my_ctime(&check_time);
+  logger(dbg_checks, basic)
+      << "Scheduling a "
+      << (options & CHECK_OPTION_FORCE_EXECUTION ? "forced" : "non-forced")
+      << ", active check of service '" << _description << "' on host '"
+      << _hostname << "' @ " << my_ctime(&check_time);
 
   // Don't schedule a check if active checks
   // of this service are disabled.
@@ -2538,19 +2503,12 @@ bool service::schedule_check(time_t check_time, int options) {
       set_next_check(check_time);
 
       // Place the new event in the event queue.
-      timed_event* new_event = new timed_event(timed_event::EVENT_SERVICE_CHECK,
-                                               get_next_check(),
-                                               false,
-                                               0L,
-                                               nullptr,
-                                               true,
-                                               this,
-                                               nullptr,
-                                               options);
+      timed_event* new_event =
+          new timed_event(timed_event::EVENT_SERVICE_CHECK, get_next_check(),
+                          false, 0L, nullptr, true, this, nullptr, options);
 
       events::loop::instance().reschedule_event(new_event, events::loop::low);
-    }
-    catch (...) {
+    } catch (...) {
       // Update the status log.
       update_status();
       throw;
@@ -2591,22 +2549,16 @@ void service::set_flap(double percent_change,
       << "Notifications for this service are being suppressed because "
          "it was detected as "
       << "having been flapping between different "
-         "states (" << percent_change << "% change >= " << high_threshold
+         "states ("
+      << percent_change << "% change >= " << high_threshold
       << "% threshold).  When the service state stabilizes and the "
          "flapping "
       << "stops, notifications will be re-enabled.";
 
-  std::shared_ptr<comment> com{new comment(comment::service,
-                                           comment::flapping,
-                                           get_host_id(),
-                                           _service_id,
-                                           time(nullptr),
-                                           "(Centreon Engine Process)",
-                                           oss.str(),
-                                           false,
-                                           comment::internal,
-                                           false,
-                                           (time_t)0)};
+  std::shared_ptr<comment> com{
+      new comment(comment::service, comment::flapping, get_host_id(),
+                  _service_id, time(nullptr), "(Centreon Engine Process)",
+                  oss.str(), false, comment::internal, false, (time_t)0)};
 
   comment::comments.insert({com->get_comment_id(), com});
 
@@ -2616,15 +2568,9 @@ void service::set_flap(double percent_change,
   set_is_flapping(true);
 
   /* send data to event broker */
-  broker_flapping_data(NEBTYPE_FLAPPING_START,
-                       NEBFLAG_NONE,
-                       NEBATTR_NONE,
-                       SERVICE_FLAPPING,
-                       this,
-                       percent_change,
-                       high_threshold,
-                       low_threshold,
-                       nullptr);
+  broker_flapping_data(NEBTYPE_FLAPPING_START, NEBFLAG_NONE, NEBATTR_NONE,
+                       SERVICE_FLAPPING, this, percent_change, high_threshold,
+                       low_threshold, nullptr);
 
   /* send a notification */
   if (allow_flapstart_notification)
@@ -2656,15 +2602,9 @@ void service::clear_flap(double percent_change,
   set_is_flapping(false);
 
   /* send data to event broker */
-  broker_flapping_data(NEBTYPE_FLAPPING_STOP,
-                       NEBFLAG_NONE,
-                       NEBATTR_FLAPPING_STOP_NORMAL,
-                       SERVICE_FLAPPING,
-                       this,
-                       percent_change,
-                       high_threshold,
-                       low_threshold,
-                       nullptr);
+  broker_flapping_data(NEBTYPE_FLAPPING_STOP, NEBFLAG_NONE,
+                       NEBATTR_FLAPPING_STOP_NORMAL, SERVICE_FLAPPING, this,
+                       percent_change, high_threshold, low_threshold, nullptr);
 
   /* send a notification */
   notify(reason_flappingstop, "", "", notification_option_none);
@@ -2679,9 +2619,9 @@ void service::enable_flap_detection() {
 
   logger(dbg_functions, basic) << "service::enable_flap_detection()";
 
-  logger(dbg_flapping, more) << "Enabling flap detection for service '"
-                             << _description << "' on host '" << _hostname
-                             << "'.";
+  logger(dbg_flapping, more)
+      << "Enabling flap detection for service '" << _description
+      << "' on host '" << _hostname << "'.";
 
   /* nothing to do... */
   if (get_flap_detection_enabled())
@@ -2694,14 +2634,9 @@ void service::enable_flap_detection() {
   set_flap_detection_enabled(true);
 
   /* send data to event broker */
-  broker_adaptive_service_data(NEBTYPE_ADAPTIVESERVICE_UPDATE,
-                               NEBFLAG_NONE,
-                               NEBATTR_NONE,
-                               this,
-                               CMD_NONE,
-                               attr,
-                               get_modified_attributes(),
-                               nullptr);
+  broker_adaptive_service_data(NEBTYPE_ADAPTIVESERVICE_UPDATE, NEBFLAG_NONE,
+                               NEBATTR_NONE, this, CMD_NONE, attr,
+                               get_modified_attributes(), nullptr);
 
   /* check for flapping */
   check_for_flapping(false, true);
@@ -2716,9 +2651,9 @@ void service::disable_flap_detection() {
 
   logger(dbg_functions, basic) << "disable_service_flap_detection()";
 
-  logger(dbg_flapping, more) << "Disabling flap detection for service '"
-                             << _description << "' on host '" << _hostname
-                             << "'.";
+  logger(dbg_flapping, more)
+      << "Disabling flap detection for service '" << _description
+      << "' on host '" << _hostname << "'.";
 
   /* nothing to do... */
   if (!get_flap_detection_enabled())
@@ -2731,14 +2666,9 @@ void service::disable_flap_detection() {
   set_flap_detection_enabled(false);
 
   /* send data to event broker */
-  broker_adaptive_service_data(NEBTYPE_ADAPTIVESERVICE_UPDATE,
-                               NEBFLAG_NONE,
-                               NEBATTR_NONE,
-                               this,
-                               CMD_NONE,
-                               attr,
-                               get_modified_attributes(),
-                               nullptr);
+  broker_adaptive_service_data(NEBTYPE_ADAPTIVESERVICE_UPDATE, NEBFLAG_NONE,
+                               NEBATTR_NONE, this, CMD_NONE, attr,
+                               get_modified_attributes(), nullptr);
 
   /* handle the details... */
   handle_flap_detection_disabled();
@@ -2748,8 +2678,8 @@ void service::disable_flap_detection() {
  * @brief Updates service status info. Send data to event broker.
  */
 void service::update_status() {
-  broker_service_status(
-      NEBTYPE_SERVICESTATUS_UPDATE, NEBFLAG_NONE, NEBATTR_NONE, this, nullptr);
+  broker_service_status(NEBTYPE_SERVICESTATUS_UPDATE, NEBFLAG_NONE,
+                        NEBATTR_NONE, this, nullptr);
 }
 
 /* checks viability of performing a service check */
@@ -2844,8 +2774,8 @@ int service::notify_contact(nagios_macros* mac,
   int neb_result;
 
   logger(dbg_functions, basic) << "notify_contact_of_service()";
-  logger(dbg_notifications, most) << "** Notifying contact '"
-                                  << cntct->get_name() << "'";
+  logger(dbg_notifications, most)
+      << "** Notifying contact '" << cntct->get_name() << "'";
 
   /* get start time */
   gettimeofday(&start_time, nullptr);
@@ -2853,20 +2783,10 @@ int service::notify_contact(nagios_macros* mac,
   /* send data to event broker */
   end_time.tv_sec = 0L;
   end_time.tv_usec = 0L;
-  neb_result =
-      broker_contact_notification_data(NEBTYPE_CONTACTNOTIFICATION_START,
-                                       NEBFLAG_NONE,
-                                       NEBATTR_NONE,
-                                       service_notification,
-                                       type,
-                                       start_time,
-                                       end_time,
-                                       (void*)this,
-                                       cntct,
-                                       not_author.c_str(),
-                                       not_data.c_str(),
-                                       escalated,
-                                       nullptr);
+  neb_result = broker_contact_notification_data(
+      NEBTYPE_CONTACTNOTIFICATION_START, NEBFLAG_NONE, NEBATTR_NONE,
+      service_notification, type, start_time, end_time, (void*)this, cntct,
+      not_author.c_str(), not_data.c_str(), escalated, nullptr);
   if (NEBERROR_CALLBACKCANCEL == neb_result)
     return ERROR;
   else if (NEBERROR_CALLBACKOVERRIDE == neb_result)
@@ -2882,36 +2802,23 @@ int service::notify_contact(nagios_macros* mac,
     method_end_time.tv_sec = 0L;
     method_end_time.tv_usec = 0L;
     neb_result = broker_contact_notification_method_data(
-        NEBTYPE_CONTACTNOTIFICATIONMETHOD_START,
-        NEBFLAG_NONE,
-        NEBATTR_NONE,
-        service_notification,
-        type,
-        method_start_time,
-        method_end_time,
-        (void*)this,
-        cntct,
-        cmd->get_command_line().c_str(),
-        not_author.c_str(),
-        not_data.c_str(),
-        escalated,
-        nullptr);
+        NEBTYPE_CONTACTNOTIFICATIONMETHOD_START, NEBFLAG_NONE, NEBATTR_NONE,
+        service_notification, type, method_start_time, method_end_time,
+        (void*)this, cntct, cmd->get_command_line().c_str(), not_author.c_str(),
+        not_data.c_str(), escalated, nullptr);
     if (NEBERROR_CALLBACKCANCEL == neb_result)
       break;
     else if (NEBERROR_CALLBACKOVERRIDE == neb_result)
       continue;
 
     /* get the raw command line */
-    get_raw_command_line_r(mac,
-                           cmd.get(),
-                           cmd->get_command_line().c_str(),
-                           raw_command,
-                           macro_options);
+    get_raw_command_line_r(mac, cmd.get(), cmd->get_command_line().c_str(),
+                           raw_command, macro_options);
     if (raw_command.empty())
       continue;
 
-    logger(dbg_notifications, most) << "Raw notification command: "
-                                    << raw_command;
+    logger(dbg_notifications, most)
+        << "Raw notification command: " << raw_command;
 
     /* process any macros contained in the argument */
     process_macros_r(mac, raw_command, processed_command, macro_options);
@@ -2920,8 +2827,8 @@ int service::notify_contact(nagios_macros* mac,
 
     /* run the notification command... */
 
-    logger(dbg_notifications, most) << "Processed notification command: "
-                                    << processed_command;
+    logger(dbg_notifications, most)
+        << "Processed notification command: " << processed_command;
 
     /* log the notification to program log file */
     if (config->log_notifications()) {
@@ -2958,15 +2865,9 @@ int service::notify_contact(nagios_macros* mac,
     /* run the notification command */
     try {
       std::string tmp;
-      my_system_r(mac,
-                  processed_command,
-                  config->notification_timeout(),
-                  &early_timeout,
-                  &exectime,
-                  tmp,
-                  0);
-    }
-    catch (std::exception const& e) {
+      my_system_r(mac, processed_command, config->notification_timeout(),
+                  &early_timeout, &exectime, tmp, 0);
+    } catch (std::exception const& e) {
       logger(log_runtime_error, basic)
           << "Error: can't execute service notification '" << cntct->get_name()
           << "' : " << e.what();
@@ -2986,20 +2887,10 @@ int service::notify_contact(nagios_macros* mac,
 
     /* send data to event broker */
     broker_contact_notification_method_data(
-        NEBTYPE_CONTACTNOTIFICATIONMETHOD_END,
-        NEBFLAG_NONE,
-        NEBATTR_NONE,
-        service_notification,
-        type,
-        method_start_time,
-        method_end_time,
-        (void*)this,
-        cntct,
-        cmd->get_command_line().c_str(),
-        not_author.c_str(),
-        not_data.c_str(),
-        escalated,
-        nullptr);
+        NEBTYPE_CONTACTNOTIFICATIONMETHOD_END, NEBFLAG_NONE, NEBATTR_NONE,
+        service_notification, type, method_start_time, method_end_time,
+        (void*)this, cntct, cmd->get_command_line().c_str(), not_author.c_str(),
+        not_data.c_str(), escalated, nullptr);
   }
 
   /* get end time */
@@ -3009,19 +2900,10 @@ int service::notify_contact(nagios_macros* mac,
   cntct->set_last_service_notification(start_time.tv_sec);
 
   /* send data to event broker */
-  broker_contact_notification_data(NEBTYPE_CONTACTNOTIFICATION_END,
-                                   NEBFLAG_NONE,
-                                   NEBATTR_NONE,
-                                   service_notification,
-                                   type,
-                                   start_time,
-                                   end_time,
-                                   (void*)this,
-                                   cntct,
-                                   not_author.c_str(),
-                                   not_data.c_str(),
-                                   escalated,
-                                   nullptr);
+  broker_contact_notification_data(
+      NEBTYPE_CONTACTNOTIFICATION_END, NEBFLAG_NONE, NEBATTR_NONE,
+      service_notification, type, start_time, end_time, (void*)this, cntct,
+      not_author.c_str(), not_data.c_str(), escalated, nullptr);
   return OK;
 }
 
@@ -3169,10 +3051,10 @@ bool service::is_result_fresh(time_t current_time, int log_this) {
 
   /* the results for the last check of this service are stale */
   if (expiration_time < current_time) {
-    get_time_breakdown(
-        (current_time - expiration_time), &days, &hours, &minutes, &seconds);
-    get_time_breakdown(
-        freshness_threshold, &tdays, &thours, &tminutes, &tseconds);
+    get_time_breakdown((current_time - expiration_time), &days, &hours,
+                       &minutes, &seconds);
+    get_time_breakdown(freshness_threshold, &tdays, &thours, &tminutes,
+                       &tseconds);
 
     /* log a warning */
     if (log_this)
@@ -3181,17 +3063,18 @@ bool service::is_result_fresh(time_t current_time, int log_this) {
           << "' on host '" << this->get_hostname() << "' are stale by " << days
           << "d " << hours << "h " << minutes << "m " << seconds
           << "s (threshold=" << tdays << "d " << thours << "h " << tminutes
-          << "m " << tseconds << "s).  I'm forcing an immediate check "
-                                 "of the service.";
+          << "m " << tseconds
+          << "s).  I'm forcing an immediate check "
+             "of the service.";
 
-    logger(dbg_checks, more) << "Check results for service '"
-                             << this->get_description() << "' on host '"
-                             << this->get_hostname() << "' are stale by "
-                             << days << "d " << hours << "h " << minutes << "m "
-                             << seconds << "s (threshold=" << tdays << "d "
-                             << thours << "h " << tminutes << "m " << tseconds
-                             << "s).  Forcing an immediate check of "
-                                "the service...";
+    logger(dbg_checks, more)
+        << "Check results for service '" << this->get_description()
+        << "' on host '" << this->get_hostname() << "' are stale by " << days
+        << "d " << hours << "h " << minutes << "m " << seconds
+        << "s (threshold=" << tdays << "d " << thours << "h " << tminutes
+        << "m " << tseconds
+        << "s).  Forcing an immediate check of "
+           "the service...";
 
     return false;
   }
@@ -3224,15 +3107,9 @@ void service::handle_flap_detection_disabled() {
         << ";DISABLED; Flap detection has been disabled";
 
     /* send data to event broker */
-    broker_flapping_data(NEBTYPE_FLAPPING_STOP,
-                         NEBFLAG_NONE,
-                         NEBATTR_FLAPPING_STOP_DISABLED,
-                         SERVICE_FLAPPING,
-                         this,
-                         get_percent_state_change(),
-                         0.0,
-                         0.0,
-                         nullptr);
+    broker_flapping_data(NEBTYPE_FLAPPING_STOP, NEBFLAG_NONE,
+                         NEBATTR_FLAPPING_STOP_DISABLED, SERVICE_FLAPPING, this,
+                         get_percent_state_change(), 0.0, 0.0, nullptr);
 
     /* send a notification */
     this->notify(reason_flappingdisabled, "", "", notification_option_none);
@@ -3268,15 +3145,14 @@ timeperiod* service::get_notification_timeperiod() const {
  *
  * @return true if it is authorized.
  */
-bool service::authorized_by_dependencies(dependency::types dependency_type)
-    const {
+bool service::authorized_by_dependencies(
+    dependency::types dependency_type) const {
   logger(dbg_functions, basic) << "service::authorized_by_dependencies()";
 
   auto p(servicedependency::servicedependencies.equal_range(
       {_hostname, _description}));
   for (servicedependency_mmap::const_iterator it{p.first}, end{p.second};
-       it != end;
-       ++it) {
+       it != end; ++it) {
     servicedependency* dep{it->second.get()};
     /* Only check dependencies of the desired type (notification or execution)
      */
@@ -3334,8 +3210,7 @@ void service::check_for_orphaned() {
   /* check all services... */
   for (service_map::iterator it(service::services.begin()),
        end(service::services.end());
-       it != end;
-       ++it) {
+       it != end; ++it) {
     /* skip services that are not currently executing */
     if (!it->second->get_is_executing())
       continue;
@@ -3394,8 +3269,7 @@ void service::check_result_freshness() {
   /* check all services... */
   for (service_map::iterator it(service::services.begin()),
        end(service::services.end());
-       it != end;
-       ++it) {
+       it != end; ++it) {
     /* skip services we shouldn't be checking for freshness */
     if (!it->second->get_check_freshness())
       continue;
@@ -3459,19 +3333,24 @@ bool service::is_in_downtime() const {
          _host_ptr->get_scheduled_downtime_depth() > 0;
 }
 
-void service::set_host_ptr(host* h) { _host_ptr = h; }
+void service::set_host_ptr(host* h) {
+  _host_ptr = h;
+}
 
-host const* service::get_host_ptr() const { return _host_ptr; }
+host const* service::get_host_ptr() const {
+  return _host_ptr;
+}
 
-host* service::get_host_ptr() { return _host_ptr; }
+host* service::get_host_ptr() {
+  return _host_ptr;
+}
 
 void service::resolve(int& w, int& e) {
   int warnings{0}, errors{0};
 
   try {
     notifier::resolve(warnings, errors);
-  }
-  catch (std::exception const& e) {
+  } catch (std::exception const& e) {
     logger(log_verification_error, basic)
         << "Error: Service description '" << _description << "' of host '"
         << _hostname << "' has problem in its notifier part: " << e.what();
@@ -3484,10 +3363,11 @@ void service::resolve(int& w, int& e) {
     /* we couldn't find an associated host! */
 
     if (it == host::hosts.end() || !it->second) {
-      logger(log_verification_error, basic) << "Error: Host '" << _hostname
-                                            << "' specified in service "
-                                               "'" << _description
-                                            << "' not defined anywhere!";
+      logger(log_verification_error, basic)
+          << "Error: Host '" << _hostname
+          << "' specified in service "
+             "'"
+          << _description << "' not defined anywhere!";
       errors++;
       set_host_ptr(nullptr);
     } else {
@@ -3501,14 +3381,8 @@ void service::resolve(int& w, int& e) {
 
       // Notify event broker.
       timeval tv(get_broker_timestamp(NULL));
-      broker_relation_data(NEBTYPE_PARENT_ADD,
-                           NEBFLAG_NONE,
-                           NEBATTR_NONE,
-                           get_host_ptr(),
-                           NULL,
-                           NULL,
-                           this,
-                           &tv);
+      broker_relation_data(NEBTYPE_PARENT_ADD, NEBFLAG_NONE, NEBATTR_NONE,
+                           get_host_ptr(), NULL, NULL, this, &tv);
     }
   }
 

--- a/src/service.cc
+++ b/src/service.cc
@@ -17,7 +17,6 @@
 ** <http://www.gnu.org/licenses/>.
 */
 
-#include <cassert>
 #include "com/centreon/engine/service.hh"
 
 #include <iomanip>
@@ -92,39 +91,23 @@ service::service(std::string const& hostname,
                  int freshness_threshold,
                  bool obsess_over,
                  std::string const& timezone)
-    : notifier{service_notification,
-               display_name,
-               check_command,
-               checks_enabled,
-               accept_passive_checks,
-               check_interval,
-               retry_interval,
-               notification_interval,
-               max_attempts,
-               0u,  // notify
-               0u,  // stalk
-               first_notification_delay,
-               recovery_notification_delay,
-               notification_period,
-               notifications_enabled,
-               check_period,
-               event_handler,
-               event_handler_enabled,
-               notes,
-               notes_url,
-               action_url,
-               icon_image,
-               icon_image_alt,
-               flap_detection_enabled,
-               low_flap_threshold,
-               high_flap_threshold,
-               check_freshness,
-               freshness_threshold,
-               obsess_over,
-               timezone,
-               0,
-               0,
-               is_volatile},
+    : notifier{service_notification,     display_name,
+               check_command,            checks_enabled,
+               accept_passive_checks,    check_interval,
+               retry_interval,           notification_interval,
+               max_attempts,             0u,  // notify
+               0u,                            // stalk
+               first_notification_delay, recovery_notification_delay,
+               notification_period,      notifications_enabled,
+               check_period,             event_handler,
+               event_handler_enabled,    notes,
+               notes_url,                action_url,
+               icon_image,               icon_image_alt,
+               flap_detection_enabled,   low_flap_threshold,
+               high_flap_threshold,      check_freshness,
+               freshness_threshold,      obsess_over,
+               timezone,                 0,
+               0,                        is_volatile},
       _host_id{0},
       _service_id{0},
       _hostname{hostname},
@@ -144,39 +127,25 @@ service::service(std::string const& hostname,
   set_current_attempt(initial_state == service::state_ok ? 1 : max_attempts);
 }
 
-time_t service::get_last_time_ok() const {
-  return _last_time_ok;
-}
+time_t service::get_last_time_ok() const { return _last_time_ok; }
 
-void service::set_last_time_ok(time_t last_time) {
-  assert(last_time < 2000000000);
-  _last_time_ok = last_time;
-}
+void service::set_last_time_ok(time_t last_time) { _last_time_ok = last_time; }
 
-time_t service::get_last_time_warning() const {
-  return _last_time_warning;
-}
+time_t service::get_last_time_warning() const { return _last_time_warning; }
 
 void service::set_last_time_warning(time_t last_time) {
-  assert(last_time < 2000000000);
   _last_time_warning = last_time;
 }
 
-time_t service::get_last_time_unknown() const {
-  return _last_time_unknown;
-}
+time_t service::get_last_time_unknown() const { return _last_time_unknown; }
 
 void service::set_last_time_unknown(time_t last_time) {
-  assert(last_time < 2000000000);
   _last_time_unknown = last_time;
 }
 
-time_t service::get_last_time_critical() const {
-  return _last_time_critical;
-}
+time_t service::get_last_time_critical() const { return _last_time_critical; }
 
 void service::set_last_time_critical(time_t last_time) {
-  assert(last_time < 2000000000);
   _last_time_critical = last_time;
 }
 
@@ -228,9 +197,7 @@ void service::set_check_flapping_recovery_notification(bool check) {
   _check_flapping_recovery_notification = check;
 }
 
-bool service::recovered() const {
-  return _current_state == service::state_ok;
-}
+bool service::recovered() const { return _current_state == service::state_ok; }
 
 int service::get_current_state_int() const {
   return static_cast<int>(_current_state);
@@ -246,7 +213,8 @@ int service::get_current_state_int() const {
  */
 std::ostream& operator<<(std::ostream& os, service_map_unsafe const& obj) {
   for (service_map_unsafe::const_iterator it(obj.begin()), end(obj.end());
-       it != end; ++it)
+       it != end;
+       ++it)
     os << "(" << it->first.first << ", " << it->first.second
        << (std::next(it) != obj.end() ? "), " : ")");
   return os;
@@ -300,7 +268,7 @@ std::ostream& operator<<(std::ostream& os,
   {
     std::ostringstream oss;
     for (int i = 0; i < 6; i++) {
-      std::shared_ptr<notification> s{obj.get_current_notifications()[i]};
+      notification* s{obj.get_current_notifications()[i].get()};
       if (s)
         oss << "  notification_" << i << ": " << *s;
     }
@@ -308,38 +276,27 @@ std::ostream& operator<<(std::ostream& os,
   }
 
   os << "service {\n"
-        "  host_name:                            "
-     << obj.get_hostname()
+        "  host_name:                            " << obj.get_hostname()
      << "\n"
-        "  description:                          "
-     << obj.get_description()
+        "  description:                          " << obj.get_description()
      << "\n"
-        "  display_name:                         "
-     << obj.get_display_name()
+        "  display_name:                         " << obj.get_display_name()
      << "\n"
-        "  service_check_command:                "
-     << obj.get_check_command()
+        "  service_check_command:                " << obj.get_check_command()
      << "\n"
-        "  event_handler:                        "
-     << obj.get_event_handler()
+        "  event_handler:                        " << obj.get_event_handler()
      << "\n"
-        "  initial_state:                        "
-     << obj.get_initial_state()
+        "  initial_state:                        " << obj.get_initial_state()
      << "\n"
-        "  check_interval:                       "
-     << obj.get_check_interval()
+        "  check_interval:                       " << obj.get_check_interval()
      << "\n"
-        "  retry_interval:                       "
-     << obj.get_retry_interval()
+        "  retry_interval:                       " << obj.get_retry_interval()
      << "\n"
-        "  max_attempts:                         "
-     << obj.get_max_attempts()
+        "  max_attempts:                         " << obj.get_max_attempts()
      << "\n"
-        "  contact_groups:                       "
-     << cg_oss
+        "  contact_groups:                       " << cg_oss
      << "\n"
-        "  contacts:                             "
-     << c_oss
+        "  contacts:                             " << c_oss
      << "\n"
         "  notification_interval:                "
      << obj.get_notification_interval()
@@ -386,12 +343,10 @@ std::ostream& operator<<(std::ostream& os,
         "  stalk_on_critical:                    "
      << obj.get_stalk_on(notifier::critical)
      << "\n"
-        "  is_volatile:                          "
-     << obj.get_is_volatile()
+        "  is_volatile:                          " << obj.get_is_volatile()
      << "\n"
         "  notification_period:                  "
-     << obj.get_notification_period() << "\n"
-     << notifications
+     << obj.get_notification_period() << "\n" << notifications
      << "  check_period:                         " << obj.get_check_period()
      << "\n"
         "  flap_detection_enabled:               "
@@ -418,8 +373,7 @@ std::ostream& operator<<(std::ostream& os,
         "  process_performance_data:             "
      << obj.get_process_performance_data()
      << "\n"
-        "  check_freshness:                      "
-     << obj.get_check_freshness()
+        "  check_freshness:                      " << obj.get_check_freshness()
      << "\n"
         "  freshness_threshold:                  "
      << obj.get_freshness_threshold()
@@ -490,8 +444,7 @@ std::ostream& operator<<(std::ostream& os,
      << string::ctime(obj.get_last_time_unknown())
      << "\n  last_time_critical:                   "
      << string::ctime(obj.get_last_time_critical())
-     << "\n  has_been_checked:                     "
-     << obj.has_been_checked()
+     << "\n  has_been_checked:                     " << obj.has_been_checked()
      << "\n  is_being_freshened:                   "
      << obj.get_is_being_freshened()
      << "\n  notified_on_unknown:                  "
@@ -680,22 +633,22 @@ com::centreon::engine::service* add_service(
     logger(log_config_error, basic) << "Error: Service description is not set";
     return nullptr;
   } else if (host_name.empty()) {
-    logger(log_config_error, basic)
-        << "Error: Host name of service '" << description << "' is not set";
+    logger(log_config_error, basic) << "Error: Host name of service '"
+                                    << description << "' is not set";
     return nullptr;
   } else if (check_command.empty()) {
-    logger(log_config_error, basic)
-        << "Error: Check command of service '" << description << "' on host '"
-        << host_name << "' is not set";
+    logger(log_config_error, basic) << "Error: Check command of service '"
+                                    << description << "' on host '" << host_name
+                                    << "' is not set";
     return nullptr;
   }
 
   uint64_t hid = get_host_id(host_name);
   if (!host_id) {
-    logger(log_config_error, basic)
-        << "Error: The service '" << description
-        << "' cannot be created because"
-        << " host '" << host_name << "' does not exist (host_id is null)";
+    logger(log_config_error, basic) << "Error: The service '" << description
+                                    << "' cannot be created because"
+                                    << " host '" << host_name
+                                    << "' does not exist (host_id is null)";
     return nullptr;
   } else if (host_id != hid) {
     logger(log_config_error, basic)
@@ -710,30 +663,52 @@ com::centreon::engine::service* add_service(
       notification_interval < 0) {
     logger(log_config_error, basic)
         << "Error: Invalid max_attempts, check_interval, retry_interval"
-           ", or notification_interval value for service '"
-        << description << "' on host '" << host_name << "'";
+           ", or notification_interval value for service '" << description
+        << "' on host '" << host_name << "'";
     return nullptr;
   }
   // Check if the service is already exist.
   std::pair<uint64_t, uint64_t> id(std::make_pair(host_id, service_id));
   if (is_service_exist(id)) {
-    logger(log_config_error, basic)
-        << "Error: Service '" << description << "' on host '" << host_name
-        << "' has already been defined";
+    logger(log_config_error, basic) << "Error: Service '" << description
+                                    << "' on host '" << host_name
+                                    << "' has already been defined";
     return nullptr;
   }
 
   // Allocate memory.
   std::shared_ptr<service> obj{std::make_shared<service>(
-      host_name, description, display_name.empty() ? description : display_name,
-      check_command, checks_enabled, accept_passive_checks, initial_state,
-      check_interval, retry_interval, notification_interval, max_attempts,
-      first_notification_delay, recovery_notification_delay,
-      notification_period, notifications_enabled, is_volatile, check_period,
-      event_handler, event_handler_enabled, notes, notes_url, action_url,
-      icon_image, icon_image_alt, flap_detection_enabled, low_flap_threshold,
-      high_flap_threshold, check_freshness, freshness_threshold,
-      obsess_over_service, timezone)};
+      host_name,
+      description,
+      display_name.empty() ? description : display_name,
+      check_command,
+      checks_enabled,
+      accept_passive_checks,
+      initial_state,
+      check_interval,
+      retry_interval,
+      notification_interval,
+      max_attempts,
+      first_notification_delay,
+      recovery_notification_delay,
+      notification_period,
+      notifications_enabled,
+      is_volatile,
+      check_period,
+      event_handler,
+      event_handler_enabled,
+      notes,
+      notes_url,
+      action_url,
+      icon_image,
+      icon_image_alt,
+      flap_detection_enabled,
+      low_flap_threshold,
+      high_flap_threshold,
+      check_freshness,
+      freshness_threshold,
+      obsess_over_service,
+      timezone)};
   try {
     obj->set_acknowledgement_type(ACKNOWLEDGEMENT_NONE);
     obj->set_check_options(CHECK_OPTION_NONE);
@@ -779,7 +754,8 @@ com::centreon::engine::service* add_service(
     // Add new items to the list.
     service::services[{obj->get_hostname(), obj->get_description()}] = obj;
     service::services_by_id[{host_id, service_id}] = obj;
-  } catch (...) {
+  }
+  catch (...) {
     obj.reset();
   }
 
@@ -795,10 +771,10 @@ void service::check_for_expired_acknowledgement() {
     if (get_acknowledgement_timeout() > 0) {
       time_t now(time(nullptr));
       if (get_last_acknowledgement() + get_acknowledgement_timeout() >= now) {
-        logger(log_info_message, basic)
-            << "Acknowledgement of service '" << get_description()
-            << "' on host '" << this->get_host_ptr()->get_name()
-            << "' just expired";
+        logger(log_info_message, basic) << "Acknowledgement of service '"
+                                        << get_description() << "' on host '"
+                                        << this->get_host_ptr()->get_name()
+                                        << "' just expired";
         set_problem_has_been_acknowledged(false);
         this->set_acknowledgement_type(ACKNOWLEDGEMENT_NONE);
         update_status();
@@ -851,8 +827,8 @@ std::pair<uint64_t, uint64_t> engine::get_host_and_service_id(
     std::string const& svc) {
   service_map::const_iterator found = service::services.find({host, svc});
   return found != service::services.end()
-             ? std::pair<uint64_t, uint64_t>{found->second->get_host_id(),
-                                             found->second->get_service_id()}
+      ? std::pair<uint64_t, uint64_t>{found->second->get_host_id(),
+                                      found->second->get_service_id()}
              : std::pair<uint64_t, uint64_t>{0u, 0u};
 }
 
@@ -878,53 +854,43 @@ void service::schedule_acknowledgement_expiration() {
       get_last_acknowledgement() != (time_t)0) {
     timed_event* evt = new timed_event(
         timed_event::EVENT_EXPIRE_SERVICE_ACK,
-        get_last_acknowledgement() + get_acknowledgement_timeout(), false, 0,
-        nullptr, true, this, nullptr, 0);
+        get_last_acknowledgement() + get_acknowledgement_timeout(),
+        false,
+        0,
+        nullptr,
+        true,
+        this,
+        nullptr,
+        0);
     events::loop::instance().schedule(evt, false);
   }
 }
 
-void service::set_host_id(uint64_t host_id) {
-  _host_id = host_id;
-}
+void service::set_host_id(uint64_t host_id) { _host_id = host_id; }
 
-uint64_t service::get_host_id() const {
-  return _host_id;
-}
+uint64_t service::get_host_id() const { return _host_id; }
 
-void service::set_service_id(uint64_t service_id) {
-  _service_id = service_id;
-}
+void service::set_service_id(uint64_t service_id) { _service_id = service_id; }
 
-uint64_t service::get_service_id() const {
-  return _service_id;
-}
+uint64_t service::get_service_id() const { return _service_id; }
 
-void service::set_hostname(std::string const& name) {
-  _hostname = name;
-}
+void service::set_hostname(std::string const& name) { _hostname = name; }
 
 /**
  * @brief Get the hostname of the host associated with this downtime.
  *
  * @return A string reference to the host name.
  */
-std::string const& service::get_hostname() const {
-  return _hostname;
-}
+std::string const& service::get_hostname() const { return _hostname; }
 
-void service::set_description(std::string const& desc) {
-  _description = desc;
-}
+void service::set_description(std::string const& desc) { _description = desc; }
 
 /**
  * @brief Get the description of the service.
  *
  * @return A string reference to the description.
  */
-std::string const& service::get_description() const {
-  return _description;
-}
+std::string const& service::get_description() const { return _description; }
 
 /**
  * @brief set the event handler arguments
@@ -999,9 +965,9 @@ int service::handle_async_check_result(check_result* queued_check_result) {
   if (execution_time < 0.0)
     execution_time = 0.0;
 
-  logger(dbg_checks, basic)
-      << "** Handling check result for service '" << _description
-      << "' on host '" << _hostname << "'...";
+  logger(dbg_checks, basic) << "** Handling check result for service '"
+                            << _description << "' on host '" << _hostname
+                            << "'...";
   logger(dbg_checks, more)
       << "HOST: " << _hostname << ", SERVICE: " << _description
       << ", CHECK TYPE: "
@@ -1101,9 +1067,10 @@ int service::handle_async_check_result(check_result* queued_check_result) {
    * shouldn't be happening)
    */
   if (!queued_check_result->get_exited_ok()) {
-    logger(log_runtime_warning, basic)
-        << "Warning:  Check of service '" << _description << "' on host '"
-        << _hostname << "' did not exit properly!";
+    logger(log_runtime_warning, basic) << "Warning:  Check of service '"
+                                       << _description << "' on host '"
+                                       << _hostname
+                                       << "' did not exit properly!";
 
     set_plugin_output("(Service check did not exit properly)");
     _current_state = service::state_unknown;
@@ -1129,8 +1096,7 @@ int service::handle_async_check_result(check_result* queued_check_result) {
                 ? " - plugin may not be executable"
                 : (queued_check_result->get_return_code() == 127
                        ? " - plugin may be missing"
-                       : ""))
-        << ')';
+                       : "")) << ')';
 
     set_plugin_output(oss.str());
     _current_state = service::state_unknown;
@@ -1145,8 +1111,8 @@ int service::handle_async_check_result(check_result* queued_check_result) {
     std::string plugin_output;
     std::string long_plugin_output;
     std::string perf_data;
-    parse_check_output(output, plugin_output, long_plugin_output, perf_data,
-                       true, false);
+    parse_check_output(
+        output, plugin_output, long_plugin_output, perf_data, true, false);
 
     set_long_plugin_output(long_plugin_output);
     set_perf_data(perf_data);
@@ -1169,8 +1135,7 @@ int service::handle_async_check_result(check_result* queued_check_result) {
         << (get_plugin_output().empty() ? "NULL" : get_plugin_output()) << "\n"
         << "Long Output:\n"
         << (get_long_plugin_output().empty() ? "NULL"
-                                             : get_long_plugin_output())
-        << "\n"
+                                             : get_long_plugin_output()) << "\n"
         << "Perf Data:\n"
         << (get_perf_data().empty() ? "NULL" : get_perf_data());
 
@@ -1207,9 +1172,10 @@ int service::handle_async_check_result(check_result* queued_check_result) {
    */
   if (get_check_type() == check_passive) {
     if (config->log_passive_checks())
-      logger(log_passive_check, basic)
-          << "PASSIVE SERVICE CHECK: " << _hostname << ";" << _description
-          << ";" << _current_state << ";" << get_plugin_output();
+      logger(log_passive_check, basic) << "PASSIVE SERVICE CHECK: " << _hostname
+                                       << ";" << _description << ";"
+                                       << _current_state << ";"
+                                       << get_plugin_output();
   }
 
   host* hst{get_host_ptr()};
@@ -1226,8 +1192,8 @@ int service::handle_async_check_result(check_result* queued_check_result) {
       /* set a flag to remember that we launched a check */
       first_host_check_initiated = true;
 
-      hst->run_async_check(CHECK_OPTION_NONE, 0.0, false, false, nullptr,
-                             nullptr);
+      hst->run_async_check(
+          CHECK_OPTION_NONE, 0.0, false, false, nullptr, nullptr);
     }
   }
 
@@ -1384,16 +1350,16 @@ int service::handle_async_check_result(check_result* queued_check_result) {
             hst->has_been_checked() &&
             (static_cast<unsigned long>(current_time - hst->get_last_check()) <=
              config->cached_host_check_horizon())) {
-          logger(dbg_checks, more)
-              << "* Using cached host state: " << hst->get_current_state();
+          logger(dbg_checks, more) << "* Using cached host state: "
+                                   << hst->get_current_state();
           update_check_stats(ACTIVE_ONDEMAND_HOST_CHECK_STATS, current_time);
           update_check_stats(ACTIVE_CACHED_HOST_CHECK_STATS, current_time);
         }
 
         /* else launch an async (parallel) check of the host */
         else
-          hst->run_async_check(CHECK_OPTION_NONE, 0.0, false, false, nullptr,
-                               nullptr);
+          hst->run_async_check(
+              CHECK_OPTION_NONE, 0.0, false, false, nullptr, nullptr);
       }
     }
 
@@ -1483,16 +1449,16 @@ int service::handle_async_check_result(check_result* queued_check_result) {
              "make sure...";
 
       /* previous logic was to simply run a sync (serial) host check */
-        /* can we use the last cached host state? */
-        /* only use cached host state if no service state change has occurred */
+      /* can we use the last cached host state? */
+      /* only use cached host state if no service state change has occurred */
       if ((!state_change || state_changes_use_cached_state) &&
           hst->has_been_checked() &&
           (static_cast<unsigned long>(current_time - hst->get_last_check()) <=
            config->cached_host_check_horizon())) {
         /* use current host state as route result */
         route_result = hst->get_current_state();
-        logger(dbg_checks, more)
-            << "* Using cached host state: " << hst->get_current_state();
+        logger(dbg_checks, more) << "* Using cached host state: "
+                                 << hst->get_current_state();
         update_check_stats(ACTIVE_ONDEMAND_HOST_CHECK_STATS, current_time);
         update_check_stats(ACTIVE_CACHED_HOST_CHECK_STATS, current_time);
       }
@@ -1503,16 +1469,16 @@ int service::handle_async_check_result(check_result* queued_check_result) {
       else if (state_change) {
         /* use current host state as route result */
         route_result = hst->get_current_state();
-        hst->run_async_check(CHECK_OPTION_NONE, 0.0, false, false, nullptr,
-                             nullptr);
+        hst->run_async_check(
+            CHECK_OPTION_NONE, 0.0, false, false, nullptr, nullptr);
       }
 
       /* ADDED 02/15/08 */
       /* else assume same host state */
       else {
         route_result = hst->get_current_state();
-        logger(dbg_checks, more)
-            << "* Using last known host state: " << hst->get_current_state();
+        logger(dbg_checks, more) << "* Using last known host state: "
+                                 << hst->get_current_state();
         update_check_stats(ACTIVE_ONDEMAND_HOST_CHECK_STATS, current_time);
         update_check_stats(ACTIVE_CACHED_HOST_CHECK_STATS, current_time);
       }
@@ -1525,15 +1491,15 @@ int service::handle_async_check_result(check_result* queued_check_result) {
 
       /* the service wobbled between non-OK states, so check the host... */
       if ((state_change && !state_changes_use_cached_state) &&
-               _last_hard_state != service::state_ok) {
+          _last_hard_state != service::state_ok) {
         logger(dbg_checks, more)
             << "Service wobbled between non-OK states, so we'll recheck"
                " the host state...";
         /* previous logic was to simply run a sync (serial) host check */
         /* use current host state as route result */
         route_result = hst->get_current_state();
-        hst->run_async_check(CHECK_OPTION_NONE, 0.0, false, false, nullptr,
-                             nullptr);
+        hst->run_async_check(
+            CHECK_OPTION_NONE, 0.0, false, false, nullptr, nullptr);
         /*perform_on_demand_host_check(hst,&route_result,CHECK_OPTION_NONE,true,config->cached_host_check_horizon());
          */
       }
@@ -1609,9 +1575,9 @@ int service::handle_async_check_result(check_result* queued_check_result) {
         set_current_attempt(1);
     }
 
-    logger(dbg_checks, more)
-        << "Current/Max Attempt(s): " << get_current_attempt() << '/'
-        << get_max_attempts();
+    logger(dbg_checks, more) << "Current/Max Attempt(s): "
+                             << get_current_attempt() << '/'
+                             << get_max_attempts();
 
     /* if we should retry the service check, do so (except it the host is down
      * or unreachable!) */
@@ -1674,16 +1640,18 @@ int service::handle_async_check_result(check_result* queued_check_result) {
         std::pair<std::string, std::string> id({_hostname, _description});
         auto p(servicedependency::servicedependencies.equal_range(id));
         for (servicedependency_mmap::const_iterator it{p.first}, end{p.second};
-             it != end; ++it) {
+             it != end;
+             ++it) {
           servicedependency* temp_dependency{it->second.get()};
 
           if (temp_dependency->dependent_service_ptr == this &&
               temp_dependency->master_service_ptr) {
             master_service = temp_dependency->master_service_ptr;
-            logger(dbg_checks, most)
-                << "Predictive check of service '"
-                << master_service->get_description() << "' on host '"
-                << master_service->get_hostname() << "' queued.";
+            logger(dbg_checks, most) << "Predictive check of service '"
+                                     << master_service->get_description()
+                                     << "' on host '"
+                                     << master_service->get_hostname()
+                                     << "' queued.";
             check_servicelist.push_back(master_service);
           }
         }
@@ -1774,8 +1742,8 @@ int service::handle_async_check_result(check_result* queued_check_result) {
     {
       timezone_locker lock(get_timezone());
       preferred_time = get_next_check();
-      get_next_valid_time(preferred_time, &next_valid_time,
-                          this->check_period_ptr);
+      get_next_valid_time(
+          preferred_time, &next_valid_time, this->check_period_ptr);
       set_next_check(next_valid_time);
     }
 
@@ -1813,16 +1781,23 @@ int service::handle_async_check_result(check_result* queued_check_result) {
   }
 
   /* send data to event broker */
-  broker_service_check(
-      NEBTYPE_SERVICECHECK_PROCESSED, NEBFLAG_NONE, NEBATTR_NONE, this,
-      get_check_type(), queued_check_result->get_start_time(),
-      queued_check_result->get_finish_time(), nullptr, get_latency(),
-      get_execution_time(), config->service_check_timeout(),
-      queued_check_result->get_early_timeout(),
-      queued_check_result->get_return_code(), nullptr, nullptr);
+  broker_service_check(NEBTYPE_SERVICECHECK_PROCESSED,
+                       NEBFLAG_NONE,
+                       NEBATTR_NONE,
+                       this,
+                       get_check_type(),
+                       queued_check_result->get_start_time(),
+                       queued_check_result->get_finish_time(),
+                       nullptr,
+                       get_latency(),
+                       get_execution_time(),
+                       config->service_check_timeout(),
+                       queued_check_result->get_early_timeout(),
+                       queued_check_result->get_return_code(),
+                       nullptr,
+                       nullptr);
 
-  if (!(reschedule_check && get_should_be_scheduled() &&
-        has_been_checked()) ||
+  if (!(reschedule_check && get_should_be_scheduled() && has_been_checked()) ||
       !get_checks_enabled()) {
     /* set the checked flag */
     set_has_been_checked(true);
@@ -1858,8 +1833,8 @@ int service::handle_async_check_result(check_result* queued_check_result) {
       run_async_check = false;
 
     if (run_async_check)
-      svc->run_async_check(CHECK_OPTION_NONE, 0.0, false, false, nullptr,
-                           nullptr);
+      svc->run_async_check(
+          CHECK_OPTION_NONE, 0.0, false, false, nullptr, nullptr);
   }
   return OK;
 }
@@ -1885,10 +1860,10 @@ int service::log_event() {
   }
   std::string const& state_type{tab_state_type[get_state_type()]};
 
-  logger(log_options, basic)
-      << "SERVICE ALERT: " << _hostname << ";" << _description << ";" << state
-      << ";" << state_type << ";" << get_current_attempt() << ";"
-      << get_plugin_output();
+  logger(log_options, basic) << "SERVICE ALERT: " << _hostname << ";"
+                             << _description << ";" << state << ";"
+                             << state_type << ";" << get_current_attempt()
+                             << ";" << get_plugin_output();
   return OK;
 }
 
@@ -1913,9 +1888,9 @@ void service::check_for_flapping(bool update,
 
   logger(dbg_functions, basic) << "check_for_flapping()";
 
-  logger(dbg_flapping, more)
-      << "Checking service '" << _description << "' on host '" << _hostname
-      << "' for flapping...";
+  logger(dbg_flapping, more) << "Checking service '" << _description
+                             << "' on host '" << _hostname
+                             << "' for flapping...";
 
   /* if this is a soft service state and not a soft recovery, don't record this
    * in the history */
@@ -1989,10 +1964,11 @@ void service::check_for_flapping(bool update,
 
   set_percent_state_change(curved_percent_change);
 
-  logger(dbg_flapping, most)
-      << com::centreon::logging::setprecision(2) << "LFT=" << low_threshold
-      << ", HFT=" << high_threshold << ", CPC=" << curved_percent_change
-      << ", PSC=" << curved_percent_change << "%";
+  logger(dbg_flapping, most) << com::centreon::logging::setprecision(2)
+                             << "LFT=" << low_threshold
+                             << ", HFT=" << high_threshold
+                             << ", CPC=" << curved_percent_change
+                             << ", PSC=" << curved_percent_change << "%";
 
   /* don't do anything if we don't have flap detection enabled on a program-wide
    * basis */
@@ -2017,14 +1993,16 @@ void service::check_for_flapping(bool update,
   else if (curved_percent_change >= high_threshold)
     is_flapping = true;
 
-  logger(dbg_flapping, more)
-      << com::centreon::logging::setprecision(2) << "Service "
-      << (is_flapping ? "is" : "is not") << " flapping ("
-      << curved_percent_change << "% state change).";
+  logger(dbg_flapping, more) << com::centreon::logging::setprecision(2)
+                             << "Service " << (is_flapping ? "is" : "is not")
+                             << " flapping (" << curved_percent_change
+                             << "% state change).";
 
   /* did the service just start flapping? */
   if (is_flapping && !get_is_flapping())
-    set_flap(curved_percent_change, high_threshold, low_threshold,
+    set_flap(curved_percent_change,
+             high_threshold,
+             low_threshold,
              allow_flapstart_notification);
 
   /* did the service just stop flapping? */
@@ -2039,10 +2017,16 @@ int service::handle_service_event() {
   logger(dbg_functions, basic) << "handle_service_event()";
 
   /* send event data to broker */
-  broker_statechange_data(NEBTYPE_STATECHANGE_END, NEBFLAG_NONE, NEBATTR_NONE,
-                          SERVICE_STATECHANGE, (void*)this, _current_state,
-                          get_state_type(), get_current_attempt(),
-                          get_max_attempts(), nullptr);
+  broker_statechange_data(NEBTYPE_STATECHANGE_END,
+                          NEBFLAG_NONE,
+                          NEBATTR_NONE,
+                          SERVICE_STATECHANGE,
+                          (void*)this,
+                          _current_state,
+                          get_state_type(),
+                          get_current_attempt(),
+                          get_max_attempts(),
+                          nullptr);
 
   /* bail out if we shouldn't be running event handlers */
   if (!config->enable_event_handlers())
@@ -2067,9 +2051,14 @@ int service::handle_service_event() {
   clear_volatile_macros_r(mac);
 
   /* send data to event broker */
-  broker_external_command(NEBTYPE_EXTERNALCOMMAND_CHECK, NEBFLAG_NONE,
-                          NEBATTR_NONE, CMD_NONE, time(nullptr), nullptr,
-                          nullptr, nullptr);
+  broker_external_command(NEBTYPE_EXTERNALCOMMAND_CHECK,
+                          NEBFLAG_NONE,
+                          NEBATTR_NONE,
+                          CMD_NONE,
+                          time(nullptr),
+                          nullptr,
+                          nullptr,
+                          nullptr);
 
   return OK;
 }
@@ -2106,16 +2095,18 @@ int service::obsessive_compulsive_service_check_processor() {
   grab_service_macros_r(mac, this);
 
   /* get the raw command line */
-  get_raw_command_line_r(mac, ocsp_command_ptr, config->ocsp_command().c_str(),
-                         raw_command, macro_options);
+  get_raw_command_line_r(mac,
+                         ocsp_command_ptr,
+                         config->ocsp_command().c_str(),
+                         raw_command,
+                         macro_options);
   if (raw_command.empty()) {
     clear_volatile_macros_r(mac);
     return ERROR;
   }
 
   logger(dbg_checks, most) << "Raw obsessive compulsive service processor "
-                              "command line: "
-                           << raw_command;
+                              "command line: " << raw_command;
 
   /* process any macros in the raw command line */
   process_macros_r(mac, raw_command, processed_command, macro_options);
@@ -2125,15 +2116,20 @@ int service::obsessive_compulsive_service_check_processor() {
   }
 
   logger(dbg_checks, most) << "Processed obsessive compulsive service "
-                              "processor command line: "
-                           << processed_command;
+                              "processor command line: " << processed_command;
 
   /* run the command */
   try {
     std::string tmp;
-    my_system_r(mac, processed_command, config->ocsp_timeout(), &early_timeout,
-                &exectime, tmp, 0);
-  } catch (std::exception const& e) {
+    my_system_r(mac,
+                processed_command,
+                config->ocsp_timeout(),
+                &early_timeout,
+                &exectime,
+                tmp,
+                0);
+  }
+  catch (std::exception const& e) {
     logger(log_runtime_error, basic)
         << "Error: can't execute compulsive service processor command line '"
         << processed_command << "' : " << e.what();
@@ -2143,10 +2139,11 @@ int service::obsessive_compulsive_service_check_processor() {
 
   /* check to see if the command timed out */
   if (early_timeout == true)
-    logger(log_runtime_warning, basic)
-        << "Warning: OCSP command '" << processed_command << "' for service '"
-        << _description << "' on host '" << _hostname << "' timed out after "
-        << config->ocsp_timeout() << " seconds";
+    logger(log_runtime_warning, basic) << "Warning: OCSP command '"
+                                       << processed_command << "' for service '"
+                                       << _description << "' on host '"
+                                       << _hostname << "' timed out after "
+                                       << config->ocsp_timeout() << " seconds";
 
   return OK;
 }
@@ -2175,14 +2172,14 @@ int service::run_scheduled_check(int check_options, double latency) {
   bool time_is_valid = true;
 
   logger(dbg_functions, basic) << "run_scheduled_service_check()";
-  logger(dbg_checks, basic)
-      << "Attempting to run scheduled check of service '" << _description
-      << "' on host '" << _hostname << "': check options=" << check_options
-      << ", latency=" << latency;
+  logger(dbg_checks, basic) << "Attempting to run scheduled check of service '"
+                            << _description << "' on host '" << _hostname
+                            << "': check options=" << check_options
+                            << ", latency=" << latency;
 
   /* attempt to run the check */
-  result = run_async_check(check_options, latency, true, true, &time_is_valid,
-                           &preferred_time);
+  result = run_async_check(
+      check_options, latency, true, true, &time_is_valid, &preferred_time);
 
   /* an error occurred, so reschedule the check */
   if (result == ERROR) {
@@ -2210,13 +2207,13 @@ int service::run_scheduled_check(int check_options, double latency) {
       // Make sure we rescheduled the next service check at a valid time.
       {
         timezone_locker lock(get_timezone());
-        get_next_valid_time(preferred_time, &next_valid_time,
-                            this->check_period_ptr);
+        get_next_valid_time(
+            preferred_time, &next_valid_time, this->check_period_ptr);
 
         // The service could not be rescheduled properly.
         // Set the next check time for next week.
         if (!time_is_valid && !check_time_against_period(
-                                  next_valid_time, this->check_period_ptr)) {
+                                   next_valid_time, this->check_period_ptr)) {
           set_next_check((time_t)(next_valid_time + 60 * 60 * 24 * 7));
           logger(log_runtime_warning, basic)
               << "Warning: Check of service '" << _description << "' on host '"
@@ -2264,10 +2261,10 @@ int service::run_async_check(int check_options,
                              bool reschedule_check,
                              bool* time_is_valid,
                              time_t* preferred_time) noexcept {
-  logger(dbg_functions, basic)
-      << "service::run_async_check, check_options=" << check_options
-      << ", latency=" << latency << ", scheduled_check=" << scheduled_check
-      << ", reschedule_check=" << reschedule_check;
+  logger(dbg_functions, basic) << "service::run_async_check, check_options="
+                               << check_options << ", latency=" << latency
+                               << ", scheduled_check=" << scheduled_check
+                               << ", reschedule_check=" << reschedule_check;
 
   // Preamble.
   if (!get_check_command_ptr()) {
@@ -2278,9 +2275,9 @@ int service::run_async_check(int check_options,
     return ERROR;
   }
 
-  logger(dbg_checks, basic)
-      << "** Running async check of service '" << get_description()
-      << "' on host '" << get_hostname() << "'...";
+  logger(dbg_checks, basic) << "** Running async check of service '"
+                            << get_description() << "' on host '"
+                            << get_hostname() << "'...";
 
   // Check if the service is viable now.
   if (!verify_check_viability(check_options, time_is_valid, preferred_time))
@@ -2289,11 +2286,21 @@ int service::run_async_check(int check_options,
   // Send broker event.
   timeval start_time = {0, 0};
   timeval end_time = {0, 0};
-  int res =
-      broker_service_check(NEBTYPE_SERVICECHECK_ASYNC_PRECHECK, NEBFLAG_NONE,
-                           NEBATTR_NONE, this, checkable::check_active,
-                           start_time, end_time, get_check_command().c_str(),
-                           get_latency(), 0.0, 0, false, 0, nullptr, nullptr);
+  int res = broker_service_check(NEBTYPE_SERVICECHECK_ASYNC_PRECHECK,
+                                 NEBFLAG_NONE,
+                                 NEBATTR_NONE,
+                                 this,
+                                 checkable::check_active,
+                                 start_time,
+                                 end_time,
+                                 get_check_command().c_str(),
+                                 get_latency(),
+                                 0.0,
+                                 0,
+                                 false,
+                                 0,
+                                 nullptr,
+                                 nullptr);
 
   // Service check was cancelled by NEB module. reschedule check later.
   if (NEBERROR_CALLBACKCANCEL == res) {
@@ -2330,16 +2337,16 @@ int service::run_async_check(int check_options,
   grab_host_macros_r(macros, get_host_ptr());
   grab_service_macros_r(macros, this);
   std::string tmp;
-  get_raw_command_line_r(macros, get_check_command_ptr(),
-                         get_check_command().c_str(), tmp, 0);
+  get_raw_command_line_r(
+      macros, get_check_command_ptr(), get_check_command().c_str(), tmp, 0);
 
   // Time to start command.
   gettimeofday(&start_time, nullptr);
 
   // Update the number of running service checks.
   ++currently_running_service_checks;
-  logger(dbg_checks, basic)
-      << "Current running service checks: " << currently_running_service_checks;
+  logger(dbg_checks, basic) << "Current running service checks: "
+                            << currently_running_service_checks;
 
   // Set the execution flag.
   set_is_executing(true);
@@ -2349,12 +2356,21 @@ int service::run_async_check(int check_options,
   std::string processed_cmd(cmd->process_cmd(macros));
 
   // Send event broker.
-  res =
-      broker_service_check(NEBTYPE_SERVICECHECK_INITIATE, NEBFLAG_NONE,
-                           NEBATTR_NONE, this, checkable::check_active,
-                           start_time, end_time, get_check_command().c_str(),
-                           get_latency(), 0.0, config->service_check_timeout(),
-                           false, 0, processed_cmd.c_str(), nullptr);
+  res = broker_service_check(NEBTYPE_SERVICECHECK_INITIATE,
+                             NEBFLAG_NONE,
+                             NEBATTR_NONE,
+                             this,
+                             checkable::check_active,
+                             start_time,
+                             end_time,
+                             get_check_command().c_str(),
+                             get_latency(),
+                             0.0,
+                             config->service_check_timeout(),
+                             false,
+                             0,
+                             processed_cmd.c_str(),
+                             nullptr);
 
   // Restore latency.
   set_latency(old_latency);
@@ -2374,10 +2390,18 @@ int service::run_async_check(int check_options,
   std::unique_ptr<check_result> check_result_info;
   do {
     // Init check result info.
-    check_result_info.reset(
-        new check_result(service_check, this, checkable::check_active,
-                         check_options, reschedule_check, latency, start_time,
-                         start_time, false, true, service::state_ok, ""));
+    check_result_info.reset(new check_result(service_check,
+                                             this,
+                                             checkable::check_active,
+                                             check_options,
+                                             reschedule_check,
+                                             latency,
+                                             start_time,
+                                             start_time,
+                                             false,
+                                             true,
+                                             service::state_ok,
+                                             ""));
 
     retry = false;
     try {
@@ -2387,9 +2411,11 @@ int service::run_async_check(int check_options,
       if (id != 0)
         checks::checker::instance().add_check_result(
             id, check_result_info.release());
-    } catch (com::centreon::exceptions::interruption const& e) {
+    }
+    catch (com::centreon::exceptions::interruption const& e) {
       retry = true;
-    } catch (std::exception const& e) {
+    }
+    catch (std::exception const& e) {
       // Update check result.
       timeval tv;
       gettimeofday(&tv, nullptr);
@@ -2425,11 +2451,13 @@ int service::run_async_check(int check_options,
 bool service::schedule_check(time_t check_time, int options) {
   logger(dbg_functions, basic) << "schedule_service_check()";
 
-  logger(dbg_checks, basic)
-      << "Scheduling a "
-      << (options & CHECK_OPTION_FORCE_EXECUTION ? "forced" : "non-forced")
-      << ", active check of service '" << _description << "' on host '"
-      << _hostname << "' @ " << my_ctime(&check_time);
+  logger(dbg_checks, basic) << "Scheduling a "
+                            << (options & CHECK_OPTION_FORCE_EXECUTION
+                                    ? "forced"
+                                    : "non-forced")
+                            << ", active check of service '" << _description
+                            << "' on host '" << _hostname << "' @ "
+                            << my_ctime(&check_time);
 
   // Don't schedule a check if active checks
   // of this service are disabled.
@@ -2510,12 +2538,19 @@ bool service::schedule_check(time_t check_time, int options) {
       set_next_check(check_time);
 
       // Place the new event in the event queue.
-      timed_event* new_event =
-          new timed_event(timed_event::EVENT_SERVICE_CHECK, get_next_check(),
-                          false, 0L, nullptr, true, this, nullptr, options);
+      timed_event* new_event = new timed_event(timed_event::EVENT_SERVICE_CHECK,
+                                               get_next_check(),
+                                               false,
+                                               0L,
+                                               nullptr,
+                                               true,
+                                               this,
+                                               nullptr,
+                                               options);
 
       events::loop::instance().reschedule_event(new_event, events::loop::low);
-    } catch (...) {
+    }
+    catch (...) {
       // Update the status log.
       update_status();
       throw;
@@ -2556,16 +2591,22 @@ void service::set_flap(double percent_change,
       << "Notifications for this service are being suppressed because "
          "it was detected as "
       << "having been flapping between different "
-         "states ("
-      << percent_change << "% change >= " << high_threshold
+         "states (" << percent_change << "% change >= " << high_threshold
       << "% threshold).  When the service state stabilizes and the "
          "flapping "
       << "stops, notifications will be re-enabled.";
 
-  std::shared_ptr<comment> com{
-      new comment(comment::service, comment::flapping, get_host_id(),
-                  _service_id, time(nullptr), "(Centreon Engine Process)",
-                  oss.str(), false, comment::internal, false, (time_t)0)};
+  std::shared_ptr<comment> com{new comment(comment::service,
+                                           comment::flapping,
+                                           get_host_id(),
+                                           _service_id,
+                                           time(nullptr),
+                                           "(Centreon Engine Process)",
+                                           oss.str(),
+                                           false,
+                                           comment::internal,
+                                           false,
+                                           (time_t)0)};
 
   comment::comments.insert({com->get_comment_id(), com});
 
@@ -2575,9 +2616,15 @@ void service::set_flap(double percent_change,
   set_is_flapping(true);
 
   /* send data to event broker */
-  broker_flapping_data(NEBTYPE_FLAPPING_START, NEBFLAG_NONE, NEBATTR_NONE,
-                       SERVICE_FLAPPING, this, percent_change, high_threshold,
-                       low_threshold, nullptr);
+  broker_flapping_data(NEBTYPE_FLAPPING_START,
+                       NEBFLAG_NONE,
+                       NEBATTR_NONE,
+                       SERVICE_FLAPPING,
+                       this,
+                       percent_change,
+                       high_threshold,
+                       low_threshold,
+                       nullptr);
 
   /* send a notification */
   if (allow_flapstart_notification)
@@ -2609,9 +2656,15 @@ void service::clear_flap(double percent_change,
   set_is_flapping(false);
 
   /* send data to event broker */
-  broker_flapping_data(NEBTYPE_FLAPPING_STOP, NEBFLAG_NONE,
-                       NEBATTR_FLAPPING_STOP_NORMAL, SERVICE_FLAPPING, this,
-                       percent_change, high_threshold, low_threshold, nullptr);
+  broker_flapping_data(NEBTYPE_FLAPPING_STOP,
+                       NEBFLAG_NONE,
+                       NEBATTR_FLAPPING_STOP_NORMAL,
+                       SERVICE_FLAPPING,
+                       this,
+                       percent_change,
+                       high_threshold,
+                       low_threshold,
+                       nullptr);
 
   /* send a notification */
   notify(reason_flappingstop, "", "", notification_option_none);
@@ -2626,9 +2679,9 @@ void service::enable_flap_detection() {
 
   logger(dbg_functions, basic) << "service::enable_flap_detection()";
 
-  logger(dbg_flapping, more)
-      << "Enabling flap detection for service '" << _description
-      << "' on host '" << _hostname << "'.";
+  logger(dbg_flapping, more) << "Enabling flap detection for service '"
+                             << _description << "' on host '" << _hostname
+                             << "'.";
 
   /* nothing to do... */
   if (get_flap_detection_enabled())
@@ -2641,9 +2694,14 @@ void service::enable_flap_detection() {
   set_flap_detection_enabled(true);
 
   /* send data to event broker */
-  broker_adaptive_service_data(NEBTYPE_ADAPTIVESERVICE_UPDATE, NEBFLAG_NONE,
-                               NEBATTR_NONE, this, CMD_NONE, attr,
-                               get_modified_attributes(), nullptr);
+  broker_adaptive_service_data(NEBTYPE_ADAPTIVESERVICE_UPDATE,
+                               NEBFLAG_NONE,
+                               NEBATTR_NONE,
+                               this,
+                               CMD_NONE,
+                               attr,
+                               get_modified_attributes(),
+                               nullptr);
 
   /* check for flapping */
   check_for_flapping(false, true);
@@ -2658,9 +2716,9 @@ void service::disable_flap_detection() {
 
   logger(dbg_functions, basic) << "disable_service_flap_detection()";
 
-  logger(dbg_flapping, more)
-      << "Disabling flap detection for service '" << _description
-      << "' on host '" << _hostname << "'.";
+  logger(dbg_flapping, more) << "Disabling flap detection for service '"
+                             << _description << "' on host '" << _hostname
+                             << "'.";
 
   /* nothing to do... */
   if (!get_flap_detection_enabled())
@@ -2673,9 +2731,14 @@ void service::disable_flap_detection() {
   set_flap_detection_enabled(false);
 
   /* send data to event broker */
-  broker_adaptive_service_data(NEBTYPE_ADAPTIVESERVICE_UPDATE, NEBFLAG_NONE,
-                               NEBATTR_NONE, this, CMD_NONE, attr,
-                               get_modified_attributes(), nullptr);
+  broker_adaptive_service_data(NEBTYPE_ADAPTIVESERVICE_UPDATE,
+                               NEBFLAG_NONE,
+                               NEBATTR_NONE,
+                               this,
+                               CMD_NONE,
+                               attr,
+                               get_modified_attributes(),
+                               nullptr);
 
   /* handle the details... */
   handle_flap_detection_disabled();
@@ -2685,8 +2748,8 @@ void service::disable_flap_detection() {
  * @brief Updates service status info. Send data to event broker.
  */
 void service::update_status() {
-  broker_service_status(NEBTYPE_SERVICESTATUS_UPDATE, NEBFLAG_NONE,
-                        NEBATTR_NONE, this, nullptr);
+  broker_service_status(
+      NEBTYPE_SERVICESTATUS_UPDATE, NEBFLAG_NONE, NEBATTR_NONE, this, nullptr);
 }
 
 /* checks viability of performing a service check */
@@ -2781,8 +2844,8 @@ int service::notify_contact(nagios_macros* mac,
   int neb_result;
 
   logger(dbg_functions, basic) << "notify_contact_of_service()";
-  logger(dbg_notifications, most)
-      << "** Notifying contact '" << cntct->get_name() << "'";
+  logger(dbg_notifications, most) << "** Notifying contact '"
+                                  << cntct->get_name() << "'";
 
   /* get start time */
   gettimeofday(&start_time, nullptr);
@@ -2790,10 +2853,20 @@ int service::notify_contact(nagios_macros* mac,
   /* send data to event broker */
   end_time.tv_sec = 0L;
   end_time.tv_usec = 0L;
-  neb_result = broker_contact_notification_data(
-      NEBTYPE_CONTACTNOTIFICATION_START, NEBFLAG_NONE, NEBATTR_NONE,
-      service_notification, type, start_time, end_time, (void*)this, cntct,
-      not_author.c_str(), not_data.c_str(), escalated, nullptr);
+  neb_result =
+      broker_contact_notification_data(NEBTYPE_CONTACTNOTIFICATION_START,
+                                       NEBFLAG_NONE,
+                                       NEBATTR_NONE,
+                                       service_notification,
+                                       type,
+                                       start_time,
+                                       end_time,
+                                       (void*)this,
+                                       cntct,
+                                       not_author.c_str(),
+                                       not_data.c_str(),
+                                       escalated,
+                                       nullptr);
   if (NEBERROR_CALLBACKCANCEL == neb_result)
     return ERROR;
   else if (NEBERROR_CALLBACKOVERRIDE == neb_result)
@@ -2809,23 +2882,36 @@ int service::notify_contact(nagios_macros* mac,
     method_end_time.tv_sec = 0L;
     method_end_time.tv_usec = 0L;
     neb_result = broker_contact_notification_method_data(
-        NEBTYPE_CONTACTNOTIFICATIONMETHOD_START, NEBFLAG_NONE, NEBATTR_NONE,
-        service_notification, type, method_start_time, method_end_time,
-        (void*)this, cntct, cmd->get_command_line().c_str(), not_author.c_str(),
-        not_data.c_str(), escalated, nullptr);
+        NEBTYPE_CONTACTNOTIFICATIONMETHOD_START,
+        NEBFLAG_NONE,
+        NEBATTR_NONE,
+        service_notification,
+        type,
+        method_start_time,
+        method_end_time,
+        (void*)this,
+        cntct,
+        cmd->get_command_line().c_str(),
+        not_author.c_str(),
+        not_data.c_str(),
+        escalated,
+        nullptr);
     if (NEBERROR_CALLBACKCANCEL == neb_result)
       break;
     else if (NEBERROR_CALLBACKOVERRIDE == neb_result)
       continue;
 
     /* get the raw command line */
-    get_raw_command_line_r(mac, cmd.get(), cmd->get_command_line().c_str(),
-                           raw_command, macro_options);
+    get_raw_command_line_r(mac,
+                           cmd.get(),
+                           cmd->get_command_line().c_str(),
+                           raw_command,
+                           macro_options);
     if (raw_command.empty())
       continue;
 
-    logger(dbg_notifications, most)
-        << "Raw notification command: " << raw_command;
+    logger(dbg_notifications, most) << "Raw notification command: "
+                                    << raw_command;
 
     /* process any macros contained in the argument */
     process_macros_r(mac, raw_command, processed_command, macro_options);
@@ -2834,8 +2920,8 @@ int service::notify_contact(nagios_macros* mac,
 
     /* run the notification command... */
 
-    logger(dbg_notifications, most)
-        << "Processed notification command: " << processed_command;
+    logger(dbg_notifications, most) << "Processed notification command: "
+                                    << processed_command;
 
     /* log the notification to program log file */
     if (config->log_notifications()) {
@@ -2872,9 +2958,15 @@ int service::notify_contact(nagios_macros* mac,
     /* run the notification command */
     try {
       std::string tmp;
-      my_system_r(mac, processed_command, config->notification_timeout(),
-                  &early_timeout, &exectime, tmp, 0);
-    } catch (std::exception const& e) {
+      my_system_r(mac,
+                  processed_command,
+                  config->notification_timeout(),
+                  &early_timeout,
+                  &exectime,
+                  tmp,
+                  0);
+    }
+    catch (std::exception const& e) {
       logger(log_runtime_error, basic)
           << "Error: can't execute service notification '" << cntct->get_name()
           << "' : " << e.what();
@@ -2894,10 +2986,20 @@ int service::notify_contact(nagios_macros* mac,
 
     /* send data to event broker */
     broker_contact_notification_method_data(
-        NEBTYPE_CONTACTNOTIFICATIONMETHOD_END, NEBFLAG_NONE, NEBATTR_NONE,
-        service_notification, type, method_start_time, method_end_time,
-        (void*)this, cntct, cmd->get_command_line().c_str(), not_author.c_str(),
-        not_data.c_str(), escalated, nullptr);
+        NEBTYPE_CONTACTNOTIFICATIONMETHOD_END,
+        NEBFLAG_NONE,
+        NEBATTR_NONE,
+        service_notification,
+        type,
+        method_start_time,
+        method_end_time,
+        (void*)this,
+        cntct,
+        cmd->get_command_line().c_str(),
+        not_author.c_str(),
+        not_data.c_str(),
+        escalated,
+        nullptr);
   }
 
   /* get end time */
@@ -2907,10 +3009,19 @@ int service::notify_contact(nagios_macros* mac,
   cntct->set_last_service_notification(start_time.tv_sec);
 
   /* send data to event broker */
-  broker_contact_notification_data(
-      NEBTYPE_CONTACTNOTIFICATION_END, NEBFLAG_NONE, NEBATTR_NONE,
-      service_notification, type, start_time, end_time, (void*)this, cntct,
-      not_author.c_str(), not_data.c_str(), escalated, nullptr);
+  broker_contact_notification_data(NEBTYPE_CONTACTNOTIFICATION_END,
+                                   NEBFLAG_NONE,
+                                   NEBATTR_NONE,
+                                   service_notification,
+                                   type,
+                                   start_time,
+                                   end_time,
+                                   (void*)this,
+                                   cntct,
+                                   not_author.c_str(),
+                                   not_data.c_str(),
+                                   escalated,
+                                   nullptr);
   return OK;
 }
 
@@ -3058,10 +3169,10 @@ bool service::is_result_fresh(time_t current_time, int log_this) {
 
   /* the results for the last check of this service are stale */
   if (expiration_time < current_time) {
-    get_time_breakdown((current_time - expiration_time), &days, &hours,
-                       &minutes, &seconds);
-    get_time_breakdown(freshness_threshold, &tdays, &thours, &tminutes,
-                       &tseconds);
+    get_time_breakdown(
+        (current_time - expiration_time), &days, &hours, &minutes, &seconds);
+    get_time_breakdown(
+        freshness_threshold, &tdays, &thours, &tminutes, &tseconds);
 
     /* log a warning */
     if (log_this)
@@ -3070,18 +3181,17 @@ bool service::is_result_fresh(time_t current_time, int log_this) {
           << "' on host '" << this->get_hostname() << "' are stale by " << days
           << "d " << hours << "h " << minutes << "m " << seconds
           << "s (threshold=" << tdays << "d " << thours << "h " << tminutes
-          << "m " << tseconds
-          << "s).  I'm forcing an immediate check "
-             "of the service.";
+          << "m " << tseconds << "s).  I'm forcing an immediate check "
+                                 "of the service.";
 
-    logger(dbg_checks, more)
-        << "Check results for service '" << this->get_description()
-        << "' on host '" << this->get_hostname() << "' are stale by " << days
-        << "d " << hours << "h " << minutes << "m " << seconds
-        << "s (threshold=" << tdays << "d " << thours << "h " << tminutes
-        << "m " << tseconds
-        << "s).  Forcing an immediate check of "
-           "the service...";
+    logger(dbg_checks, more) << "Check results for service '"
+                             << this->get_description() << "' on host '"
+                             << this->get_hostname() << "' are stale by "
+                             << days << "d " << hours << "h " << minutes << "m "
+                             << seconds << "s (threshold=" << tdays << "d "
+                             << thours << "h " << tminutes << "m " << tseconds
+                             << "s).  Forcing an immediate check of "
+                                "the service...";
 
     return false;
   }
@@ -3114,9 +3224,15 @@ void service::handle_flap_detection_disabled() {
         << ";DISABLED; Flap detection has been disabled";
 
     /* send data to event broker */
-    broker_flapping_data(NEBTYPE_FLAPPING_STOP, NEBFLAG_NONE,
-                         NEBATTR_FLAPPING_STOP_DISABLED, SERVICE_FLAPPING, this,
-                         get_percent_state_change(), 0.0, 0.0, nullptr);
+    broker_flapping_data(NEBTYPE_FLAPPING_STOP,
+                         NEBFLAG_NONE,
+                         NEBATTR_FLAPPING_STOP_DISABLED,
+                         SERVICE_FLAPPING,
+                         this,
+                         get_percent_state_change(),
+                         0.0,
+                         0.0,
+                         nullptr);
 
     /* send a notification */
     this->notify(reason_flappingdisabled, "", "", notification_option_none);
@@ -3152,14 +3268,15 @@ timeperiod* service::get_notification_timeperiod() const {
  *
  * @return true if it is authorized.
  */
-bool service::authorized_by_dependencies(
-    dependency::types dependency_type) const {
+bool service::authorized_by_dependencies(dependency::types dependency_type)
+    const {
   logger(dbg_functions, basic) << "service::authorized_by_dependencies()";
 
   auto p(servicedependency::servicedependencies.equal_range(
       {_hostname, _description}));
   for (servicedependency_mmap::const_iterator it{p.first}, end{p.second};
-       it != end; ++it) {
+       it != end;
+       ++it) {
     servicedependency* dep{it->second.get()};
     /* Only check dependencies of the desired type (notification or execution)
      */
@@ -3217,7 +3334,8 @@ void service::check_for_orphaned() {
   /* check all services... */
   for (service_map::iterator it(service::services.begin()),
        end(service::services.end());
-       it != end; ++it) {
+       it != end;
+       ++it) {
     /* skip services that are not currently executing */
     if (!it->second->get_is_executing())
       continue;
@@ -3276,7 +3394,8 @@ void service::check_result_freshness() {
   /* check all services... */
   for (service_map::iterator it(service::services.begin()),
        end(service::services.end());
-       it != end; ++it) {
+       it != end;
+       ++it) {
     /* skip services we shouldn't be checking for freshness */
     if (!it->second->get_check_freshness())
       continue;
@@ -3340,24 +3459,19 @@ bool service::is_in_downtime() const {
          _host_ptr->get_scheduled_downtime_depth() > 0;
 }
 
-void service::set_host_ptr(host* h) {
-  _host_ptr = h;
-}
+void service::set_host_ptr(host* h) { _host_ptr = h; }
 
-host const* service::get_host_ptr() const {
-  return _host_ptr;
-}
+host const* service::get_host_ptr() const { return _host_ptr; }
 
-host* service::get_host_ptr() {
-  return _host_ptr;
-}
+host* service::get_host_ptr() { return _host_ptr; }
 
 void service::resolve(int& w, int& e) {
   int warnings{0}, errors{0};
 
   try {
     notifier::resolve(warnings, errors);
-  } catch (std::exception const& e) {
+  }
+  catch (std::exception const& e) {
     logger(log_verification_error, basic)
         << "Error: Service description '" << _description << "' of host '"
         << _hostname << "' has problem in its notifier part: " << e.what();
@@ -3370,11 +3484,10 @@ void service::resolve(int& w, int& e) {
     /* we couldn't find an associated host! */
 
     if (it == host::hosts.end() || !it->second) {
-      logger(log_verification_error, basic)
-          << "Error: Host '" << _hostname
-          << "' specified in service "
-             "'"
-          << _description << "' not defined anywhere!";
+      logger(log_verification_error, basic) << "Error: Host '" << _hostname
+                                            << "' specified in service "
+                                               "'" << _description
+                                            << "' not defined anywhere!";
       errors++;
       set_host_ptr(nullptr);
     } else {
@@ -3388,8 +3501,14 @@ void service::resolve(int& w, int& e) {
 
       // Notify event broker.
       timeval tv(get_broker_timestamp(NULL));
-      broker_relation_data(NEBTYPE_PARENT_ADD, NEBFLAG_NONE, NEBATTR_NONE,
-                           get_host_ptr(), NULL, NULL, this, &tv);
+      broker_relation_data(NEBTYPE_PARENT_ADD,
+                           NEBFLAG_NONE,
+                           NEBATTR_NONE,
+                           get_host_ptr(),
+                           NULL,
+                           NULL,
+                           this,
+                           &tv);
     }
   }
 

--- a/src/timeperiod.cc
+++ b/src/timeperiod.cc
@@ -55,27 +55,19 @@ timeperiod::timeperiod(std::string const& name, std::string const& alias)
   // Check if the timeperiod already exist.
   timeperiod_map::const_iterator it{timeperiod::timeperiods.find(name)};
   if (it != timeperiod::timeperiods.end()) {
-    logger(log_config_error, basic)
-        << "Error: Timeperiod '" << name << "' has already been defined";
+    logger(log_config_error, basic) << "Error: Timeperiod '" << name
+                                    << "' has already been defined";
     throw engine_error() << "Could not register time period '" << name << "'";
   }
 }
 
-std::string const& timeperiod::timeperiod::get_name() const {
-  return _name;
-}
+std::string const& timeperiod::timeperiod::get_name() const { return _name; }
 
-void timeperiod::set_name(std::string const& name) {
-  _name = name;
-}
+void timeperiod::set_name(std::string const& name) { _name = name; }
 
-std::string const timeperiod::get_alias() const {
-  return _alias;
-}
+std::string const timeperiod::get_alias() const { return _alias; }
 
-void timeperiod::set_alias(std::string const& alias) {
-  _alias = alias;
-}
+void timeperiod::set_alias(std::string const& alias) { _alias = alias; }
 
 /**
  *  Equal operator.
@@ -88,8 +80,8 @@ void timeperiod::set_alias(std::string const& alias) {
 bool timeperiod::operator==(timeperiod const& obj) noexcept {
   if (_name == obj._name && _alias == obj._alias &&
       (_exclusions.size() == obj._exclusions.size() &&
-       std::equal(_exclusions.begin(), _exclusions.end(),
-                  obj._exclusions.begin()))) {
+       std::equal(
+           _exclusions.begin(), _exclusions.end(), obj._exclusions.begin()))) {
     for (uint32_t i{0}; i < exceptions.size(); ++i)
       if (exceptions[i] != obj.exceptions[i])
         return false;
@@ -135,7 +127,8 @@ std::ostream& operator<<(std::ostream& os, timeperiod const& obj) {
   for (uint32_t i = 0; i < obj.exceptions.size(); ++i)
     for (daterange_list::const_iterator it(obj.exceptions[i].begin()),
          end(obj.exceptions[i].end());
-         it != end; ++it)
+         it != end;
+         ++it)
       os << "  " << **it << "\n";
   os << "}\n";
   return os;
@@ -143,7 +136,8 @@ std::ostream& operator<<(std::ostream& os, timeperiod const& obj) {
 
 std::ostream& operator<<(std::ostream& os, timeperiodexclusion const& obj) {
   for (timeperiodexclusion::const_iterator it(obj.begin()), end(obj.end());
-       it != end; ++it)
+       it != end;
+       ++it)
     os << it->first << (std::next(it) != obj.end() ? ", " : "");
   return os;
 }
@@ -212,7 +206,7 @@ static time_t calculate_time_from_day_of_month(int year,
     // If we rolled over to the next month, time is invalid, assume the
     // user's intention is to keep it in the current month.
     if (t.tm_mon != month)
-      midnight = (time_t)-1;
+      midnight = (time_t) - 1;
   }
   // Negative offset (last day, 3rd to last day).
   else {
@@ -228,7 +222,7 @@ static time_t calculate_time_from_day_of_month(int year,
       t.tm_mday = day;
       t.tm_isdst = -1;
       midnight = mktime(&t);
-    } while ((midnight == (time_t)-1) || (t.tm_mon != month));
+    } while ((midnight == (time_t) - 1) || (t.tm_mon != month));
 
     // Now that we know the last day, back up more.
     t.tm_mon = month;
@@ -296,7 +290,7 @@ static time_t calculate_time_from_weekday_of_month(int year,
     // If we rolled over to the next month, time is invalid, assume the
     // user's intention is to keep it in the current month.
     if (t.tm_mon != month)
-      midnight = (time_t)-1;
+      midnight = (time_t) - 1;
   }
   // Negative offset (last thursday, 3rd to last tuesday).
   else {
@@ -312,7 +306,7 @@ static time_t calculate_time_from_weekday_of_month(int year,
       t.tm_mday = days + 1;
       t.tm_isdst = -1;
       midnight = mktime(&t);
-    } while ((midnight == (time_t)-1) || (t.tm_mon != month));
+    } while ((midnight == (time_t) - 1) || (t.tm_mon != month));
 
     // Now that we know the last instance of the weekday, back up more.
     days = ((weekday_offset + 1) * 7);
@@ -363,7 +357,7 @@ static bool _daterange_calendar_date_to_time_t(daterange const& r,
   t.tm_mday = r.get_smday();
   t.tm_mon = r.get_smon();
   t.tm_year = r.get_syear() - 1900;
-  if ((start = mktime(&t)) == (time_t)-1)
+  if ((start = mktime(&t)) == (time_t) - 1)
     return false;
 
   if (r.get_eyear()) {
@@ -374,11 +368,11 @@ static bool _daterange_calendar_date_to_time_t(daterange const& r,
     t.tm_mday = r.get_emday();
     t.tm_mon = r.get_emon();
     t.tm_year = r.get_eyear() - 1900;
-    if ((end = mktime(&t)) == (time_t)-1)
+    if ((end = mktime(&t)) == (time_t) - 1)
       return false;
     end = _add_round_days_to_midnight(end, 24 * 60 * 60);
   } else
-    end = (time_t)-1;
+    end = (time_t) - 1;
 
   return true;
 }
@@ -406,9 +400,9 @@ static bool _daterange_month_date_to_time_t(daterange const& r,
   bool found(false);
   for (int i(0); (i < 3) && !found; ++i, ++year) {
     start = calculate_time_from_day_of_month(year, r.get_smon(), r.get_smday());
-    end = calculate_time_from_day_of_month(year + (end_before_start ? 1 : 0),
-                                           r.get_emon(), r.get_emday());
-    if (end != (time_t)-1) {
+    end = calculate_time_from_day_of_month(
+        year + (end_before_start ? 1 : 0), r.get_emon(), r.get_emday());
+    if (end != (time_t) - 1) {
       end = _add_round_days_to_midnight(end, 24 * 60 * 60);
       if (ti.preferred_time < end)
         found = true;
@@ -454,11 +448,11 @@ static bool _daterange_month_day_to_time_t(daterange const& r,
 
   // No decay, current month only.
   if (!decay) {
-    start = calculate_time_from_day_of_month(ti.preftime.tm_year,
-                                             ti.preftime.tm_mon, r.get_smday());
-    end = calculate_time_from_day_of_month(ti.preftime.tm_year,
-                                           ti.preftime.tm_mon, r.get_emday());
-    if ((start == (time_t)-1) || (end == (time_t)-1))
+    start = calculate_time_from_day_of_month(
+        ti.preftime.tm_year, ti.preftime.tm_mon, r.get_smday());
+    end = calculate_time_from_day_of_month(
+        ti.preftime.tm_year, ti.preftime.tm_mon, r.get_emday());
+    if ((start == (time_t) - 1) || (end == (time_t) - 1))
       return false;
     end = _add_round_days_to_midnight(end, 24 * 60 * 60);
   }
@@ -473,9 +467,9 @@ static bool _daterange_month_day_to_time_t(daterange const& r,
     } else
       --month;
     start = calculate_time_from_day_of_month(year, month, r.get_smday());
-    end = calculate_time_from_day_of_month(ti.preftime.tm_year,
-                                           ti.preftime.tm_mon, r.get_emday());
-    if ((start == (time_t)-1) || (end == (time_t)-1))
+    end = calculate_time_from_day_of_month(
+        ti.preftime.tm_year, ti.preftime.tm_mon, r.get_emday());
+    if ((start == (time_t) - 1) || (end == (time_t) - 1))
       return false;
     end = _add_round_days_to_midnight(end, 24 * 60 * 60);
 
@@ -492,7 +486,7 @@ static bool _daterange_month_day_to_time_t(daterange const& r,
       start = calculate_time_from_day_of_month(
           ti.preftime.tm_year, ti.preftime.tm_mon, r.get_smday());
       end = calculate_time_from_day_of_month(year, month, r.get_emday());
-      if ((start == (time_t)-1) || (end == (time_t)-1))
+      if ((start == (time_t) - 1) || (end == (time_t) - 1))
         return false;
       end = _add_round_days_to_midnight(end, 24 * 60 * 60);
     }
@@ -524,7 +518,7 @@ static bool _daterange_month_week_day_to_time_t(daterange const& r,
         ti.preftime.tm_year, r.get_smon(), r.get_swday(), r.get_swday_offset());
     end = calculate_time_from_weekday_of_month(
         ti.preftime.tm_year, r.get_emon(), r.get_ewday(), r.get_ewday_offset());
-    if ((start == (time_t)-1) || (end == (time_t)-1))
+    if ((start == (time_t) - 1) || (end == (time_t) - 1))
       return false;
     end = _add_round_days_to_midnight(end, 24 * 60 * 60);
   }
@@ -533,11 +527,12 @@ static bool _daterange_month_week_day_to_time_t(daterange const& r,
   else {
     // Check previous year -> current year.
     start = calculate_time_from_weekday_of_month(ti.preftime.tm_year - 1,
-                                                 r.get_smon(), r.get_swday(),
+                                                 r.get_smon(),
+                                                 r.get_swday(),
                                                  r.get_swday_offset());
     end = calculate_time_from_weekday_of_month(
         ti.preftime.tm_year, r.get_emon(), r.get_ewday(), r.get_ewday_offset());
-    if ((start == (time_t)-1) || (end == (time_t)-1))
+    if ((start == (time_t) - 1) || (end == (time_t) - 1))
       return false;
     end = _add_round_days_to_midnight(end, 24 * 60 * 60);
 
@@ -545,12 +540,14 @@ static bool _daterange_month_week_day_to_time_t(daterange const& r,
     // current year -> next year.
     if (ti.preferred_time >= end) {
       start = calculate_time_from_weekday_of_month(ti.preftime.tm_year,
-                                                   r.get_smon(), r.get_swday(),
+                                                   r.get_smon(),
+                                                   r.get_swday(),
                                                    r.get_swday_offset());
       end = calculate_time_from_weekday_of_month(ti.preftime.tm_year + 1,
-                                                 r.get_emon(), r.get_ewday(),
+                                                 r.get_emon(),
+                                                 r.get_ewday(),
                                                  r.get_ewday_offset());
-      if ((start == (time_t)-1) || (end == (time_t)-1))
+      if ((start == (time_t) - 1) || (end == (time_t) - 1))
         return false;
       end = _add_round_days_to_midnight(end, 24 * 60 * 60);
     }
@@ -581,13 +578,13 @@ static bool _daterange_week_day_to_time_t(daterange const& r,
 
   while (true) {
     // Calculate time of specified weekday of month.
-    start = calculate_time_from_weekday_of_month(year, month, r.get_swday(),
-                                                 r.get_swday_offset());
+    start = calculate_time_from_weekday_of_month(
+        year, month, r.get_swday(), r.get_swday_offset());
 
     // Use same year and month as was calculated for start time above.
-    end = calculate_time_from_weekday_of_month(year, month, r.get_ewday(),
-                                               r.get_ewday_offset());
-    if (end == (time_t)-1) {
+    end = calculate_time_from_weekday_of_month(
+        year, month, r.get_ewday(), r.get_ewday_offset());
+    if (end == (time_t) - 1) {
       // End date can't be helped, so skip it.
       if (r.get_ewday_offset() < 0)
         return false;
@@ -608,7 +605,7 @@ static bool _daterange_week_day_to_time_t(daterange const& r,
       end = _add_round_days_to_midnight(end, 24 * 60 * 60);
 
     // Error checking.
-    if (((time_t)-1 == start) || ((time_t)-1 == end) || (start > end))
+    if (((time_t) - 1 == start) || ((time_t) - 1 == end) || (start > end))
       return false;
 
     // We should have an interval that includes or is above
@@ -701,7 +698,7 @@ static time_t _earliest_midnight_in_daterange(time_t preferred_time,
   // XXX : handle full day skipping directly (from preferred_time to next
   // midnight)
   while ((drange_start_time < drange_end_time) ||
-         (drange_end_time == (time_t)-1)) {
+         (drange_end_time == (time_t) - 1)) {
     // Next day at midnight.
     time_t next_day(
         _add_round_days_to_midnight(drange_start_time, 24 * 60 * 60));
@@ -718,7 +715,7 @@ static time_t _earliest_midnight_in_daterange(time_t preferred_time,
       drange_start_time = _add_round_days_to_midnight(
           drange_start_time, drange->get_skip_interval() * 24 * 60 * 60);
   }
-  return (time_t)-1;
+  return (time_t) - 1;
 }
 
 /**
@@ -765,7 +762,7 @@ bool check_time_against_period(time_t test_time, timeperiod* tperiod) {
     return true;
 
   // Faked next valid time must be tested time.
-  time_t next_valid_time{(time_t)-1};
+  time_t next_valid_time{(time_t) - 1};
   tperiod->get_next_valid_time_per_timeperiod(test_time, &next_valid_time);
   return next_valid_time == test_time;
 }
@@ -788,9 +785,9 @@ void timeperiod::get_next_invalid_time_per_timeperiod(time_t preferred_time,
   // Do not compute more than one year ahead (we might compute forever).
   time_t earliest_time(preferred_time);
   time_t in_one_year(preferred_time + 366 * 24 * 60 * 60);
-  while ((earliest_time != (time_t)-1) && (preferred_time < in_one_year)) {
+  while ((earliest_time != (time_t) - 1) && (preferred_time < in_one_year)) {
     preferred_time = earliest_time;
-    earliest_time = (time_t)-1;
+    earliest_time = (time_t) - 1;
 
     // Compute time information.
     time_info ti;
@@ -805,24 +802,30 @@ void timeperiod::get_next_invalid_time_per_timeperiod(time_t preferred_time,
     // XXX: handle range end reached.
     // Browse all date range.
     for (unsigned int daterange_type(0);
-         (daterange_type < DATERANGE_TYPES) && ((time_t)-1 == earliest_time);
+         (daterange_type < DATERANGE_TYPES) && ((time_t) - 1 == earliest_time);
          ++daterange_type) {
       for (daterange_list::iterator
                it(this->exceptions[daterange_type].begin()),
            end(this->exceptions[daterange_type].end());
-           it != end && ((time_t)-1 == earliest_time); ++it) {
+           it != end && ((time_t) - 1 == earliest_time);
+           ++it) {
         // Get range limits.
-        time_t daterange_start_time((time_t)-1);
-        time_t daterange_end_time((time_t)-1);
-        if (_daterange_to_time_t(it->get(), daterange_type, &ti,
-                                 daterange_start_time, daterange_end_time) &&
+        time_t daterange_start_time((time_t) - 1);
+        time_t daterange_end_time((time_t) - 1);
+        if (_daterange_to_time_t(it->get(),
+                                 daterange_type,
+                                 &ti,
+                                 daterange_start_time,
+                                 daterange_end_time) &&
             ((preferred_time < daterange_end_time) ||
-             ((time_t)-1 == daterange_end_time))) {
+             ((time_t) - 1 == daterange_end_time))) {
           // Check that date is within range.
-          time_t earliest_midnight(_earliest_midnight_in_daterange(
-              preferred_time, it->get(), daterange_start_time,
-              daterange_end_time));
-          if (earliest_midnight != (time_t)-1) {
+          time_t earliest_midnight(
+              _earliest_midnight_in_daterange(preferred_time,
+                                              it->get(),
+                                              daterange_start_time,
+                                              daterange_end_time));
+          if (earliest_midnight != (time_t) - 1) {
             // Midnight.
             struct tm midnight;
             localtime_r(&earliest_midnight, &midnight);
@@ -830,12 +833,13 @@ void timeperiod::get_next_invalid_time_per_timeperiod(time_t preferred_time,
             // Browse all time range of date range.
             for (timerange_list::iterator it_tr((*it)->times.begin()),
                  end_tr((*it)->times.end());
-                 it_tr != end_tr && ((time_t)-1 == earliest_time); ++it_tr) {
+                 it_tr != end_tr && ((time_t) - 1 == earliest_time);
+                 ++it_tr) {
               // Get range limits.
-              time_t range_start((time_t)-1);
-              time_t range_end((time_t)-1);
-              if (_timerange_to_time_t(it_tr->get(), &midnight, range_start,
-                                       range_end) &&
+              time_t range_start((time_t) - 1);
+              time_t range_end((time_t) - 1);
+              if (_timerange_to_time_t(
+                      it_tr->get(), &midnight, range_start, range_end) &&
                   (preferred_time >= range_start) &&
                   (preferred_time < range_end))
                 earliest_time = range_end;
@@ -851,7 +855,7 @@ void timeperiod::get_next_invalid_time_per_timeperiod(time_t preferred_time,
     ** ahead) because time ranges are recurring the same way every week.
     */
     for (int weekday(ti.preftime.tm_wday), days_into_the_future(0);
-         (days_into_the_future <= 7) && ((time_t)-1 == earliest_time);
+         (days_into_the_future <= 7) && ((time_t) - 1 == earliest_time);
          ++weekday, ++days_into_the_future) {
       if (weekday >= 7)
         weekday -= 7;
@@ -865,26 +869,28 @@ void timeperiod::get_next_invalid_time_per_timeperiod(time_t preferred_time,
       // Check all time ranges for this day of the week.
       for (timerange_list::iterator it(this->days[weekday].begin()),
            end(this->days[weekday].end());
-           it != end && ((time_t)-1 == earliest_time); ++it) {
+           it != end && ((time_t) - 1 == earliest_time);
+           ++it) {
         // Get range limits.
-        time_t range_start((time_t)-1);
-        time_t range_end((time_t)-1);
-        if (_timerange_to_time_t(it->get(), &day_midnight, range_start,
-                                 range_end) &&
+        time_t range_start((time_t) - 1);
+        time_t range_end((time_t) - 1);
+        if (_timerange_to_time_t(
+                it->get(), &day_midnight, range_start, range_end) &&
             (preferred_time >= range_start) && (preferred_time < range_end))
           earliest_time = range_end;
       }
     }
 
     // Find next exclusion time.
-    time_t next_exclusion((time_t)-1);
+    time_t next_exclusion((time_t) - 1);
     timeperiodexclusion tpe = std::move(this->get_exclusions());
     for (timeperiodexclusion::iterator it(tpe.begin()), end(tpe.end());
-         it != end; ++it) {
-      time_t valid((time_t)-1);
+         it != end;
+         ++it) {
+      time_t valid((time_t) - 1);
       it->second->get_next_valid_time_per_timeperiod(preferred_time, &valid);
-      if ((valid != (time_t)-1) &&
-          (((time_t)-1 == next_exclusion) || (valid < next_exclusion)))
+      if ((valid != (time_t) - 1) &&
+          (((time_t) - 1 == next_exclusion) || (valid < next_exclusion)))
         next_exclusion = valid;
     }
     _exclusions = std::move(tpe);
@@ -896,22 +902,23 @@ void timeperiod::get_next_invalid_time_per_timeperiod(time_t preferred_time,
     ** before.
     */
 
-    if ((next_exclusion != (time_t)-1) &&
+    if ((next_exclusion != (time_t) - 1) &&
         (next_exclusion <
          _add_round_days_to_midnight(ti.midnight, 24 * 60 * 60)) &&
-        (((time_t)-1 == earliest_time) || (next_exclusion <= earliest_time))) {
-      earliest_time = (time_t)-1;
+        (((time_t) - 1 == earliest_time) ||
+         (next_exclusion <= earliest_time))) {
+      earliest_time = (time_t) - 1;
       preferred_time = next_exclusion;
       break;  // We have our time, no need to search anymore.
     }
-    if (earliest_time != (time_t)-1) {
+    if (earliest_time != (time_t) - 1) {
       preferred_time = earliest_time;
-      earliest_time = (time_t)-1;
+      earliest_time = (time_t) - 1;
     }
   }
 
   // If we couldn't find a time period there must be none defined.
-  if (earliest_time != (time_t)-1)
+  if (earliest_time != (time_t) - 1)
     *invalid_time = original_preferred_time;
   // Else use the calculated time.
   else
@@ -928,7 +935,7 @@ void timeperiod::get_next_invalid_time_per_timeperiod(time_t preferred_time,
  */
 static time_t _get_next_valid_time_in_timeranges(time_t preferred_time,
                                                  timerange_list timeranges) {
-  time_t earliest_time((time_t)-1);
+  time_t earliest_time((time_t) - 1);
   struct tm midnight;
   localtime_r(&preferred_time, &midnight);
   midnight.tm_hour = 0;
@@ -936,13 +943,14 @@ static time_t _get_next_valid_time_in_timeranges(time_t preferred_time,
   midnight.tm_sec = 0;
   midnight.tm_isdst = -1;
   for (timerange_list::iterator it(timeranges.begin()), end(timeranges.end());
-       it != end; ++it) {
-    time_t range_start((time_t)-1);
-    time_t range_end((time_t)-1);
+       it != end;
+       ++it) {
+    time_t range_start((time_t) - 1);
+    time_t range_end((time_t) - 1);
     if (_timerange_to_time_t(it->get(), &midnight, range_start, range_end)) {
       // Time range is in the future.
       if (range_start >= preferred_time) {
-        if ((earliest_time == (time_t)-1) || (range_start < earliest_time))
+        if ((earliest_time == (time_t) - 1) || (range_start < earliest_time))
           earliest_time = range_start;
       }
       // Preferred time is within the range.
@@ -963,16 +971,12 @@ void timeperiod::get_next_valid_time_per_timeperiod(time_t preferred_time,
                                                     time_t* valid_time) {
   logger(dbg_functions, basic) << "get_next_valid_time_per_timeperiod()";
 
-  // If no time can be found, the original preferred time will be set
-  // in valid_time at the end of the loop.
-  time_t original_preferred_time(preferred_time);
-
   // Loop through the upcoming year a day at a time.
-  time_t earliest_time((time_t)-1);
+  time_t earliest_time((time_t) - 1);
   time_info ti;
   ti.preferred_time = preferred_time;
   for (time_t in_one_year(ti.preferred_time + 366 * 24 * 60 * 60);
-       (earliest_time == (time_t)-1) && (ti.preferred_time < in_one_year);) {
+       (earliest_time == (time_t) - 1) && (ti.preferred_time < in_one_year);) {
     // Compute time information.
     localtime_r(&ti.preferred_time, &ti.preftime);
     ti.preftime.tm_sec = 0;
@@ -984,22 +988,26 @@ void timeperiod::get_next_valid_time_per_timeperiod(time_t preferred_time,
     // Browse all date range types in precedence order.
     bool skip_this_day(false);
     for (size_t daterange_type{0};
-         daterange_type < DATERANGE_TYPES && earliest_time == (time_t)-1 &&
-         !skip_this_day;
+         daterange_type < DATERANGE_TYPES && earliest_time == (time_t) - 1 &&
+             !skip_this_day;
          ++daterange_type) {
       // Browse all date ranges of a given type. The earliest valid
       // time found in any date range will be valid.
       for (daterange_list::iterator it{exceptions[daterange_type].begin()},
            end{exceptions[daterange_type].end()};
-           it != end; ++it) {
+           it != end;
+           ++it) {
         // Get next range limits and check that we are within bounds.
-        time_t daterange_start_time((time_t)-1);
-        time_t daterange_end_time((time_t)-1);
-        if (_daterange_to_time_t(it->get(), daterange_type, &ti,
-                                 daterange_start_time, daterange_end_time) &&
-            ((daterange_start_time == (time_t)-1) ||
+        time_t daterange_start_time((time_t) - 1);
+        time_t daterange_end_time((time_t) - 1);
+        if (_daterange_to_time_t(it->get(),
+                                 daterange_type,
+                                 &ti,
+                                 daterange_start_time,
+                                 daterange_end_time) &&
+            ((daterange_start_time == (time_t) - 1) ||
              (daterange_start_time <= ti.midnight)) &&
-            ((daterange_end_time == (time_t)-1) ||
+            ((daterange_end_time == (time_t) - 1) ||
              (ti.midnight < daterange_end_time))) {
           // Only test today. An higher precedence exception might have
           // been skipped because it was not valid on the current day
@@ -1008,8 +1016,8 @@ void timeperiod::get_next_valid_time_per_timeperiod(time_t preferred_time,
               ti.preferred_time, (*it)->times));
 
           // Potential time found.
-          if (potential_time != (time_t)-1) {
-            if ((earliest_time == (time_t)-1) ||
+          if (potential_time != (time_t) - 1) {
+            if ((earliest_time == (time_t) - 1) ||
                 (potential_time < earliest_time))
               earliest_time = potential_time;
             skip_this_day = false;
@@ -1028,33 +1036,35 @@ void timeperiod::get_next_valid_time_per_timeperiod(time_t preferred_time,
     if (!skip_this_day) {
       // Try the weekly schedule only if no valid time was found in
       // exceptions for this day.
-      if (earliest_time == (time_t)-1) {
+      if (earliest_time == (time_t) - 1) {
         time_t potential_time(_get_next_valid_time_in_timeranges(
             ti.preferred_time, this->days[ti.preftime.tm_wday]));
-        if ((potential_time != (time_t)-1) &&
-            ((earliest_time == (time_t)-1) || (potential_time < earliest_time)))
+        if ((potential_time != (time_t) - 1) &&
+            ((earliest_time == (time_t) - 1) ||
+             (potential_time < earliest_time)))
           earliest_time = potential_time;
       }
     }
 
     // Check exclusions.
     bool skipped(false);
-    if (earliest_time != (time_t)-1) {
-      time_t max_invalid((time_t)-1);
+    if (earliest_time != (time_t) - 1) {
+      time_t max_invalid((time_t) - 1);
       timeperiodexclusion tpe = std::move(this->get_exclusions());
 
       for (timeperiodexclusion::iterator it(tpe.begin()), end(tpe.end());
-           it != end; ++it) {
-        time_t invalid((time_t)-1);
+           it != end;
+           ++it) {
+        time_t invalid((time_t) - 1);
         it->second->get_next_invalid_time_per_timeperiod(earliest_time,
                                                          &invalid);
-        if ((invalid != (time_t)-1) &&
-            (((time_t)-1 == max_invalid) || (invalid > max_invalid)))
+        if ((invalid != (time_t) - 1) &&
+            (((time_t) - 1 == max_invalid) || (invalid > max_invalid)))
           max_invalid = invalid;
       }
       _exclusions = std::move(tpe);
-      if ((max_invalid != (time_t)-1) && (max_invalid != earliest_time)) {
-        earliest_time = (time_t)-1;
+      if ((max_invalid != (time_t) - 1) && (max_invalid != earliest_time)) {
+        earliest_time = (time_t) - 1;
         ti.preferred_time = max_invalid;
         skipped = true;
       }
@@ -1121,7 +1131,8 @@ void timeperiod::resolve(int& w __attribute__((unused)), int& e) {
   // Check for valid timeperiod names in exclusion list.
   for (timeperiodexclusion::iterator it{_exclusions.begin()},
        end{_exclusions.end()};
-       it != end; ++it) {
+       it != end;
+       ++it) {
     timeperiod_map::const_iterator found{
         timeperiod::timeperiods.find(it->first)};
 
@@ -1148,6 +1159,4 @@ timeperiodexclusion const& timeperiod::get_exclusions() const {
   return _exclusions;
 }
 
-timeperiodexclusion& timeperiod::get_exclusions() {
-  return _exclusions;
-}
+timeperiodexclusion& timeperiod::get_exclusions() { return _exclusions; }

--- a/src/timeperiod.cc
+++ b/src/timeperiod.cc
@@ -55,19 +55,27 @@ timeperiod::timeperiod(std::string const& name, std::string const& alias)
   // Check if the timeperiod already exist.
   timeperiod_map::const_iterator it{timeperiod::timeperiods.find(name)};
   if (it != timeperiod::timeperiods.end()) {
-    logger(log_config_error, basic) << "Error: Timeperiod '" << name
-                                    << "' has already been defined";
+    logger(log_config_error, basic)
+        << "Error: Timeperiod '" << name << "' has already been defined";
     throw engine_error() << "Could not register time period '" << name << "'";
   }
 }
 
-std::string const& timeperiod::timeperiod::get_name() const { return _name; }
+std::string const& timeperiod::timeperiod::get_name() const {
+  return _name;
+}
 
-void timeperiod::set_name(std::string const& name) { _name = name; }
+void timeperiod::set_name(std::string const& name) {
+  _name = name;
+}
 
-std::string const timeperiod::get_alias() const { return _alias; }
+std::string const timeperiod::get_alias() const {
+  return _alias;
+}
 
-void timeperiod::set_alias(std::string const& alias) { _alias = alias; }
+void timeperiod::set_alias(std::string const& alias) {
+  _alias = alias;
+}
 
 /**
  *  Equal operator.
@@ -80,8 +88,8 @@ void timeperiod::set_alias(std::string const& alias) { _alias = alias; }
 bool timeperiod::operator==(timeperiod const& obj) noexcept {
   if (_name == obj._name && _alias == obj._alias &&
       (_exclusions.size() == obj._exclusions.size() &&
-       std::equal(
-           _exclusions.begin(), _exclusions.end(), obj._exclusions.begin()))) {
+       std::equal(_exclusions.begin(), _exclusions.end(),
+                  obj._exclusions.begin()))) {
     for (uint32_t i{0}; i < exceptions.size(); ++i)
       if (exceptions[i] != obj.exceptions[i])
         return false;
@@ -127,8 +135,7 @@ std::ostream& operator<<(std::ostream& os, timeperiod const& obj) {
   for (uint32_t i = 0; i < obj.exceptions.size(); ++i)
     for (daterange_list::const_iterator it(obj.exceptions[i].begin()),
          end(obj.exceptions[i].end());
-         it != end;
-         ++it)
+         it != end; ++it)
       os << "  " << **it << "\n";
   os << "}\n";
   return os;
@@ -136,8 +143,7 @@ std::ostream& operator<<(std::ostream& os, timeperiod const& obj) {
 
 std::ostream& operator<<(std::ostream& os, timeperiodexclusion const& obj) {
   for (timeperiodexclusion::const_iterator it(obj.begin()), end(obj.end());
-       it != end;
-       ++it)
+       it != end; ++it)
     os << it->first << (std::next(it) != obj.end() ? ", " : "");
   return os;
 }
@@ -206,7 +212,7 @@ static time_t calculate_time_from_day_of_month(int year,
     // If we rolled over to the next month, time is invalid, assume the
     // user's intention is to keep it in the current month.
     if (t.tm_mon != month)
-      midnight = (time_t) - 1;
+      midnight = (time_t)-1;
   }
   // Negative offset (last day, 3rd to last day).
   else {
@@ -222,7 +228,7 @@ static time_t calculate_time_from_day_of_month(int year,
       t.tm_mday = day;
       t.tm_isdst = -1;
       midnight = mktime(&t);
-    } while ((midnight == (time_t) - 1) || (t.tm_mon != month));
+    } while ((midnight == (time_t)-1) || (t.tm_mon != month));
 
     // Now that we know the last day, back up more.
     t.tm_mon = month;
@@ -290,7 +296,7 @@ static time_t calculate_time_from_weekday_of_month(int year,
     // If we rolled over to the next month, time is invalid, assume the
     // user's intention is to keep it in the current month.
     if (t.tm_mon != month)
-      midnight = (time_t) - 1;
+      midnight = (time_t)-1;
   }
   // Negative offset (last thursday, 3rd to last tuesday).
   else {
@@ -306,7 +312,7 @@ static time_t calculate_time_from_weekday_of_month(int year,
       t.tm_mday = days + 1;
       t.tm_isdst = -1;
       midnight = mktime(&t);
-    } while ((midnight == (time_t) - 1) || (t.tm_mon != month));
+    } while ((midnight == (time_t)-1) || (t.tm_mon != month));
 
     // Now that we know the last instance of the weekday, back up more.
     days = ((weekday_offset + 1) * 7);
@@ -357,7 +363,7 @@ static bool _daterange_calendar_date_to_time_t(daterange const& r,
   t.tm_mday = r.get_smday();
   t.tm_mon = r.get_smon();
   t.tm_year = r.get_syear() - 1900;
-  if ((start = mktime(&t)) == (time_t) - 1)
+  if ((start = mktime(&t)) == (time_t)-1)
     return false;
 
   if (r.get_eyear()) {
@@ -368,11 +374,11 @@ static bool _daterange_calendar_date_to_time_t(daterange const& r,
     t.tm_mday = r.get_emday();
     t.tm_mon = r.get_emon();
     t.tm_year = r.get_eyear() - 1900;
-    if ((end = mktime(&t)) == (time_t) - 1)
+    if ((end = mktime(&t)) == (time_t)-1)
       return false;
     end = _add_round_days_to_midnight(end, 24 * 60 * 60);
   } else
-    end = (time_t) - 1;
+    end = (time_t)-1;
 
   return true;
 }
@@ -400,9 +406,9 @@ static bool _daterange_month_date_to_time_t(daterange const& r,
   bool found(false);
   for (int i(0); (i < 3) && !found; ++i, ++year) {
     start = calculate_time_from_day_of_month(year, r.get_smon(), r.get_smday());
-    end = calculate_time_from_day_of_month(
-        year + (end_before_start ? 1 : 0), r.get_emon(), r.get_emday());
-    if (end != (time_t) - 1) {
+    end = calculate_time_from_day_of_month(year + (end_before_start ? 1 : 0),
+                                           r.get_emon(), r.get_emday());
+    if (end != (time_t)-1) {
       end = _add_round_days_to_midnight(end, 24 * 60 * 60);
       if (ti.preferred_time < end)
         found = true;
@@ -448,11 +454,11 @@ static bool _daterange_month_day_to_time_t(daterange const& r,
 
   // No decay, current month only.
   if (!decay) {
-    start = calculate_time_from_day_of_month(
-        ti.preftime.tm_year, ti.preftime.tm_mon, r.get_smday());
-    end = calculate_time_from_day_of_month(
-        ti.preftime.tm_year, ti.preftime.tm_mon, r.get_emday());
-    if ((start == (time_t) - 1) || (end == (time_t) - 1))
+    start = calculate_time_from_day_of_month(ti.preftime.tm_year,
+                                             ti.preftime.tm_mon, r.get_smday());
+    end = calculate_time_from_day_of_month(ti.preftime.tm_year,
+                                           ti.preftime.tm_mon, r.get_emday());
+    if ((start == (time_t)-1) || (end == (time_t)-1))
       return false;
     end = _add_round_days_to_midnight(end, 24 * 60 * 60);
   }
@@ -467,9 +473,9 @@ static bool _daterange_month_day_to_time_t(daterange const& r,
     } else
       --month;
     start = calculate_time_from_day_of_month(year, month, r.get_smday());
-    end = calculate_time_from_day_of_month(
-        ti.preftime.tm_year, ti.preftime.tm_mon, r.get_emday());
-    if ((start == (time_t) - 1) || (end == (time_t) - 1))
+    end = calculate_time_from_day_of_month(ti.preftime.tm_year,
+                                           ti.preftime.tm_mon, r.get_emday());
+    if ((start == (time_t)-1) || (end == (time_t)-1))
       return false;
     end = _add_round_days_to_midnight(end, 24 * 60 * 60);
 
@@ -486,7 +492,7 @@ static bool _daterange_month_day_to_time_t(daterange const& r,
       start = calculate_time_from_day_of_month(
           ti.preftime.tm_year, ti.preftime.tm_mon, r.get_smday());
       end = calculate_time_from_day_of_month(year, month, r.get_emday());
-      if ((start == (time_t) - 1) || (end == (time_t) - 1))
+      if ((start == (time_t)-1) || (end == (time_t)-1))
         return false;
       end = _add_round_days_to_midnight(end, 24 * 60 * 60);
     }
@@ -518,7 +524,7 @@ static bool _daterange_month_week_day_to_time_t(daterange const& r,
         ti.preftime.tm_year, r.get_smon(), r.get_swday(), r.get_swday_offset());
     end = calculate_time_from_weekday_of_month(
         ti.preftime.tm_year, r.get_emon(), r.get_ewday(), r.get_ewday_offset());
-    if ((start == (time_t) - 1) || (end == (time_t) - 1))
+    if ((start == (time_t)-1) || (end == (time_t)-1))
       return false;
     end = _add_round_days_to_midnight(end, 24 * 60 * 60);
   }
@@ -527,12 +533,11 @@ static bool _daterange_month_week_day_to_time_t(daterange const& r,
   else {
     // Check previous year -> current year.
     start = calculate_time_from_weekday_of_month(ti.preftime.tm_year - 1,
-                                                 r.get_smon(),
-                                                 r.get_swday(),
+                                                 r.get_smon(), r.get_swday(),
                                                  r.get_swday_offset());
     end = calculate_time_from_weekday_of_month(
         ti.preftime.tm_year, r.get_emon(), r.get_ewday(), r.get_ewday_offset());
-    if ((start == (time_t) - 1) || (end == (time_t) - 1))
+    if ((start == (time_t)-1) || (end == (time_t)-1))
       return false;
     end = _add_round_days_to_midnight(end, 24 * 60 * 60);
 
@@ -540,14 +545,12 @@ static bool _daterange_month_week_day_to_time_t(daterange const& r,
     // current year -> next year.
     if (ti.preferred_time >= end) {
       start = calculate_time_from_weekday_of_month(ti.preftime.tm_year,
-                                                   r.get_smon(),
-                                                   r.get_swday(),
+                                                   r.get_smon(), r.get_swday(),
                                                    r.get_swday_offset());
       end = calculate_time_from_weekday_of_month(ti.preftime.tm_year + 1,
-                                                 r.get_emon(),
-                                                 r.get_ewday(),
+                                                 r.get_emon(), r.get_ewday(),
                                                  r.get_ewday_offset());
-      if ((start == (time_t) - 1) || (end == (time_t) - 1))
+      if ((start == (time_t)-1) || (end == (time_t)-1))
         return false;
       end = _add_round_days_to_midnight(end, 24 * 60 * 60);
     }
@@ -578,13 +581,13 @@ static bool _daterange_week_day_to_time_t(daterange const& r,
 
   while (true) {
     // Calculate time of specified weekday of month.
-    start = calculate_time_from_weekday_of_month(
-        year, month, r.get_swday(), r.get_swday_offset());
+    start = calculate_time_from_weekday_of_month(year, month, r.get_swday(),
+                                                 r.get_swday_offset());
 
     // Use same year and month as was calculated for start time above.
-    end = calculate_time_from_weekday_of_month(
-        year, month, r.get_ewday(), r.get_ewday_offset());
-    if (end == (time_t) - 1) {
+    end = calculate_time_from_weekday_of_month(year, month, r.get_ewday(),
+                                               r.get_ewday_offset());
+    if (end == (time_t)-1) {
       // End date can't be helped, so skip it.
       if (r.get_ewday_offset() < 0)
         return false;
@@ -605,7 +608,7 @@ static bool _daterange_week_day_to_time_t(daterange const& r,
       end = _add_round_days_to_midnight(end, 24 * 60 * 60);
 
     // Error checking.
-    if (((time_t) - 1 == start) || ((time_t) - 1 == end) || (start > end))
+    if (((time_t)-1 == start) || ((time_t)-1 == end) || (start > end))
       return false;
 
     // We should have an interval that includes or is above
@@ -698,7 +701,7 @@ static time_t _earliest_midnight_in_daterange(time_t preferred_time,
   // XXX : handle full day skipping directly (from preferred_time to next
   // midnight)
   while ((drange_start_time < drange_end_time) ||
-         (drange_end_time == (time_t) - 1)) {
+         (drange_end_time == (time_t)-1)) {
     // Next day at midnight.
     time_t next_day(
         _add_round_days_to_midnight(drange_start_time, 24 * 60 * 60));
@@ -715,7 +718,7 @@ static time_t _earliest_midnight_in_daterange(time_t preferred_time,
       drange_start_time = _add_round_days_to_midnight(
           drange_start_time, drange->get_skip_interval() * 24 * 60 * 60);
   }
-  return (time_t) - 1;
+  return (time_t)-1;
 }
 
 /**
@@ -762,7 +765,7 @@ bool check_time_against_period(time_t test_time, timeperiod* tperiod) {
     return true;
 
   // Faked next valid time must be tested time.
-  time_t next_valid_time{(time_t) - 1};
+  time_t next_valid_time{(time_t)-1};
   tperiod->get_next_valid_time_per_timeperiod(test_time, &next_valid_time);
   return next_valid_time == test_time;
 }
@@ -785,9 +788,9 @@ void timeperiod::get_next_invalid_time_per_timeperiod(time_t preferred_time,
   // Do not compute more than one year ahead (we might compute forever).
   time_t earliest_time(preferred_time);
   time_t in_one_year(preferred_time + 366 * 24 * 60 * 60);
-  while ((earliest_time != (time_t) - 1) && (preferred_time < in_one_year)) {
+  while ((earliest_time != (time_t)-1) && (preferred_time < in_one_year)) {
     preferred_time = earliest_time;
-    earliest_time = (time_t) - 1;
+    earliest_time = (time_t)-1;
 
     // Compute time information.
     time_info ti;
@@ -802,30 +805,24 @@ void timeperiod::get_next_invalid_time_per_timeperiod(time_t preferred_time,
     // XXX: handle range end reached.
     // Browse all date range.
     for (unsigned int daterange_type(0);
-         (daterange_type < DATERANGE_TYPES) && ((time_t) - 1 == earliest_time);
+         (daterange_type < DATERANGE_TYPES) && ((time_t)-1 == earliest_time);
          ++daterange_type) {
       for (daterange_list::iterator
                it(this->exceptions[daterange_type].begin()),
            end(this->exceptions[daterange_type].end());
-           it != end && ((time_t) - 1 == earliest_time);
-           ++it) {
+           it != end && ((time_t)-1 == earliest_time); ++it) {
         // Get range limits.
-        time_t daterange_start_time((time_t) - 1);
-        time_t daterange_end_time((time_t) - 1);
-        if (_daterange_to_time_t(it->get(),
-                                 daterange_type,
-                                 &ti,
-                                 daterange_start_time,
-                                 daterange_end_time) &&
+        time_t daterange_start_time((time_t)-1);
+        time_t daterange_end_time((time_t)-1);
+        if (_daterange_to_time_t(it->get(), daterange_type, &ti,
+                                 daterange_start_time, daterange_end_time) &&
             ((preferred_time < daterange_end_time) ||
-             ((time_t) - 1 == daterange_end_time))) {
+             ((time_t)-1 == daterange_end_time))) {
           // Check that date is within range.
-          time_t earliest_midnight(
-              _earliest_midnight_in_daterange(preferred_time,
-                                              it->get(),
-                                              daterange_start_time,
-                                              daterange_end_time));
-          if (earliest_midnight != (time_t) - 1) {
+          time_t earliest_midnight(_earliest_midnight_in_daterange(
+              preferred_time, it->get(), daterange_start_time,
+              daterange_end_time));
+          if (earliest_midnight != (time_t)-1) {
             // Midnight.
             struct tm midnight;
             localtime_r(&earliest_midnight, &midnight);
@@ -833,13 +830,12 @@ void timeperiod::get_next_invalid_time_per_timeperiod(time_t preferred_time,
             // Browse all time range of date range.
             for (timerange_list::iterator it_tr((*it)->times.begin()),
                  end_tr((*it)->times.end());
-                 it_tr != end_tr && ((time_t) - 1 == earliest_time);
-                 ++it_tr) {
+                 it_tr != end_tr && ((time_t)-1 == earliest_time); ++it_tr) {
               // Get range limits.
-              time_t range_start((time_t) - 1);
-              time_t range_end((time_t) - 1);
-              if (_timerange_to_time_t(
-                      it_tr->get(), &midnight, range_start, range_end) &&
+              time_t range_start((time_t)-1);
+              time_t range_end((time_t)-1);
+              if (_timerange_to_time_t(it_tr->get(), &midnight, range_start,
+                                       range_end) &&
                   (preferred_time >= range_start) &&
                   (preferred_time < range_end))
                 earliest_time = range_end;
@@ -855,7 +851,7 @@ void timeperiod::get_next_invalid_time_per_timeperiod(time_t preferred_time,
     ** ahead) because time ranges are recurring the same way every week.
     */
     for (int weekday(ti.preftime.tm_wday), days_into_the_future(0);
-         (days_into_the_future <= 7) && ((time_t) - 1 == earliest_time);
+         (days_into_the_future <= 7) && ((time_t)-1 == earliest_time);
          ++weekday, ++days_into_the_future) {
       if (weekday >= 7)
         weekday -= 7;
@@ -869,28 +865,26 @@ void timeperiod::get_next_invalid_time_per_timeperiod(time_t preferred_time,
       // Check all time ranges for this day of the week.
       for (timerange_list::iterator it(this->days[weekday].begin()),
            end(this->days[weekday].end());
-           it != end && ((time_t) - 1 == earliest_time);
-           ++it) {
+           it != end && ((time_t)-1 == earliest_time); ++it) {
         // Get range limits.
-        time_t range_start((time_t) - 1);
-        time_t range_end((time_t) - 1);
-        if (_timerange_to_time_t(
-                it->get(), &day_midnight, range_start, range_end) &&
+        time_t range_start((time_t)-1);
+        time_t range_end((time_t)-1);
+        if (_timerange_to_time_t(it->get(), &day_midnight, range_start,
+                                 range_end) &&
             (preferred_time >= range_start) && (preferred_time < range_end))
           earliest_time = range_end;
       }
     }
 
     // Find next exclusion time.
-    time_t next_exclusion((time_t) - 1);
+    time_t next_exclusion((time_t)-1);
     timeperiodexclusion tpe = std::move(this->get_exclusions());
     for (timeperiodexclusion::iterator it(tpe.begin()), end(tpe.end());
-         it != end;
-         ++it) {
-      time_t valid((time_t) - 1);
+         it != end; ++it) {
+      time_t valid((time_t)-1);
       it->second->get_next_valid_time_per_timeperiod(preferred_time, &valid);
-      if ((valid != (time_t) - 1) &&
-          (((time_t) - 1 == next_exclusion) || (valid < next_exclusion)))
+      if ((valid != (time_t)-1) &&
+          (((time_t)-1 == next_exclusion) || (valid < next_exclusion)))
         next_exclusion = valid;
     }
     _exclusions = std::move(tpe);
@@ -902,23 +896,22 @@ void timeperiod::get_next_invalid_time_per_timeperiod(time_t preferred_time,
     ** before.
     */
 
-    if ((next_exclusion != (time_t) - 1) &&
+    if ((next_exclusion != (time_t)-1) &&
         (next_exclusion <
          _add_round_days_to_midnight(ti.midnight, 24 * 60 * 60)) &&
-        (((time_t) - 1 == earliest_time) ||
-         (next_exclusion <= earliest_time))) {
-      earliest_time = (time_t) - 1;
+        (((time_t)-1 == earliest_time) || (next_exclusion <= earliest_time))) {
+      earliest_time = (time_t)-1;
       preferred_time = next_exclusion;
       break;  // We have our time, no need to search anymore.
     }
-    if (earliest_time != (time_t) - 1) {
+    if (earliest_time != (time_t)-1) {
       preferred_time = earliest_time;
-      earliest_time = (time_t) - 1;
+      earliest_time = (time_t)-1;
     }
   }
 
   // If we couldn't find a time period there must be none defined.
-  if (earliest_time != (time_t) - 1)
+  if (earliest_time != (time_t)-1)
     *invalid_time = original_preferred_time;
   // Else use the calculated time.
   else
@@ -935,7 +928,7 @@ void timeperiod::get_next_invalid_time_per_timeperiod(time_t preferred_time,
  */
 static time_t _get_next_valid_time_in_timeranges(time_t preferred_time,
                                                  timerange_list timeranges) {
-  time_t earliest_time((time_t) - 1);
+  time_t earliest_time((time_t)-1);
   struct tm midnight;
   localtime_r(&preferred_time, &midnight);
   midnight.tm_hour = 0;
@@ -943,14 +936,13 @@ static time_t _get_next_valid_time_in_timeranges(time_t preferred_time,
   midnight.tm_sec = 0;
   midnight.tm_isdst = -1;
   for (timerange_list::iterator it(timeranges.begin()), end(timeranges.end());
-       it != end;
-       ++it) {
-    time_t range_start((time_t) - 1);
-    time_t range_end((time_t) - 1);
+       it != end; ++it) {
+    time_t range_start((time_t)-1);
+    time_t range_end((time_t)-1);
     if (_timerange_to_time_t(it->get(), &midnight, range_start, range_end)) {
       // Time range is in the future.
       if (range_start >= preferred_time) {
-        if ((earliest_time == (time_t) - 1) || (range_start < earliest_time))
+        if ((earliest_time == (time_t)-1) || (range_start < earliest_time))
           earliest_time = range_start;
       }
       // Preferred time is within the range.
@@ -972,11 +964,11 @@ void timeperiod::get_next_valid_time_per_timeperiod(time_t preferred_time,
   logger(dbg_functions, basic) << "get_next_valid_time_per_timeperiod()";
 
   // Loop through the upcoming year a day at a time.
-  time_t earliest_time((time_t) - 1);
+  time_t earliest_time((time_t)-1);
   time_info ti;
   ti.preferred_time = preferred_time;
   for (time_t in_one_year(ti.preferred_time + 366 * 24 * 60 * 60);
-       (earliest_time == (time_t) - 1) && (ti.preferred_time < in_one_year);) {
+       (earliest_time == (time_t)-1) && (ti.preferred_time < in_one_year);) {
     // Compute time information.
     localtime_r(&ti.preferred_time, &ti.preftime);
     ti.preftime.tm_sec = 0;
@@ -988,26 +980,22 @@ void timeperiod::get_next_valid_time_per_timeperiod(time_t preferred_time,
     // Browse all date range types in precedence order.
     bool skip_this_day(false);
     for (size_t daterange_type{0};
-         daterange_type < DATERANGE_TYPES && earliest_time == (time_t) - 1 &&
-             !skip_this_day;
+         daterange_type < DATERANGE_TYPES && earliest_time == (time_t)-1 &&
+         !skip_this_day;
          ++daterange_type) {
       // Browse all date ranges of a given type. The earliest valid
       // time found in any date range will be valid.
       for (daterange_list::iterator it{exceptions[daterange_type].begin()},
            end{exceptions[daterange_type].end()};
-           it != end;
-           ++it) {
+           it != end; ++it) {
         // Get next range limits and check that we are within bounds.
-        time_t daterange_start_time((time_t) - 1);
-        time_t daterange_end_time((time_t) - 1);
-        if (_daterange_to_time_t(it->get(),
-                                 daterange_type,
-                                 &ti,
-                                 daterange_start_time,
-                                 daterange_end_time) &&
-            ((daterange_start_time == (time_t) - 1) ||
+        time_t daterange_start_time((time_t)-1);
+        time_t daterange_end_time((time_t)-1);
+        if (_daterange_to_time_t(it->get(), daterange_type, &ti,
+                                 daterange_start_time, daterange_end_time) &&
+            ((daterange_start_time == (time_t)-1) ||
              (daterange_start_time <= ti.midnight)) &&
-            ((daterange_end_time == (time_t) - 1) ||
+            ((daterange_end_time == (time_t)-1) ||
              (ti.midnight < daterange_end_time))) {
           // Only test today. An higher precedence exception might have
           // been skipped because it was not valid on the current day
@@ -1016,8 +1004,8 @@ void timeperiod::get_next_valid_time_per_timeperiod(time_t preferred_time,
               ti.preferred_time, (*it)->times));
 
           // Potential time found.
-          if (potential_time != (time_t) - 1) {
-            if ((earliest_time == (time_t) - 1) ||
+          if (potential_time != (time_t)-1) {
+            if ((earliest_time == (time_t)-1) ||
                 (potential_time < earliest_time))
               earliest_time = potential_time;
             skip_this_day = false;
@@ -1036,35 +1024,33 @@ void timeperiod::get_next_valid_time_per_timeperiod(time_t preferred_time,
     if (!skip_this_day) {
       // Try the weekly schedule only if no valid time was found in
       // exceptions for this day.
-      if (earliest_time == (time_t) - 1) {
+      if (earliest_time == (time_t)-1) {
         time_t potential_time(_get_next_valid_time_in_timeranges(
             ti.preferred_time, this->days[ti.preftime.tm_wday]));
-        if ((potential_time != (time_t) - 1) &&
-            ((earliest_time == (time_t) - 1) ||
-             (potential_time < earliest_time)))
+        if ((potential_time != (time_t)-1) &&
+            ((earliest_time == (time_t)-1) || (potential_time < earliest_time)))
           earliest_time = potential_time;
       }
     }
 
     // Check exclusions.
     bool skipped(false);
-    if (earliest_time != (time_t) - 1) {
-      time_t max_invalid((time_t) - 1);
+    if (earliest_time != (time_t)-1) {
+      time_t max_invalid((time_t)-1);
       timeperiodexclusion tpe = std::move(this->get_exclusions());
 
       for (timeperiodexclusion::iterator it(tpe.begin()), end(tpe.end());
-           it != end;
-           ++it) {
-        time_t invalid((time_t) - 1);
+           it != end; ++it) {
+        time_t invalid((time_t)-1);
         it->second->get_next_invalid_time_per_timeperiod(earliest_time,
                                                          &invalid);
-        if ((invalid != (time_t) - 1) &&
-            (((time_t) - 1 == max_invalid) || (invalid > max_invalid)))
+        if ((invalid != (time_t)-1) &&
+            (((time_t)-1 == max_invalid) || (invalid > max_invalid)))
           max_invalid = invalid;
       }
       _exclusions = std::move(tpe);
-      if ((max_invalid != (time_t) - 1) && (max_invalid != earliest_time)) {
-        earliest_time = (time_t) - 1;
+      if ((max_invalid != (time_t)-1) && (max_invalid != earliest_time)) {
+        earliest_time = (time_t)-1;
         ti.preferred_time = max_invalid;
         skipped = true;
       }
@@ -1131,8 +1117,7 @@ void timeperiod::resolve(int& w __attribute__((unused)), int& e) {
   // Check for valid timeperiod names in exclusion list.
   for (timeperiodexclusion::iterator it{_exclusions.begin()},
        end{_exclusions.end()};
-       it != end;
-       ++it) {
+       it != end; ++it) {
     timeperiod_map::const_iterator found{
         timeperiod::timeperiods.find(it->first)};
 
@@ -1159,4 +1144,6 @@ timeperiodexclusion const& timeperiod::get_exclusions() const {
   return _exclusions;
 }
 
-timeperiodexclusion& timeperiod::get_exclusions() { return _exclusions; }
+timeperiodexclusion& timeperiod::get_exclusions() {
+  return _exclusions;
+}

--- a/tests/checks/service_check.cc
+++ b/tests/checks/service_check.cc
@@ -23,6 +23,7 @@
 #include <cstring>
 #include <iostream>
 #include <memory>
+#include <fmt/format.h>
 
 #include "../test_engine.hh"
 #include "../timeperiod/utils.hh"
@@ -133,11 +134,10 @@ TEST_F(ServiceCheck, SimpleCheck) {
 
   set_time(50500);
 
-  std::ostringstream oss;
   std::time_t now{std::time(nullptr)};
-  oss << '[' << now << ']'
-      << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;service critical";
-  std::string cmd{oss.str()};
+  std::string cmd{fmt::format(
+      "[{}] PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;service critical",
+      now)};
   process_external_command(cmd.c_str());
   checks::checker::instance().reap();
   ASSERT_EQ(_svc->get_state_type(), checkable::soft);
@@ -148,10 +148,9 @@ TEST_F(ServiceCheck, SimpleCheck) {
   set_time(51000);
 
   now = std::time(nullptr);
-  oss.str("");
-  oss << '[' << now << ']'
-      << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;1;service warning";
-  cmd = oss.str();
+  cmd = fmt::format(
+      "[{}] PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;1;service warning",
+      now);
   process_external_command(cmd.c_str());
   checks::checker::instance().reap();
   ASSERT_EQ(_svc->get_state_type(), checkable::soft);
@@ -162,10 +161,9 @@ TEST_F(ServiceCheck, SimpleCheck) {
   set_time(51500);
 
   now = std::time(nullptr);
-  oss.str("");
-  oss << '[' << now << ']'
-      << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;service critical";
-  cmd = oss.str();
+  cmd = fmt::format(
+      "[{}] PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;service critical",
+      now);
   process_external_command(cmd.c_str());
   checks::checker::instance().reap();
   ASSERT_EQ(_svc->get_state_type(), checkable::hard);
@@ -176,10 +174,9 @@ TEST_F(ServiceCheck, SimpleCheck) {
   set_time(52000);
 
   now = std::time(nullptr);
-  oss.str("");
-  oss << '[' << now << ']'
-      << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;1;service warning";
-  cmd = oss.str();
+  cmd = fmt::format(
+      "[{}] PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;1;service warning",
+      now);
   process_external_command(cmd.c_str());
   checks::checker::instance().reap();
   ASSERT_EQ(_svc->get_state_type(), checkable::hard);
@@ -191,10 +188,9 @@ TEST_F(ServiceCheck, SimpleCheck) {
 
   time_t previous = now;
   now = std::time(nullptr);
-  oss.str("");
-  oss << '[' << now << ']'
-      << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;1;service warning";
-  cmd = oss.str();
+  cmd = fmt::format(
+      "[{}] PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;1;service warning",
+      now);
   process_external_command(cmd.c_str());
   checks::checker::instance().reap();
   ASSERT_EQ(_svc->get_state_type(), checkable::hard);
@@ -204,12 +200,9 @@ TEST_F(ServiceCheck, SimpleCheck) {
 
   set_time(53000);
 
-  previous = now;
   now = std::time(nullptr);
-  oss.str("");
-  oss << '[' << now << ']'
-      << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;0;service ok";
-  cmd = oss.str();
+  cmd = fmt::format(
+      "[{}] PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;0;service ok", now);
   process_external_command(cmd.c_str());
   checks::checker::instance().reap();
   ASSERT_EQ(_svc->get_state_type(), checkable::hard);
@@ -221,10 +214,8 @@ TEST_F(ServiceCheck, SimpleCheck) {
 
   previous = now;
   now = std::time(nullptr);
-  oss.str("");
-  oss << '[' << now << ']'
-      << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;0;service ok";
-  cmd = oss.str();
+  cmd = fmt::format(
+      "[{}] PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;0;service ok", now);
   process_external_command(cmd.c_str());
   checks::checker::instance().reap();
   ASSERT_EQ(_svc->get_state_type(), checkable::hard);
@@ -234,12 +225,10 @@ TEST_F(ServiceCheck, SimpleCheck) {
 
   set_time(54000);
 
-  previous = now;
   now = std::time(nullptr);
-  oss.str("");
-  oss << '[' << now << ']'
-      << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;4;service unknown";
-  cmd = oss.str();
+  cmd = fmt::format(
+      "[{}] PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;4;service unknown",
+      now);
   process_external_command(cmd.c_str());
   checks::checker::instance().reap();
   ASSERT_EQ(_svc->get_state_type(), checkable::soft);
@@ -250,12 +239,9 @@ TEST_F(ServiceCheck, SimpleCheck) {
 
   set_time(54500);
 
-  previous = now;
   now = std::time(nullptr);
-  oss.str("");
-  oss << '[' << now << ']'
-      << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;0;service ok";
-  cmd = oss.str();
+  cmd = fmt::format(
+      "[{}] PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;0;service ok", now);
   process_external_command(cmd.c_str());
   checks::checker::instance().reap();
   ASSERT_EQ(_svc->get_state_type(), checkable::soft);
@@ -265,12 +251,9 @@ TEST_F(ServiceCheck, SimpleCheck) {
 
   set_time(55000);
 
-  previous = now;
   now = std::time(nullptr);
-  oss.str("");
-  oss << '[' << now << ']'
-      << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;0;service ok";
-  cmd = oss.str();
+  cmd = fmt::format(
+      "[{}] PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;0;service ok", now);
   process_external_command(cmd.c_str());
   checks::checker::instance().reap();
   ASSERT_EQ(_svc->get_state_type(), checkable::hard);
@@ -290,14 +273,12 @@ TEST_F(ServiceCheck, SimpleCheck) {
  * ------------------------------------------------------
  */
 TEST_F(ServiceCheck, OkCritical) {
-  std::ostringstream oss;
   set_time(55000);
 
   time_t now = std::time(nullptr);
-  oss.str("");
-  oss << '[' << now << ']'
-      << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;0;service ok";
-  std::string cmd = oss.str();
+  std::string cmd{fmt::format(
+      "[{}] PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;0;service ok",
+      now)};
   process_external_command(cmd.c_str());
   checks::checker::instance().reap();
   ASSERT_EQ(_svc->get_state_type(), checkable::hard);
@@ -308,10 +289,9 @@ TEST_F(ServiceCheck, OkCritical) {
   set_time(55500);
 
   now = std::time(nullptr);
-  oss.str("");
-  oss << '[' << now << ']'
-      << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;service critical";
-  cmd = oss.str();
+  cmd = fmt::format(
+      "[{}] PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;service critical",
+      now);
   process_external_command(cmd.c_str());
   checks::checker::instance().reap();
   ASSERT_EQ(_svc->get_state_type(), checkable::soft);
@@ -323,10 +303,9 @@ TEST_F(ServiceCheck, OkCritical) {
 
   time_t previous = now;
   now = std::time(nullptr);
-  oss.str("");
-  oss << '[' << now << ']'
-      << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;service critical";
-  cmd = oss.str();
+  cmd = fmt::format(
+      "[{}] PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;service critical",
+      now);
   process_external_command(cmd.c_str());
   checks::checker::instance().reap();
   ASSERT_EQ(_svc->get_state_type(), checkable::soft);
@@ -337,10 +316,9 @@ TEST_F(ServiceCheck, OkCritical) {
   set_time(56500);
 
   now = std::time(nullptr);
-  oss.str("");
-  oss << '[' << now << ']'
-      << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;service critical";
-  cmd = oss.str();
+  cmd = fmt::format(
+      "[{}] PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;service critical",
+      now);
   process_external_command(cmd.c_str());
   checks::checker::instance().reap();
   ASSERT_EQ(_svc->get_state_type(), checkable::hard);
@@ -360,10 +338,8 @@ TEST_F(ServiceCheck, OkCritical) {
  * ------------------------------------------------------
  */
 TEST_F(ServiceCheck, OkSoft_Critical) {
-  std::ostringstream oss;
   set_time(55000);
 
-  time_t now = std::time(nullptr);
   _svc->set_current_state(engine::service::state_ok);
   _svc->set_last_state_change(55000);
   _svc->set_current_attempt(2);
@@ -372,11 +348,10 @@ TEST_F(ServiceCheck, OkSoft_Critical) {
 
   set_time(55500);
 
-  now = std::time(nullptr);
-  oss.str("");
-  oss << '[' << now << ']'
-      << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;service critical";
-  std::string cmd = oss.str();
+  time_t now = std::time(nullptr);
+  std::string cmd{fmt::format(
+      "[{}] PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;service critical",
+      now)};
   process_external_command(cmd.c_str());
   checks::checker::instance().reap();
   ASSERT_EQ(_svc->get_state_type(), checkable::soft);
@@ -388,10 +363,9 @@ TEST_F(ServiceCheck, OkSoft_Critical) {
 
   time_t previous = now;
   now = std::time(nullptr);
-  oss.str("");
-  oss << '[' << now << ']'
-      << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;service critical";
-  cmd = oss.str();
+  cmd = fmt::format(
+      "[{}] PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;service critical",
+      now);
   process_external_command(cmd.c_str());
   checks::checker::instance().reap();
   ASSERT_EQ(_svc->get_state_type(), checkable::soft);
@@ -402,10 +376,9 @@ TEST_F(ServiceCheck, OkSoft_Critical) {
   set_time(56500);
 
   now = std::time(nullptr);
-  oss.str("");
-  oss << '[' << now << ']'
-      << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;service critical";
-  cmd = oss.str();
+  cmd = fmt::format(
+      "[{}] PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;service critical",
+      now);
   process_external_command(cmd.c_str());
   checks::checker::instance().reap();
   ASSERT_EQ(_svc->get_state_type(), checkable::hard);
@@ -429,10 +402,8 @@ TEST_F(ServiceCheck, OkSoft_Critical) {
  * ------------------------------------------------------
  */
 TEST_F(ServiceCheck, OkCriticalStalking) {
-  std::ostringstream oss;
   set_time(55000);
 
-  time_t now = std::time(nullptr);
   _svc->set_current_state(engine::service::state_ok);
   _svc->set_last_state_change(55000);
   _svc->set_current_attempt(2);
@@ -442,12 +413,11 @@ TEST_F(ServiceCheck, OkCriticalStalking) {
 
   set_time(55500);
   testing::internal::CaptureStdout();
-  now = std::time(nullptr);
-  oss.str("");
-  oss << '[' << now << ']'
-      << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;0;RAID array "
-         "optimal";
-  std::string cmd = oss.str();
+  time_t now = std::time(nullptr);
+  std::string cmd{fmt::format(
+      "[{}] PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;0;RAID array "
+      "optimal",
+      now)};
   process_external_command(cmd.c_str());
   checks::checker::instance().reap();
 
@@ -460,11 +430,10 @@ TEST_F(ServiceCheck, OkCriticalStalking) {
   time_t previous = now;
 
   now = std::time(nullptr);
-  oss.str("");
-  oss << '[' << now << ']'
-      << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;0;RAID array "
-         "optimal";
-  cmd = oss.str();
+  cmd = fmt::format(
+      "[{}] PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;0;RAID array "
+      "optimal",
+      now);
   process_external_command(cmd.c_str());
   checks::checker::instance().reap();
 
@@ -479,11 +448,10 @@ TEST_F(ServiceCheck, OkCriticalStalking) {
     // When i == 1, the state_critical is soft => no notification
     // When i == 2, the state_critical is hard down => notification
     now = std::time(nullptr);
-    oss.str("");
-    oss << '[' << now << ']'
-        << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;1;RAID array "
-           "degraded (1 drive bad, 1 hot spare rebuilding)";
-    cmd = oss.str();
+    cmd = fmt::format(
+        "[{}] PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;1;RAID array "
+        "degraded (1 drive bad, 1 hot spare rebuilding)",
+        now);
     process_external_command(cmd.c_str());
     checks::checker::instance().reap();
   }
@@ -495,11 +463,10 @@ TEST_F(ServiceCheck, OkCriticalStalking) {
   set_time(57000);
 
   now = std::time(nullptr);
-  oss.str("");
-  oss << '[' << now << ']'
-      << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;RAID array "
-         "degraded (2 drives bad, 1 host spare online, 1 hot spare rebuilding)";
-  cmd = oss.str();
+  cmd = fmt::format(
+      "[{}] PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;RAID array "
+      "degraded (2 drives bad, 1 host spare online, 1 hot spare rebuilding)",
+      now);
   process_external_command(cmd.c_str());
   checks::checker::instance().reap();
 
@@ -512,11 +479,10 @@ TEST_F(ServiceCheck, OkCriticalStalking) {
   previous = now;
 
   now = std::time(nullptr);
-  oss.str("");
-  oss << '[' << now << ']'
-      << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;RAID array "
-         "degraded (3 drives bad, 2 hot spares online)";
-  cmd = oss.str();
+  cmd = fmt::format(
+      "[{}] PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;RAID array "
+      "degraded (3 drives bad, 2 hot spares online)",
+      now);
   process_external_command(cmd.c_str());
   checks::checker::instance().reap();
 
@@ -528,10 +494,10 @@ TEST_F(ServiceCheck, OkCriticalStalking) {
   set_time(58000);
 
   now = std::time(nullptr);
-  oss.str("");
-  oss << '[' << now << ']'
-      << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;RAID array failed";
-  cmd = oss.str();
+  cmd = fmt::format(
+      "[{}] PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;RAID array "
+      "failed",
+      now);
   process_external_command(cmd.c_str());
   checks::checker::instance().reap();
 
@@ -543,10 +509,10 @@ TEST_F(ServiceCheck, OkCriticalStalking) {
   set_time(58500);
 
   now = std::time(nullptr);
-  oss.str("");
-  oss << '[' << now << ']'
-      << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;RAID array failed";
-  cmd = oss.str();
+  cmd = fmt::format(
+      "[{}] PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;RAID array "
+      "failed",
+      now);
   process_external_command(cmd.c_str());
   checks::checker::instance().reap();
 
@@ -558,10 +524,10 @@ TEST_F(ServiceCheck, OkCriticalStalking) {
   set_time(59000);
 
   now = std::time(nullptr);
-  oss.str("");
-  oss << '[' << now << ']'
-      << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;RAID array failed";
-  cmd = oss.str();
+  cmd = fmt::format(
+      "[{}] PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;RAID array "
+      "failed",
+      now);
   process_external_command(cmd.c_str());
   checks::checker::instance().reap();
 
@@ -576,18 +542,22 @@ TEST_F(ServiceCheck, OkCriticalStalking) {
       out.find(
           "SERVICE ALERT: test_host;test_svc;OK;HARD;1;RAID array optimal"),
       std::string::npos);
-  ASSERT_NE(out.find("SERVICE ALERT: test_host;test_svc;WARNING;HARD;3;RAID "
-                     "array degraded (1 drive bad, 1 hot spare rebuilding)"),
+  ASSERT_NE(out.find(
+                "SERVICE ALERT: test_host;test_svc;WARNING;HARD;3;RAID "
+                "array degraded (1 drive bad, 1 hot spare rebuilding)"),
             std::string::npos);
-  ASSERT_NE(out.find("SERVICE ALERT: test_host;test_svc;CRITICAL;HARD;3;RAID "
-                     "array degraded (2 drives bad, 1 host spare online, 1 hot "
-                     "spare rebuilding)"),
+  ASSERT_NE(out.find(
+                "SERVICE ALERT: test_host;test_svc;CRITICAL;HARD;3;RAID "
+                "array degraded (2 drives bad, 1 host spare online, 1 hot "
+                "spare rebuilding)"),
             std::string::npos);
-  ASSERT_NE(out.find("SERVICE ALERT: test_host;test_svc;CRITICAL;HARD;3;RAID "
-                     "array degraded (3 drives bad, 2 hot spares online"),
+  ASSERT_NE(out.find(
+                "SERVICE ALERT: test_host;test_svc;CRITICAL;HARD;3;RAID "
+                "array degraded (3 drives bad, 2 hot spares online"),
             std::string::npos);
-  ASSERT_NE(out.find("SERVICE ALERT: test_host;test_svc;CRITICAL;HARD;3;RAID "
-                     "array failed"),
+  ASSERT_NE(out.find(
+                "SERVICE ALERT: test_host;test_svc;CRITICAL;HARD;3;RAID "
+                "array failed"),
             std::string::npos);
 }
 
@@ -601,12 +571,10 @@ TEST_F(ServiceCheck, CheckRemoveCheck) {
   _svc->set_current_attempt(1);
 
   set_time(50500);
-
-  std::ostringstream oss;
   std::time_t now{std::time(nullptr)};
-  oss << '[' << now << ']'
-      << " PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;service critical";
-  std::string cmd{oss.str()};
+  std::string cmd{fmt::format(
+      "[{}] PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;service critical",
+      now)};
   process_external_command(cmd.c_str());
 
   /* We simulate a reload that destroyed the service */

--- a/tests/checks/service_check.cc
+++ b/tests/checks/service_check.cc
@@ -20,10 +20,10 @@
 #include <gtest/gtest.h>
 #include <time.h>
 
+#include <fmt/format.h>
 #include <cstring>
 #include <iostream>
 #include <memory>
-#include <fmt/format.h>
 
 #include "../test_engine.hh"
 #include "../timeperiod/utils.hh"
@@ -542,22 +542,18 @@ TEST_F(ServiceCheck, OkCriticalStalking) {
       out.find(
           "SERVICE ALERT: test_host;test_svc;OK;HARD;1;RAID array optimal"),
       std::string::npos);
-  ASSERT_NE(out.find(
-                "SERVICE ALERT: test_host;test_svc;WARNING;HARD;3;RAID "
-                "array degraded (1 drive bad, 1 hot spare rebuilding)"),
+  ASSERT_NE(out.find("SERVICE ALERT: test_host;test_svc;WARNING;HARD;3;RAID "
+                     "array degraded (1 drive bad, 1 hot spare rebuilding)"),
             std::string::npos);
-  ASSERT_NE(out.find(
-                "SERVICE ALERT: test_host;test_svc;CRITICAL;HARD;3;RAID "
-                "array degraded (2 drives bad, 1 host spare online, 1 hot "
-                "spare rebuilding)"),
+  ASSERT_NE(out.find("SERVICE ALERT: test_host;test_svc;CRITICAL;HARD;3;RAID "
+                     "array degraded (2 drives bad, 1 host spare online, 1 hot "
+                     "spare rebuilding)"),
             std::string::npos);
-  ASSERT_NE(out.find(
-                "SERVICE ALERT: test_host;test_svc;CRITICAL;HARD;3;RAID "
-                "array degraded (3 drives bad, 2 hot spares online"),
+  ASSERT_NE(out.find("SERVICE ALERT: test_host;test_svc;CRITICAL;HARD;3;RAID "
+                     "array degraded (3 drives bad, 2 hot spares online"),
             std::string::npos);
-  ASSERT_NE(out.find(
-                "SERVICE ALERT: test_host;test_svc;CRITICAL;HARD;3;RAID "
-                "array failed"),
+  ASSERT_NE(out.find("SERVICE ALERT: test_host;test_svc;CRITICAL;HARD;3;RAID "
+                     "array failed"),
             std::string::npos);
 }
 

--- a/tests/commands/connector.cc
+++ b/tests/commands/connector.cc
@@ -60,11 +60,8 @@ class Connector : public ::testing::Test {
     init_config_state();
   }
 
-  void TearDown() override {
-    deinit_config_state();
-  }
+  void TearDown() override { deinit_config_state(); }
 };
-
 
 // Given an empty name
 // When the add_command method is called with it as argument,
@@ -88,9 +85,7 @@ TEST_F(Connector, ForwardWithoutCmd) {
 // Given an already existing command
 // When the add_command method is called with the same name
 // Then it returns a NULL pointer.
-TEST_F(Connector, SimpleConnector) {
-  commands::connector c("toto", "/bin/ls");
-}
+TEST_F(Connector, SimpleConnector) { commands::connector c("toto", "/bin/ls"); }
 
 // This test is just a test of the run command in usual conditions.
 // We don't test timeout because time is replaced by a fake function
@@ -131,7 +126,7 @@ TEST_F(Connector, RunWithConnectorSwitchedOff) {
     nagios_macros macros = nagios_macros();
     cmd_connector.set_listener(lstnr.get());
     cmd_connector.run("commande --kill=1", macros, 1);
-  
+
     int timeout = 0;
     int max_timeout{15};
     while (timeout < max_timeout && lstnr->get_result().output == "") {

--- a/tests/commands/connector.cc
+++ b/tests/commands/connector.cc
@@ -85,7 +85,9 @@ TEST_F(Connector, ForwardWithoutCmd) {
 // Given an already existing command
 // When the add_command method is called with the same name
 // Then it returns a NULL pointer.
-TEST_F(Connector, SimpleConnector) { commands::connector c("toto", "/bin/ls"); }
+TEST_F(Connector, SimpleConnector) {
+  commands::connector c("toto", "/bin/ls");
+}
 
 // This test is just a test of the run command in usual conditions.
 // We don't test timeout because time is replaced by a fake function

--- a/tests/custom_vars/extcmd.cc
+++ b/tests/custom_vars/extcmd.cc
@@ -92,8 +92,8 @@ TEST_F(CustomVar, UpdateHostCustomVar) {
   ASSERT_EQ(processed_cmd,
             "/check_icmp -H 127.0.0.1 -n 42 -w 200,20% -c 400,50% user");
 
-  cmd_change_object_custom_var(CMD_CHANGE_CUSTOM_HOST_VAR,
-                               "hst_test;PACKETNUMBER;44");
+  char* msg = strdupa("hst_test;PACKETNUMBER;44");
+  cmd_change_object_custom_var(CMD_CHANGE_CUSTOM_HOST_VAR, msg);
   grab_host_macros_r(macros, hst_found->second.get());
   std::string processed_cmd2(
       hst_found->second->get_check_command_ptr()->process_cmd(macros));

--- a/tests/enginerpc/client.cc
+++ b/tests/enginerpc/client.cc
@@ -241,7 +241,8 @@ class EngineRPCClient {
   bool ProcessServiceCheckResult(Check const& sc) {
     grpc::ClientContext context;
     CommandSuccess response;
-    grpc::Status status = _stub->ProcessServiceCheckResult(&context, sc, &response);
+    grpc::Status status =
+        _stub->ProcessServiceCheckResult(&context, sc, &response);
     if (!status.ok()) {
       std::cout << "ProcessServiceCheckResult failed." << std::endl;
       return false;
@@ -252,7 +253,8 @@ class EngineRPCClient {
   bool ProcessHostCheckResult(Check const& hc) {
     grpc::ClientContext context;
     CommandSuccess response;
-    grpc::Status status = _stub->ProcessHostCheckResult(&context, hc, &response);
+    grpc::Status status =
+        _stub->ProcessHostCheckResult(&context, hc, &response);
     if (!status.ok()) {
       std::cout << "ProcessHostCheckResult failed." << std::endl;
       return false;
@@ -721,7 +723,6 @@ class EngineRPCClient {
       std::string const& author,
       std::string const& commentdata,
       std::pair<bool, uint32_t> const& entrytime,
-
       CommandSuccess* response) {
     ScheduleDowntimeIdentifier request;
     grpc::ClientContext context;
@@ -800,7 +801,6 @@ class EngineRPCClient {
       std::string const& author,
       std::string const& commentdata,
       std::pair<bool, uint32_t> const& entrytime,
-
       CommandSuccess* response) {
     ScheduleDowntimeIdentifier request;
     grpc::ClientContext context;
@@ -824,8 +824,7 @@ class EngineRPCClient {
         _stub->ScheduleAndPropagateHostDowntime(&context, request, response);
     if (!status.ok() || !response->value()) {
       std::cout << "ScheduleAndPropagateHostDowntime "
-                   "rpc engine failed"
-                << std::endl;
+                   "rpc engine failed" << std::endl;
       return false;
     }
     return true;
@@ -864,8 +863,7 @@ class EngineRPCClient {
         &context, request, response);
     if (!status.ok() || !response->value()) {
       std::cout << "ScheduleAndPropagateTriggeredHostDowntime "
-                   "rpc engine failed"
-                << std::endl;
+                   "rpc engine failed" << std::endl;
       return false;
     }
     return true;
@@ -1038,8 +1036,7 @@ class EngineRPCClient {
     grpc::Status status = _stub->ScheduleHostCheck(&context, request, response);
     if (!status.ok()) {
       std::cout << "ScheduleHostCheck"
-                   "rpc engine failed"
-                << std::endl;
+                   "rpc engine failed" << std::endl;
       return false;
     }
     return true;
@@ -1057,8 +1054,7 @@ class EngineRPCClient {
         _stub->ScheduleHostServiceCheck(&context, request, response);
     if (!status.ok()) {
       std::cout << "ScheduleHostServiceCheck"
-                   "rpc engine failed"
-                << std::endl;
+                   "rpc engine failed" << std::endl;
       return false;
     }
     return true;
@@ -1078,8 +1074,7 @@ class EngineRPCClient {
         _stub->ScheduleServiceCheck(&context, request, response);
     if (!status.ok()) {
       std::cout << "ScheduleServiceCheck"
-                   "rpc engine failed"
-                << std::endl;
+                   "rpc engine failed" << std::endl;
       return false;
     }
     return true;
@@ -1361,12 +1356,10 @@ class EngineRPCClient {
     }
     return true;
   }
-
-
 };
 
 int main(int argc, char** argv) {
-  int32_t status;
+  int32_t status = 0;
   EngineRPCClient client(grpc::CreateChannel(
       "127.0.0.1:40001", grpc::InsecureChannelCredentials()));
 
@@ -1380,13 +1373,11 @@ int main(int argc, char** argv) {
     Version version;
     status = client.GetVersion(&version) ? 0 : 1;
     std::cout << "GetVersion: " << version.DebugString();
-  }
-  else if (strcmp(argv[1], "GetStats") == 0) {
+  } else if (strcmp(argv[1], "GetStats") == 0) {
     Stats stats;
     status = client.GetStats(&stats) ? 0 : 2;
     std::cout << "GetStats: " << stats.DebugString();
-  }
-  else if (strcmp(argv[1], "ProcessServiceCheckResult") == 0) {
+  } else if (strcmp(argv[1], "ProcessServiceCheckResult") == 0) {
     Check sc;
     sc.set_host_name(argv[2]);
     sc.set_svc_desc(argv[3]);
@@ -1394,28 +1385,24 @@ int main(int argc, char** argv) {
     sc.set_output("Test external command");
     status = client.ProcessServiceCheckResult(sc) ? 0 : 3;
     std::cout << "ProcessServiceCheckResult: " << status << std::endl;
-  }
-  else if (strcmp(argv[1], "ProcessHostCheckResult") == 0) {
+  } else if (strcmp(argv[1], "ProcessHostCheckResult") == 0) {
     Check hc;
     hc.set_host_name(argv[2]);
     hc.set_code(std::stol(argv[3]));
     hc.set_output("Test external command");
     status = client.ProcessHostCheckResult(hc) ? 0 : 4;
     std::cout << "ProcessHostCheckResult: " << status << std::endl;
-  }
-  else if (strcmp(argv[1], "NewThresholdsFile") == 0) {
+  } else if (strcmp(argv[1], "NewThresholdsFile") == 0) {
     ThresholdsFile tf;
     tf.set_filename(argv[2]);
     status = client.NewThresholdsFile(tf) ? 0 : 5;
     std::cout << "NewThresholdsFile: " << status << std::endl;
-  }
-  else if (strcmp(argv[1], "GetHost") == 0) {
+  } else if (strcmp(argv[1], "GetHost") == 0) {
     if (argc != 4) {
       std::cout << "GetHost require arguments : GetHost [mode] [hostname or id]"
                 << std::endl;
       return 1;
-    }
-    else if (strcmp(argv[2], "byhostid") == 0) {
+    } else if (strcmp(argv[2], "byhostid") == 0) {
       EngineHost response;
       uint32_t val = atoi(argv[3]);
       status = client.GetHostByHostId(val, &response) ? 0 : 1;
@@ -1426,8 +1413,7 @@ int main(int argc, char** argv) {
       std::cout << "Host address: " << response.address() << std::endl;
       std::cout << "Host state: " << response.current_state() << std::endl;
       std::cout << "Host period: " << response.check_period() << std::endl;
-    }
-    else if (strcmp(argv[2], "byhostname") == 0) {
+    } else if (strcmp(argv[2], "byhostname") == 0) {
       EngineHost response;
       std::string str(argv[3]);
       status = client.GetHostByHostName(str, &response) ? 0 : 1;
@@ -1438,28 +1424,24 @@ int main(int argc, char** argv) {
       std::cout << "Host address: " << response.address() << std::endl;
       std::cout << "Host state: " << response.current_state() << std::endl;
       std::cout << "Host period: " << response.check_period() << std::endl;
-
     }
-  }
-  else if (strcmp(argv[1], "GetContact") == 0) {
-      if (argc != 3) {
-        std::cout << "GetContact require arguments : GetContact [contactname]"
-                  << std::endl;
-        return 1;
-      }
-      EngineContact response;
-      std::string str = (argv[2]);
-      status = client.GetContact(str, &response) ? 0 : 1;
-      std::cout << "GetContact" << std::endl;
-      std::cout << response.name() << std::endl;
-      std::cout << response.alias() << std::endl;
-      std::cout << response.email() << std::endl;
-  }
-  else if (strcmp(argv[1], "GetService") == 0) {
+  } else if (strcmp(argv[1], "GetContact") == 0) {
+    if (argc != 3) {
+      std::cout << "GetContact require arguments : GetContact [contactname]"
+                << std::endl;
+      return 1;
+    }
+    EngineContact response;
+    std::string str = (argv[2]);
+    status = client.GetContact(str, &response) ? 0 : 1;
+    std::cout << "GetContact" << std::endl;
+    std::cout << response.name() << std::endl;
+    std::cout << response.alias() << std::endl;
+    std::cout << response.email() << std::endl;
+  } else if (strcmp(argv[1], "GetService") == 0) {
     if (argc != 5) {
       std::cout << "GetService require arguments : GetService [mode] [hostname "
-                   "or hostid] [servicename or serviceid]"
-                << std::endl;
+                   "or hostid] [servicename or serviceid]" << std::endl;
       return 1;
     } else if (strcmp(argv[2], "bynames") == 0) {
       EngineService response;
@@ -1487,63 +1469,52 @@ int main(int argc, char** argv) {
       std::cout << "Service state: " << response.current_state() << std::endl;
       std::cout << "Service period: " << response.check_period() << std::endl;
     }
-  }
-
-  else if (strcmp(argv[1], "GetHostsCount") == 0) {
+  } else if (strcmp(argv[1], "GetHostsCount") == 0) {
     GenericValue response;
     status = client.GetHostsCount(&response) ? 0 : 1;
     std::cout << "GetHostsCount from client" << std::endl;
     std::cout << response.value() << std::endl;
-  }
-  else if (strcmp(argv[1], "GetContactsCount") == 0) {
+  } else if (strcmp(argv[1], "GetContactsCount") == 0) {
     GenericValue response;
     status = client.GetContactsCount(&response) ? 0 : 1;
     std::cout << "GetContactsCount from client" << std::endl;
     std::cout << response.value() << std::endl;
-  }
-  else if (strcmp(argv[1], "GetServicesCount") == 0) {
+  } else if (strcmp(argv[1], "GetServicesCount") == 0) {
     GenericValue response;
     status = client.GetServicesCount(&response) ? 0 : 1;
     std::cout << "GetServicesCount from client" << std::endl;
     std::cout << response.value() << std::endl;
-  }
-  else if (strcmp(argv[1], "GetServiceGroupsCount") == 0) {
+  } else if (strcmp(argv[1], "GetServiceGroupsCount") == 0) {
     GenericValue response;
     status = client.GetServiceGroupsCount(&response) ? 0 : 1;
     std::cout << "GetServiceGroupsCount from client" << std::endl;
     std::cout << response.value() << std::endl;
-  }
-  else if (strcmp(argv[1], "GetContactGroupsCount") == 0) {
+  } else if (strcmp(argv[1], "GetContactGroupsCount") == 0) {
     GenericValue response;
     status = client.GetContactGroupsCount(&response) ? 0 : 1;
     std::cout << "GetContactGroupsCount from client" << std::endl;
     std::cout << response.value() << std::endl;
-  }
-  else if (strcmp(argv[1], "GetHostGroupsCount") == 0) {
+  } else if (strcmp(argv[1], "GetHostGroupsCount") == 0) {
     GenericValue response;
     status = client.GetHostGroupsCount(&response) ? 0 : 1;
     std::cout << "GetHostGroupsCount from client" << std::endl;
     std::cout << response.value() << std::endl;
-  }
-  else if (strcmp(argv[1], "GetServiceDependenciesCount") == 0) {
+  } else if (strcmp(argv[1], "GetServiceDependenciesCount") == 0) {
     GenericValue response;
     status = client.GetServiceDependenciesCount(&response) ? 0 : 1;
     std::cout << "GetServiceDependenciesCount client" << std::endl;
     std::cout << response.value() << std::endl;
-  }
-  else if (strcmp(argv[1], "GetHostDependenciesCount") == 0) {
+  } else if (strcmp(argv[1], "GetHostDependenciesCount") == 0) {
     GenericValue response;
     status = client.GetHostDependenciesCount(&response) ? 0 : 1;
     std::cout << "GetHostDependenciesCount client" << std::endl;
     std::cout << response.value() << std::endl;
-  }
-  else if (strcmp(argv[1], "AddHostComment") == 0) {
+  } else if (strcmp(argv[1], "AddHostComment") == 0) {
     if (argc != 7) {
       std::cout << "AddHostComment require arguments : "
                    "AddHostComment "
                    "[hostname] [user] [your_own_comment] [persistent] "
-                   "[entry_time]"
-                << std::endl;
+                   "[entry_time]" << std::endl;
       return 1;
     }
     CommandSuccess response;
@@ -1552,17 +1523,15 @@ int main(int argc, char** argv) {
     std::string commentdata = argv[4];
     bool persistent = atoi(argv[5]);
     uint32_t entrytime = atoi(argv[6]);
-    status = client.AddHostComment(hostname, entrytime, user, commentdata,
-                                   persistent, &response);
+    status = client.AddHostComment(
+        hostname, entrytime, user, commentdata, persistent, &response);
     std::cout << "AddHostComment" << std::endl;
-  }
-  else if (strcmp(argv[1], "AddServiceComment") == 0) {
+  } else if (strcmp(argv[1], "AddServiceComment") == 0) {
     if (argc != 8) {
       std::cout << "AddHostComment require arguments : "
                    "AddHostComment "
                    "[hostname] [service_description] [user] [your_own_comment] "
-                   "[persistent] [entry_time]"
-                << std::endl;
+                   "[persistent] [entry_time]" << std::endl;
       return 1;
     }
     CommandSuccess response;
@@ -1572,15 +1541,13 @@ int main(int argc, char** argv) {
     std::string commentdata{argv[5]};
     bool persistent = atoi(argv[6]);
     uint32_t entrytime = atoi(argv[7]);
-    status = client.AddServiceComment(hostname, svcdsc, entrytime, user,
-                                      commentdata, persistent, &response);
+    status = client.AddServiceComment(
+        hostname, svcdsc, entrytime, user, commentdata, persistent, &response);
     std::cout << "AddServiceComment " << status << std::endl;
-  }
-  else if (strcmp(argv[1], "DeleteAllHostComments") == 0) {
+  } else if (strcmp(argv[1], "DeleteAllHostComments") == 0) {
     if (argc != 4) {
       std::cout << "DeleteAllHostComments require arguments : GetHost [mode] "
-                   "[hostname or id]"
-                << std::endl;
+                   "[hostname or id]" << std::endl;
       return 1;
     } else if (strcmp(argv[2], "byhostname") == 0) {
       CommandSuccess response;
@@ -1593,14 +1560,12 @@ int main(int argc, char** argv) {
       status = client.DeleteAllHostCommentsById(hostid, &response);
       std::cout << "DeleteAllHostComments" << std::endl;
     }
-  }
-  else if (strcmp(argv[1], "DeleteAllServiceComments") == 0) {
+  } else if (strcmp(argv[1], "DeleteAllServiceComments") == 0) {
     if (argc != 5) {
       std::cout << "DeleteAllServiceComments require arguments : "
                    "DeleteAllServiceComments "
                    "[mode] [hostname "
-                   "or hostid] [servicename or serviceid]"
-                << std::endl;
+                   "or hostid] [servicename or serviceid]" << std::endl;
       return 1;
     } else if (strcmp(argv[2], "bynames") == 0) {
       CommandSuccess response;
@@ -1617,8 +1582,7 @@ int main(int argc, char** argv) {
           client.DeleteAllServiceCommentsByIds(hostid, serviceid, &response);
       std::cout << "DeleteAllServiceComments" << std::endl;
     }
-  }
-  else if (strcmp(argv[1], "DeleteComment") == 0) {
+  } else if (strcmp(argv[1], "DeleteComment") == 0) {
     if (argc != 3) {
       std::cout
           << "DeleteComment require arguments : DeleteComment [comment_id]"
@@ -1629,8 +1593,7 @@ int main(int argc, char** argv) {
     uint32_t commentid = atoi(argv[2]);
     status = client.DeleteComment(commentid, &response);
     std::cout << "DeleteComment " << status << std::endl;
-  }
-  else if (strcmp(argv[1], "RemoveHostAcknowledgement") == 0) {
+  } else if (strcmp(argv[1], "RemoveHostAcknowledgement") == 0) {
     if (argc != 4) {
       std::cout << "RemoveHostAcknowledgement require arguments : "
                    "RemoveHostAcknowledgement [mode] [hostname or id]"
@@ -1647,32 +1610,29 @@ int main(int argc, char** argv) {
       status = client.RemoveHostAcknowledgementByIds(hostid, &response);
       std::cout << "RemoveHostAcknowledgement" << std::endl;
     }
-  }
-  else if (strcmp(argv[1], "RemoveServiceAcknowledgement") == 0) {
+  } else if (strcmp(argv[1], "RemoveServiceAcknowledgement") == 0) {
     if (argc != 5) {
       std::cout << "RemoveServiceAcknowledgement require arguments : "
                    "RemoveServiceAcknowledgement "
                    "[mode] [hostname "
-                   "or hostid] [servicename or serviceid]"
-                << std::endl;
+                   "or hostid] [servicename or serviceid]" << std::endl;
       return 1;
     } else if (strcmp(argv[2], "bynames") == 0) {
       CommandSuccess response;
       std::string hostname(argv[3]);
       std::string svcdsc(argv[4]);
-      status = client.RemoveServiceAcknowledgementByNames(hostname, svcdsc,
-                                                          &response);
+      status = client.RemoveServiceAcknowledgementByNames(
+          hostname, svcdsc, &response);
       std::cout << "RemoveServiceAcknowledgement" << std::endl;
     } else if (strcmp(argv[2], "byids") == 0) {
       CommandSuccess response;
       uint32_t hostid = atoi(argv[3]);
       uint32_t serviceid = atoi(argv[4]);
-      status = client.RemoveServiceAcknowledgementByIds(hostid, serviceid,
-                                                        &response);
+      status = client.RemoveServiceAcknowledgementByIds(
+          hostid, serviceid, &response);
       std::cout << "RemoveServiceAcknowledgement" << std::endl;
     }
-  }
-  else if (strcmp(argv[1], "AcknowledgementHostProblem") == 0) {
+  } else if (strcmp(argv[1], "AcknowledgementHostProblem") == 0) {
     CommandSuccess response;
     std::string hostname(argv[2]);
     std::string ackauthor(argv[3]);
@@ -1684,8 +1644,7 @@ int main(int argc, char** argv) {
     status = client.AcknowledgementHostProblem(
         hostname, ackauthor, ackdata, type, notify, persistent, &response);
     std::cout << "AcknowledgementHostProblem" << std::endl;
-  }
-  else if (strcmp(argv[1], "AcknowledgementServiceProblem") == 0) {
+  } else if (strcmp(argv[1], "AcknowledgementServiceProblem") == 0) {
     CommandSuccess response;
     std::string hostname(argv[2]);
     std::string servicedesc(argv[3]);
@@ -1695,12 +1654,16 @@ int main(int argc, char** argv) {
     bool notify = atoi(argv[7]);
     bool persistent = atoi(argv[8]);
 
-    status = client.AcknowledgementServiceProblem(
-        hostname, servicedesc, ackauthor, ackdata, type, notify, persistent,
-        &response);
+    status = client.AcknowledgementServiceProblem(hostname,
+                                                  servicedesc,
+                                                  ackauthor,
+                                                  ackdata,
+                                                  type,
+                                                  notify,
+                                                  persistent,
+                                                  &response);
     std::cout << "AcknowledgementServiceProblem" << std::endl;
-  }
-  else if (strcmp(argv[1], "ScheduleHostDowntime") == 0) {
+  } else if (strcmp(argv[1], "ScheduleHostDowntime") == 0) {
     CommandSuccess response;
     std::string hostname(argv[2]);
     std::pair<bool, uint32_t> start;
@@ -1741,12 +1704,18 @@ int main(int argc, char** argv) {
     else
       entrytime = std::make_pair(true, atoi(argv[10]));
 
-    status = client.ScheduleHostDowntime(hostname, start, end, fixed,
-                                         triggeredby, duration, author,
-                                         commentdata, entrytime, &response);
+    status = client.ScheduleHostDowntime(hostname,
+                                         start,
+                                         end,
+                                         fixed,
+                                         triggeredby,
+                                         duration,
+                                         author,
+                                         commentdata,
+                                         entrytime,
+                                         &response);
     std::cout << "ScheduleHostDowntime " << status << std::endl;
-  }
-  else if (strcmp(argv[1], "ScheduleServiceDowntime") == 0) {
+  } else if (strcmp(argv[1], "ScheduleServiceDowntime") == 0) {
     CommandSuccess response;
     std::string hostname(argv[2]);
     std::string svcdsc(argv[3]);
@@ -1788,12 +1757,19 @@ int main(int argc, char** argv) {
     else
       entrytime = std::make_pair(true, atoi(argv[11]));
 
-    status = client.ScheduleServiceDowntime(hostname, svcdsc, start, end, fixed,
-                                            triggeredby, duration, author,
-                                            commentdata, entrytime, &response);
+    status = client.ScheduleServiceDowntime(hostname,
+                                            svcdsc,
+                                            start,
+                                            end,
+                                            fixed,
+                                            triggeredby,
+                                            duration,
+                                            author,
+                                            commentdata,
+                                            entrytime,
+                                            &response);
     std::cout << "ScheduleServiceDowntime " << status << std::endl;
-  }
-  else if (strcmp(argv[1], "ScheduleHostServicesDowntime") == 0) {
+  } else if (strcmp(argv[1], "ScheduleHostServicesDowntime") == 0) {
     CommandSuccess response;
     std::string hostname(argv[2]);
     std::pair<bool, uint32_t> start;
@@ -1834,12 +1810,18 @@ int main(int argc, char** argv) {
     else
       entrytime = std::make_pair(true, atoi(argv[10]));
 
-    status = client.ScheduleHostServicesDowntime(
-        hostname, start, end, fixed, triggeredby, duration, author, commentdata,
-        entrytime, &response);
+    status = client.ScheduleHostServicesDowntime(hostname,
+                                                 start,
+                                                 end,
+                                                 fixed,
+                                                 triggeredby,
+                                                 duration,
+                                                 author,
+                                                 commentdata,
+                                                 entrytime,
+                                                 &response);
     std::cout << "ScheduleHostServicesDowntime " << status << std::endl;
-  }
-  else if (strcmp(argv[1], "ScheduleHostGroupHostsDowntime") == 0) {
+  } else if (strcmp(argv[1], "ScheduleHostGroupHostsDowntime") == 0) {
     CommandSuccess response;
     std::string hostgroupname(argv[2]);
     std::pair<bool, uint32_t> start;
@@ -1880,12 +1862,18 @@ int main(int argc, char** argv) {
     else
       entrytime = std::make_pair(true, atoi(argv[10]));
 
-    status = client.ScheduleHostGroupHostsDowntime(
-        hostgroupname, start, end, fixed, triggeredby, duration, author,
-        commentdata, entrytime, &response);
+    status = client.ScheduleHostGroupHostsDowntime(hostgroupname,
+                                                   start,
+                                                   end,
+                                                   fixed,
+                                                   triggeredby,
+                                                   duration,
+                                                   author,
+                                                   commentdata,
+                                                   entrytime,
+                                                   &response);
     std::cout << "ScheduleHostGroupHostsDowntime " << status << std::endl;
-  }
-  else if (strcmp(argv[1], "ScheduleHostGroupServicesDowntime") == 0) {
+  } else if (strcmp(argv[1], "ScheduleHostGroupServicesDowntime") == 0) {
     CommandSuccess response;
     std::string hostgroupname(argv[2]);
     std::pair<bool, uint32_t> start;
@@ -1926,12 +1914,18 @@ int main(int argc, char** argv) {
     else
       entrytime = std::make_pair(true, atoi(argv[10]));
 
-    status = client.ScheduleHostGroupServicesDowntime(
-        hostgroupname, start, end, fixed, triggeredby, duration, author,
-        commentdata, entrytime, &response);
+    status = client.ScheduleHostGroupServicesDowntime(hostgroupname,
+                                                      start,
+                                                      end,
+                                                      fixed,
+                                                      triggeredby,
+                                                      duration,
+                                                      author,
+                                                      commentdata,
+                                                      entrytime,
+                                                      &response);
     std::cout << "ScheduleHostGroupServicesDowntime " << status << std::endl;
-  }
-  else if (strcmp(argv[1], "ScheduleServiceGroupHostsDowntime") == 0) {
+  } else if (strcmp(argv[1], "ScheduleServiceGroupHostsDowntime") == 0) {
     CommandSuccess response;
     std::string servicegroupname(argv[2]);
     std::pair<bool, uint32_t> start;
@@ -1972,12 +1966,18 @@ int main(int argc, char** argv) {
     else
       entrytime = std::make_pair(true, atoi(argv[10]));
 
-    status = client.ScheduleServiceGroupHostsDowntime(
-        servicegroupname, start, end, fixed, triggeredby, duration, author,
-        commentdata, entrytime, &response);
+    status = client.ScheduleServiceGroupHostsDowntime(servicegroupname,
+                                                      start,
+                                                      end,
+                                                      fixed,
+                                                      triggeredby,
+                                                      duration,
+                                                      author,
+                                                      commentdata,
+                                                      entrytime,
+                                                      &response);
     std::cout << "ScheduleServiceGroupHostsDowntime " << status << std::endl;
-  }
-  else if (strcmp(argv[1], "ScheduleServiceGroupServicesDowntime") == 0) {
+  } else if (strcmp(argv[1], "ScheduleServiceGroupServicesDowntime") == 0) {
     CommandSuccess response;
     std::string servicegroupname(argv[2]);
     std::pair<bool, uint32_t> start;
@@ -2018,12 +2018,18 @@ int main(int argc, char** argv) {
     else
       entrytime = std::make_pair(true, atoi(argv[10]));
 
-    status = client.ScheduleServiceGroupServicesDowntime(
-        servicegroupname, start, end, fixed, triggeredby, duration, author,
-        commentdata, entrytime, &response);
+    status = client.ScheduleServiceGroupServicesDowntime(servicegroupname,
+                                                         start,
+                                                         end,
+                                                         fixed,
+                                                         triggeredby,
+                                                         duration,
+                                                         author,
+                                                         commentdata,
+                                                         entrytime,
+                                                         &response);
     std::cout << "ScheduleServiceGroupServicesDowntime " << status << std::endl;
-  }
-  else if (strcmp(argv[1], "ScheduleAndPropagateHostDowntime") == 0) {
+  } else if (strcmp(argv[1], "ScheduleAndPropagateHostDowntime") == 0) {
     CommandSuccess response;
     std::string hostname(argv[2]);
     std::pair<bool, uint32_t> start;
@@ -2064,12 +2070,18 @@ int main(int argc, char** argv) {
     else
       entrytime = std::make_pair(true, atoi(argv[10]));
 
-    status = client.ScheduleAndPropagateHostDowntime(
-        hostname, start, end, fixed, triggeredby, duration, author, commentdata,
-        entrytime, &response);
+    status = client.ScheduleAndPropagateHostDowntime(hostname,
+                                                     start,
+                                                     end,
+                                                     fixed,
+                                                     triggeredby,
+                                                     duration,
+                                                     author,
+                                                     commentdata,
+                                                     entrytime,
+                                                     &response);
     std::cout << "ScheduleAndPropagateHostDowntime " << status << std::endl;
-  }
-  else if (strcmp(argv[1], "ScheduleAndPropagateTriggeredHostDowntime") ==
+  } else if (strcmp(argv[1], "ScheduleAndPropagateTriggeredHostDowntime") ==
              0) {
     CommandSuccess response;
     std::string hostname(argv[2]);
@@ -2111,19 +2123,24 @@ int main(int argc, char** argv) {
     else
       entrytime = std::make_pair(true, atoi(argv[10]));
 
-    status = client.ScheduleAndPropagateTriggeredHostDowntime(
-        hostname, start, end, fixed, triggeredby, duration, author, commentdata,
-        entrytime, &response);
+    status = client.ScheduleAndPropagateTriggeredHostDowntime(hostname,
+                                                              start,
+                                                              end,
+                                                              fixed,
+                                                              triggeredby,
+                                                              duration,
+                                                              author,
+                                                              commentdata,
+                                                              entrytime,
+                                                              &response);
     std::cout << "ScheduleAndPropagateTriggeredHostDowntime " << status
               << std::endl;
-  }
-  else if (strcmp(argv[1], "DeleteDowntime") == 0) {
+  } else if (strcmp(argv[1], "DeleteDowntime") == 0) {
     CommandSuccess response;
     uint32_t downtimeid = atoi(argv[2]);
     status = client.DeleteDowntime(downtimeid, &response);
     std::cout << "DeleteDowntime" << std::endl;
-  }
-  else if (strcmp(argv[1], "DeleteDowntimeByHostName") == 0) {
+  } else if (strcmp(argv[1], "DeleteDowntimeByHostName") == 0) {
     CommandSuccess response;
     std::string hostname(argv[2]);
     std::string svcdsc;
@@ -2139,11 +2156,10 @@ int main(int argc, char** argv) {
     if (strcmp(argv[5], "undef") != 0)
       commentdata = argv[5];
 
-    status = client.DeleteDowntimeByHostName(hostname, svcdsc, start,
-                                             commentdata, &response);
+    status = client.DeleteDowntimeByHostName(
+        hostname, svcdsc, start, commentdata, &response);
     std::cout << "DeleteDowntimeByHostName" << std::endl;
-  }
-  else if (strcmp(argv[1], "DeleteDowntimeByStartTimeComment") == 0) {
+  } else if (strcmp(argv[1], "DeleteDowntimeByStartTimeComment") == 0) {
     CommandSuccess response;
     uint32_t start = atoi(argv[2]);
     std::string commentdata = argv[3];
@@ -2151,8 +2167,7 @@ int main(int argc, char** argv) {
     status =
         client.DeleteDowntimeByStartTimeComment(start, commentdata, &response);
     std::cout << "DeleteDowntimeByStartTimeComment" << std::endl;
-  }
-  else if (strcmp(argv[1], "DeleteDowntimeByHostGroupName") == 0) {
+  } else if (strcmp(argv[1], "DeleteDowntimeByHostGroupName") == 0) {
     CommandSuccess response;
     std::string hostgroupname(argv[2]);
     std::string hostname;
@@ -2173,8 +2188,7 @@ int main(int argc, char** argv) {
     status = client.DeleteDowntimeByHostGroupName(
         hostgroupname, hostname, svcdsc, commentdata, start, &response);
     std::cout << "DeleteDowntimeByHostGroupName" << std::endl;
-  }
-  else if (strcmp(argv[1], "DeleteHostDowntimeFull") == 0) {
+  } else if (strcmp(argv[1], "DeleteHostDowntimeFull") == 0) {
     CommandSuccess response;
     std::string hostname;
     std::string author;
@@ -2217,12 +2231,17 @@ int main(int argc, char** argv) {
     if (strcmp(argv[9], "undef") != 0)
       commentdata = argv[9];
 
-    status =
-        client.DeleteHostDowntimeFull(hostname, start, end, fixed, triggeredby,
-                                      duration, author, commentdata, &response);
+    status = client.DeleteHostDowntimeFull(hostname,
+                                           start,
+                                           end,
+                                           fixed,
+                                           triggeredby,
+                                           duration,
+                                           author,
+                                           commentdata,
+                                           &response);
     std::cout << "DeleteHostDowntimeFull" << std::endl;
-  }
-  else if (strcmp(argv[1], "DeleteServiceDowntimeFull") == 0) {
+  } else if (strcmp(argv[1], "DeleteServiceDowntimeFull") == 0) {
     CommandSuccess response;
     std::string hostname;
     std::string svcdsc;
@@ -2268,12 +2287,18 @@ int main(int argc, char** argv) {
     if (strcmp(argv[10], "undef") != 0)
       commentdata = argv[10];
 
-    status = client.DeleteServiceDowntimeFull(hostname, svcdsc, start, end,
-                                              fixed, triggeredby, duration,
-                                              author, commentdata, &response);
+    status = client.DeleteServiceDowntimeFull(hostname,
+                                              svcdsc,
+                                              start,
+                                              end,
+                                              fixed,
+                                              triggeredby,
+                                              duration,
+                                              author,
+                                              commentdata,
+                                              &response);
     std::cout << "DeleteServiceDowntimeFull" << std::endl;
-  }
-  else if (strcmp(argv[1], "DeleteDowntimeByHostName") == 0) {
+  } else if (strcmp(argv[1], "DeleteDowntimeByHostName") == 0) {
     CommandSuccess response;
     std::string hostname(argv[2]);
     std::string svcdsc;
@@ -2289,45 +2314,40 @@ int main(int argc, char** argv) {
     if (strcmp(argv[5], "undef") != 0)
       commentdata = argv[5];
 
-    status = client.DeleteDowntimeByHostName(hostname, svcdsc, start,
-                                             commentdata, &response);
+    status = client.DeleteDowntimeByHostName(
+        hostname, svcdsc, start, commentdata, &response);
     std::cout << "DeleteDowntimeByHostName" << std::endl;
-  }
-  else if (strcmp(argv[1], "ScheduleHostCheck") == 0) {
+  } else if (strcmp(argv[1], "ScheduleHostCheck") == 0) {
     CommandSuccess response;
     std::string hostname(argv[2]);
     uint32_t delaytime = atoi(argv[3]);
 
     status = client.ScheduleHostCheck(hostname, delaytime, &response);
     std::cout << "ScheduleHostCheck" << std::endl;
-  }
-  else if (strcmp(argv[1], "ScheduleHostServiceCheck") == 0) {
+  } else if (strcmp(argv[1], "ScheduleHostServiceCheck") == 0) {
     CommandSuccess response;
     std::string hostname(argv[2]);
     uint32_t delaytime = atoi(argv[3]);
 
     status = client.ScheduleHostServiceCheck(hostname, delaytime, &response);
     std::cout << "ScheduleHostServiceCheck" << std::endl;
-  }
-  else if (strcmp(argv[1], "ScheduleServiceCheck") == 0) {
+  } else if (strcmp(argv[1], "ScheduleServiceCheck") == 0) {
     CommandSuccess response;
     std::string hostname(argv[2]);
     std::string servicedesc(argv[3]);
     uint32_t delaytime = atoi(argv[4]);
 
-    status = client.ScheduleServiceCheck(hostname, servicedesc, delaytime,
-                                         &response);
+    status = client.ScheduleServiceCheck(
+        hostname, servicedesc, delaytime, &response);
     std::cout << "ScheduleServiceCheck" << std::endl;
-  }
-  else if (strcmp(argv[1], "SignalProcess") == 0) {
+  } else if (strcmp(argv[1], "SignalProcess") == 0) {
     CommandSuccess response;
     int process = atoi(argv[2]);
     uint32_t scheduledtime = atoi(argv[3]);
 
     status = client.SignalProcess(process, scheduledtime, &response);
     std::cout << "SignalProcess" << std::endl;
-  }
-  else if (strcmp(argv[1], "DelayHostNotification") == 0) {
+  } else if (strcmp(argv[1], "DelayHostNotification") == 0) {
     if (argc != 5) {
       std::cout
           << "RemoveHostAcknowledgement require arguments : "
@@ -2348,33 +2368,30 @@ int main(int argc, char** argv) {
       status = client.DelayHostNotificationById(hostid, delaytime, &response);
       std::cout << "DelayHostNotification" << std::endl;
     }
-  }
-  else if (strcmp(argv[1], "DelayServiceNotification") == 0) {
+  } else if (strcmp(argv[1], "DelayServiceNotification") == 0) {
     if (argc != 6) {
       std::cout << "RemoveHostAcknowledgement require arguments : "
                    "RemoveHostAcknowledgement [mode] [hostname or id] "
-                   "[servicename or id] [delay_time]"
-                << std::endl;
+                   "[servicename or id] [delay_time]" << std::endl;
       return 1;
     } else if (strcmp(argv[2], "bynames") == 0) {
       CommandSuccess response;
       std::string hostname(argv[3]);
       std::string svcdsc(argv[4]);
       uint32_t delaytime = atoi(argv[5]);
-      status = client.DelayServiceNotificationByNames(hostname, svcdsc,
-                                                      delaytime, &response);
+      status = client.DelayServiceNotificationByNames(
+          hostname, svcdsc, delaytime, &response);
       std::cout << "DelayServiceNotification" << std::endl;
     } else if (strcmp(argv[2], "byids") == 0) {
       CommandSuccess response;
       uint32_t hostid = atoi(argv[3]);
       uint32_t serviceid = atoi(argv[4]);
       uint32_t delaytime = atoi(argv[5]);
-      status = client.DelayServiceNotificationByIds(hostid, serviceid,
-                                                    delaytime, &response);
+      status = client.DelayServiceNotificationByIds(
+          hostid, serviceid, delaytime, &response);
       std::cout << "DelayServiceNotification" << std::endl;
     }
-  }
-  else if (strcmp(argv[1], "ChangeHostObjectIntVar") == 0) {
+  } else if (strcmp(argv[1], "ChangeHostObjectIntVar") == 0) {
     CommandSuccess response;
     std::string hostname(argv[2]);
     uint32_t mode = atoi(argv[3]);
@@ -2384,8 +2401,7 @@ int main(int argc, char** argv) {
     status =
         client.ChangeHostObjectIntVar(hostname, mode, intval, dval, &response);
     std::cout << "ChangeHostObjectIntVar" << std::endl;
-  }
-  else if (strcmp(argv[1], "ChangeServiceObjectIntVar") == 0) {
+  } else if (strcmp(argv[1], "ChangeServiceObjectIntVar") == 0) {
     CommandSuccess response;
     std::string hostname(argv[2]);
     std::string servicedesc(argv[3]);
@@ -2393,53 +2409,48 @@ int main(int argc, char** argv) {
     uint32_t intval = atoi(argv[5]);
     double dval = atof(argv[6]);
 
-    status = client.ChangeServiceObjectIntVar(hostname, servicedesc, mode,
-                                              intval, dval, &response);
+    status = client.ChangeServiceObjectIntVar(
+        hostname, servicedesc, mode, intval, dval, &response);
     std::cout << "ChangeServiceObjectIntVar" << std::endl;
-  }
-  else if (strcmp(argv[1], "ChangeContactObjectIntVar") == 0) {
+  } else if (strcmp(argv[1], "ChangeContactObjectIntVar") == 0) {
     CommandSuccess response;
     std::string contactname(argv[2]);
     uint32_t mode = atoi(argv[3]);
     uint32_t intval = atoi(argv[4]);
     double dval = atof(argv[5]);
 
-    status = client.ChangeContactObjectIntVar(contactname, mode, intval, dval,
-                                              &response);
+    status = client.ChangeContactObjectIntVar(
+        contactname, mode, intval, dval, &response);
     std::cout << "ChangeContactObjectIntVar" << std::endl;
-  }
-  else if (strcmp(argv[1], "ChangeHostObjectCustomVar") == 0) {
+  } else if (strcmp(argv[1], "ChangeHostObjectCustomVar") == 0) {
     CommandSuccess response;
     std::string hostname(argv[2]);
     std::string varname(argv[3]);
     std::string varvalue(argv[4]);
 
-    status = client.ChangeHostObjectCustomVar(hostname, varname, varvalue,
-                                              &response);
+    status = client.ChangeHostObjectCustomVar(
+        hostname, varname, varvalue, &response);
     std::cout << "ChangeHostObjectCustomVar" << std::endl;
-  }
-  else if (strcmp(argv[1], "ChangeServiceObjectCustomVar") == 0) {
+  } else if (strcmp(argv[1], "ChangeServiceObjectCustomVar") == 0) {
     CommandSuccess response;
     std::string hostname(argv[2]);
     std::string servicedesc(argv[3]);
     std::string varname(argv[4]);
     std::string varvalue(argv[5]);
 
-    status = client.ChangeServiceObjectCustomVar(hostname, servicedesc, varname,
-                                                 varvalue, &response);
+    status = client.ChangeServiceObjectCustomVar(
+        hostname, servicedesc, varname, varvalue, &response);
     std::cout << "ChangeServiceObjectCustomVar" << std::endl;
-  }
-  else if (strcmp(argv[1], "ChangeContactObjectCustomVar") == 0) {
+  } else if (strcmp(argv[1], "ChangeContactObjectCustomVar") == 0) {
     CommandSuccess response;
     std::string contact(argv[2]);
     std::string varname(argv[3]);
     std::string varvalue(argv[4]);
 
-    status = client.ChangeContactObjectCustomVar(contact, varname, varvalue,
-                                                 &response);
+    status = client.ChangeContactObjectCustomVar(
+        contact, varname, varvalue, &response);
     std::cout << "ChangeContactObjectCustomVar" << std::endl;
-  }
-  else if (strcmp(argv[1], "ChangeHostObjectCharVar") == 0) {
+  } else if (strcmp(argv[1], "ChangeHostObjectCharVar") == 0) {
     CommandSuccess response;
     std::string hostname(argv[2]);
     uint32_t mode = atoi(argv[3]);
@@ -2447,19 +2458,17 @@ int main(int argc, char** argv) {
 
     status = client.ChangeHostObjectCharVar(hostname, mode, charval, &response);
     std::cout << "ChangeHostObjectCharVar " << status << std::endl;
-  }
-  else if (strcmp(argv[1], "ChangeServiceObjectCharVar") == 0) {
+  } else if (strcmp(argv[1], "ChangeServiceObjectCharVar") == 0) {
     CommandSuccess response;
     std::string hostname(argv[2]);
     std::string servicedesc(argv[3]);
     uint32_t mode = atoi(argv[4]);
     std::string charval(argv[5]);
 
-    status = client.ChangeServiceObjectCharVar(hostname, servicedesc, mode,
-                                               charval, &response);
+    status = client.ChangeServiceObjectCharVar(
+        hostname, servicedesc, mode, charval, &response);
     std::cout << "ChangeServiceObjectCharVar " << status << std::endl;
-  }
-  else if (strcmp(argv[1], "ChangeContactObjectCharVar") == 0) {
+  } else if (strcmp(argv[1], "ChangeContactObjectCharVar") == 0) {
     CommandSuccess response;
     std::string contact(argv[2]);
     uint32_t mode = atoi(argv[3]);

--- a/tests/enginerpc/client.cc
+++ b/tests/enginerpc/client.cc
@@ -17,12 +17,12 @@
  *
  */
 
-#include <iostream>
-#include <memory>
 #include <grpc/grpc.h>
 #include <grpcpp/channel.h>
 #include <grpcpp/client_context.h>
 #include <grpcpp/create_channel.h>
+#include <iostream>
+#include <memory>
 #include "engine.grpc.pb.h"
 
 using namespace com::centreon::engine;
@@ -824,7 +824,8 @@ class EngineRPCClient {
         _stub->ScheduleAndPropagateHostDowntime(&context, request, response);
     if (!status.ok() || !response->value()) {
       std::cout << "ScheduleAndPropagateHostDowntime "
-                   "rpc engine failed" << std::endl;
+                   "rpc engine failed"
+                << std::endl;
       return false;
     }
     return true;
@@ -863,7 +864,8 @@ class EngineRPCClient {
         &context, request, response);
     if (!status.ok() || !response->value()) {
       std::cout << "ScheduleAndPropagateTriggeredHostDowntime "
-                   "rpc engine failed" << std::endl;
+                   "rpc engine failed"
+                << std::endl;
       return false;
     }
     return true;
@@ -1036,7 +1038,8 @@ class EngineRPCClient {
     grpc::Status status = _stub->ScheduleHostCheck(&context, request, response);
     if (!status.ok()) {
       std::cout << "ScheduleHostCheck"
-                   "rpc engine failed" << std::endl;
+                   "rpc engine failed"
+                << std::endl;
       return false;
     }
     return true;
@@ -1054,7 +1057,8 @@ class EngineRPCClient {
         _stub->ScheduleHostServiceCheck(&context, request, response);
     if (!status.ok()) {
       std::cout << "ScheduleHostServiceCheck"
-                   "rpc engine failed" << std::endl;
+                   "rpc engine failed"
+                << std::endl;
       return false;
     }
     return true;
@@ -1074,7 +1078,8 @@ class EngineRPCClient {
         _stub->ScheduleServiceCheck(&context, request, response);
     if (!status.ok()) {
       std::cout << "ScheduleServiceCheck"
-                   "rpc engine failed" << std::endl;
+                   "rpc engine failed"
+                << std::endl;
       return false;
     }
     return true;
@@ -1441,7 +1446,8 @@ int main(int argc, char** argv) {
   } else if (strcmp(argv[1], "GetService") == 0) {
     if (argc != 5) {
       std::cout << "GetService require arguments : GetService [mode] [hostname "
-                   "or hostid] [servicename or serviceid]" << std::endl;
+                   "or hostid] [servicename or serviceid]"
+                << std::endl;
       return 1;
     } else if (strcmp(argv[2], "bynames") == 0) {
       EngineService response;
@@ -1514,7 +1520,8 @@ int main(int argc, char** argv) {
       std::cout << "AddHostComment require arguments : "
                    "AddHostComment "
                    "[hostname] [user] [your_own_comment] [persistent] "
-                   "[entry_time]" << std::endl;
+                   "[entry_time]"
+                << std::endl;
       return 1;
     }
     CommandSuccess response;
@@ -1523,15 +1530,16 @@ int main(int argc, char** argv) {
     std::string commentdata = argv[4];
     bool persistent = atoi(argv[5]);
     uint32_t entrytime = atoi(argv[6]);
-    status = client.AddHostComment(
-        hostname, entrytime, user, commentdata, persistent, &response);
+    status = client.AddHostComment(hostname, entrytime, user, commentdata,
+                                   persistent, &response);
     std::cout << "AddHostComment" << std::endl;
   } else if (strcmp(argv[1], "AddServiceComment") == 0) {
     if (argc != 8) {
       std::cout << "AddHostComment require arguments : "
                    "AddHostComment "
                    "[hostname] [service_description] [user] [your_own_comment] "
-                   "[persistent] [entry_time]" << std::endl;
+                   "[persistent] [entry_time]"
+                << std::endl;
       return 1;
     }
     CommandSuccess response;
@@ -1541,13 +1549,14 @@ int main(int argc, char** argv) {
     std::string commentdata{argv[5]};
     bool persistent = atoi(argv[6]);
     uint32_t entrytime = atoi(argv[7]);
-    status = client.AddServiceComment(
-        hostname, svcdsc, entrytime, user, commentdata, persistent, &response);
+    status = client.AddServiceComment(hostname, svcdsc, entrytime, user,
+                                      commentdata, persistent, &response);
     std::cout << "AddServiceComment " << status << std::endl;
   } else if (strcmp(argv[1], "DeleteAllHostComments") == 0) {
     if (argc != 4) {
       std::cout << "DeleteAllHostComments require arguments : GetHost [mode] "
-                   "[hostname or id]" << std::endl;
+                   "[hostname or id]"
+                << std::endl;
       return 1;
     } else if (strcmp(argv[2], "byhostname") == 0) {
       CommandSuccess response;
@@ -1565,7 +1574,8 @@ int main(int argc, char** argv) {
       std::cout << "DeleteAllServiceComments require arguments : "
                    "DeleteAllServiceComments "
                    "[mode] [hostname "
-                   "or hostid] [servicename or serviceid]" << std::endl;
+                   "or hostid] [servicename or serviceid]"
+                << std::endl;
       return 1;
     } else if (strcmp(argv[2], "bynames") == 0) {
       CommandSuccess response;
@@ -1615,21 +1625,22 @@ int main(int argc, char** argv) {
       std::cout << "RemoveServiceAcknowledgement require arguments : "
                    "RemoveServiceAcknowledgement "
                    "[mode] [hostname "
-                   "or hostid] [servicename or serviceid]" << std::endl;
+                   "or hostid] [servicename or serviceid]"
+                << std::endl;
       return 1;
     } else if (strcmp(argv[2], "bynames") == 0) {
       CommandSuccess response;
       std::string hostname(argv[3]);
       std::string svcdsc(argv[4]);
-      status = client.RemoveServiceAcknowledgementByNames(
-          hostname, svcdsc, &response);
+      status = client.RemoveServiceAcknowledgementByNames(hostname, svcdsc,
+                                                          &response);
       std::cout << "RemoveServiceAcknowledgement" << std::endl;
     } else if (strcmp(argv[2], "byids") == 0) {
       CommandSuccess response;
       uint32_t hostid = atoi(argv[3]);
       uint32_t serviceid = atoi(argv[4]);
-      status = client.RemoveServiceAcknowledgementByIds(
-          hostid, serviceid, &response);
+      status = client.RemoveServiceAcknowledgementByIds(hostid, serviceid,
+                                                        &response);
       std::cout << "RemoveServiceAcknowledgement" << std::endl;
     }
   } else if (strcmp(argv[1], "AcknowledgementHostProblem") == 0) {
@@ -1654,14 +1665,9 @@ int main(int argc, char** argv) {
     bool notify = atoi(argv[7]);
     bool persistent = atoi(argv[8]);
 
-    status = client.AcknowledgementServiceProblem(hostname,
-                                                  servicedesc,
-                                                  ackauthor,
-                                                  ackdata,
-                                                  type,
-                                                  notify,
-                                                  persistent,
-                                                  &response);
+    status = client.AcknowledgementServiceProblem(
+        hostname, servicedesc, ackauthor, ackdata, type, notify, persistent,
+        &response);
     std::cout << "AcknowledgementServiceProblem" << std::endl;
   } else if (strcmp(argv[1], "ScheduleHostDowntime") == 0) {
     CommandSuccess response;
@@ -1704,16 +1710,9 @@ int main(int argc, char** argv) {
     else
       entrytime = std::make_pair(true, atoi(argv[10]));
 
-    status = client.ScheduleHostDowntime(hostname,
-                                         start,
-                                         end,
-                                         fixed,
-                                         triggeredby,
-                                         duration,
-                                         author,
-                                         commentdata,
-                                         entrytime,
-                                         &response);
+    status = client.ScheduleHostDowntime(hostname, start, end, fixed,
+                                         triggeredby, duration, author,
+                                         commentdata, entrytime, &response);
     std::cout << "ScheduleHostDowntime " << status << std::endl;
   } else if (strcmp(argv[1], "ScheduleServiceDowntime") == 0) {
     CommandSuccess response;
@@ -1757,17 +1756,9 @@ int main(int argc, char** argv) {
     else
       entrytime = std::make_pair(true, atoi(argv[11]));
 
-    status = client.ScheduleServiceDowntime(hostname,
-                                            svcdsc,
-                                            start,
-                                            end,
-                                            fixed,
-                                            triggeredby,
-                                            duration,
-                                            author,
-                                            commentdata,
-                                            entrytime,
-                                            &response);
+    status = client.ScheduleServiceDowntime(hostname, svcdsc, start, end, fixed,
+                                            triggeredby, duration, author,
+                                            commentdata, entrytime, &response);
     std::cout << "ScheduleServiceDowntime " << status << std::endl;
   } else if (strcmp(argv[1], "ScheduleHostServicesDowntime") == 0) {
     CommandSuccess response;
@@ -1810,16 +1801,9 @@ int main(int argc, char** argv) {
     else
       entrytime = std::make_pair(true, atoi(argv[10]));
 
-    status = client.ScheduleHostServicesDowntime(hostname,
-                                                 start,
-                                                 end,
-                                                 fixed,
-                                                 triggeredby,
-                                                 duration,
-                                                 author,
-                                                 commentdata,
-                                                 entrytime,
-                                                 &response);
+    status = client.ScheduleHostServicesDowntime(
+        hostname, start, end, fixed, triggeredby, duration, author, commentdata,
+        entrytime, &response);
     std::cout << "ScheduleHostServicesDowntime " << status << std::endl;
   } else if (strcmp(argv[1], "ScheduleHostGroupHostsDowntime") == 0) {
     CommandSuccess response;
@@ -1862,16 +1846,9 @@ int main(int argc, char** argv) {
     else
       entrytime = std::make_pair(true, atoi(argv[10]));
 
-    status = client.ScheduleHostGroupHostsDowntime(hostgroupname,
-                                                   start,
-                                                   end,
-                                                   fixed,
-                                                   triggeredby,
-                                                   duration,
-                                                   author,
-                                                   commentdata,
-                                                   entrytime,
-                                                   &response);
+    status = client.ScheduleHostGroupHostsDowntime(
+        hostgroupname, start, end, fixed, triggeredby, duration, author,
+        commentdata, entrytime, &response);
     std::cout << "ScheduleHostGroupHostsDowntime " << status << std::endl;
   } else if (strcmp(argv[1], "ScheduleHostGroupServicesDowntime") == 0) {
     CommandSuccess response;
@@ -1914,16 +1891,9 @@ int main(int argc, char** argv) {
     else
       entrytime = std::make_pair(true, atoi(argv[10]));
 
-    status = client.ScheduleHostGroupServicesDowntime(hostgroupname,
-                                                      start,
-                                                      end,
-                                                      fixed,
-                                                      triggeredby,
-                                                      duration,
-                                                      author,
-                                                      commentdata,
-                                                      entrytime,
-                                                      &response);
+    status = client.ScheduleHostGroupServicesDowntime(
+        hostgroupname, start, end, fixed, triggeredby, duration, author,
+        commentdata, entrytime, &response);
     std::cout << "ScheduleHostGroupServicesDowntime " << status << std::endl;
   } else if (strcmp(argv[1], "ScheduleServiceGroupHostsDowntime") == 0) {
     CommandSuccess response;
@@ -1966,16 +1936,9 @@ int main(int argc, char** argv) {
     else
       entrytime = std::make_pair(true, atoi(argv[10]));
 
-    status = client.ScheduleServiceGroupHostsDowntime(servicegroupname,
-                                                      start,
-                                                      end,
-                                                      fixed,
-                                                      triggeredby,
-                                                      duration,
-                                                      author,
-                                                      commentdata,
-                                                      entrytime,
-                                                      &response);
+    status = client.ScheduleServiceGroupHostsDowntime(
+        servicegroupname, start, end, fixed, triggeredby, duration, author,
+        commentdata, entrytime, &response);
     std::cout << "ScheduleServiceGroupHostsDowntime " << status << std::endl;
   } else if (strcmp(argv[1], "ScheduleServiceGroupServicesDowntime") == 0) {
     CommandSuccess response;
@@ -2018,16 +1981,9 @@ int main(int argc, char** argv) {
     else
       entrytime = std::make_pair(true, atoi(argv[10]));
 
-    status = client.ScheduleServiceGroupServicesDowntime(servicegroupname,
-                                                         start,
-                                                         end,
-                                                         fixed,
-                                                         triggeredby,
-                                                         duration,
-                                                         author,
-                                                         commentdata,
-                                                         entrytime,
-                                                         &response);
+    status = client.ScheduleServiceGroupServicesDowntime(
+        servicegroupname, start, end, fixed, triggeredby, duration, author,
+        commentdata, entrytime, &response);
     std::cout << "ScheduleServiceGroupServicesDowntime " << status << std::endl;
   } else if (strcmp(argv[1], "ScheduleAndPropagateHostDowntime") == 0) {
     CommandSuccess response;
@@ -2070,16 +2026,9 @@ int main(int argc, char** argv) {
     else
       entrytime = std::make_pair(true, atoi(argv[10]));
 
-    status = client.ScheduleAndPropagateHostDowntime(hostname,
-                                                     start,
-                                                     end,
-                                                     fixed,
-                                                     triggeredby,
-                                                     duration,
-                                                     author,
-                                                     commentdata,
-                                                     entrytime,
-                                                     &response);
+    status = client.ScheduleAndPropagateHostDowntime(
+        hostname, start, end, fixed, triggeredby, duration, author, commentdata,
+        entrytime, &response);
     std::cout << "ScheduleAndPropagateHostDowntime " << status << std::endl;
   } else if (strcmp(argv[1], "ScheduleAndPropagateTriggeredHostDowntime") ==
              0) {
@@ -2123,16 +2072,9 @@ int main(int argc, char** argv) {
     else
       entrytime = std::make_pair(true, atoi(argv[10]));
 
-    status = client.ScheduleAndPropagateTriggeredHostDowntime(hostname,
-                                                              start,
-                                                              end,
-                                                              fixed,
-                                                              triggeredby,
-                                                              duration,
-                                                              author,
-                                                              commentdata,
-                                                              entrytime,
-                                                              &response);
+    status = client.ScheduleAndPropagateTriggeredHostDowntime(
+        hostname, start, end, fixed, triggeredby, duration, author, commentdata,
+        entrytime, &response);
     std::cout << "ScheduleAndPropagateTriggeredHostDowntime " << status
               << std::endl;
   } else if (strcmp(argv[1], "DeleteDowntime") == 0) {
@@ -2156,8 +2098,8 @@ int main(int argc, char** argv) {
     if (strcmp(argv[5], "undef") != 0)
       commentdata = argv[5];
 
-    status = client.DeleteDowntimeByHostName(
-        hostname, svcdsc, start, commentdata, &response);
+    status = client.DeleteDowntimeByHostName(hostname, svcdsc, start,
+                                             commentdata, &response);
     std::cout << "DeleteDowntimeByHostName" << std::endl;
   } else if (strcmp(argv[1], "DeleteDowntimeByStartTimeComment") == 0) {
     CommandSuccess response;
@@ -2231,15 +2173,9 @@ int main(int argc, char** argv) {
     if (strcmp(argv[9], "undef") != 0)
       commentdata = argv[9];
 
-    status = client.DeleteHostDowntimeFull(hostname,
-                                           start,
-                                           end,
-                                           fixed,
-                                           triggeredby,
-                                           duration,
-                                           author,
-                                           commentdata,
-                                           &response);
+    status =
+        client.DeleteHostDowntimeFull(hostname, start, end, fixed, triggeredby,
+                                      duration, author, commentdata, &response);
     std::cout << "DeleteHostDowntimeFull" << std::endl;
   } else if (strcmp(argv[1], "DeleteServiceDowntimeFull") == 0) {
     CommandSuccess response;
@@ -2287,16 +2223,9 @@ int main(int argc, char** argv) {
     if (strcmp(argv[10], "undef") != 0)
       commentdata = argv[10];
 
-    status = client.DeleteServiceDowntimeFull(hostname,
-                                              svcdsc,
-                                              start,
-                                              end,
-                                              fixed,
-                                              triggeredby,
-                                              duration,
-                                              author,
-                                              commentdata,
-                                              &response);
+    status = client.DeleteServiceDowntimeFull(hostname, svcdsc, start, end,
+                                              fixed, triggeredby, duration,
+                                              author, commentdata, &response);
     std::cout << "DeleteServiceDowntimeFull" << std::endl;
   } else if (strcmp(argv[1], "DeleteDowntimeByHostName") == 0) {
     CommandSuccess response;
@@ -2314,8 +2243,8 @@ int main(int argc, char** argv) {
     if (strcmp(argv[5], "undef") != 0)
       commentdata = argv[5];
 
-    status = client.DeleteDowntimeByHostName(
-        hostname, svcdsc, start, commentdata, &response);
+    status = client.DeleteDowntimeByHostName(hostname, svcdsc, start,
+                                             commentdata, &response);
     std::cout << "DeleteDowntimeByHostName" << std::endl;
   } else if (strcmp(argv[1], "ScheduleHostCheck") == 0) {
     CommandSuccess response;
@@ -2337,8 +2266,8 @@ int main(int argc, char** argv) {
     std::string servicedesc(argv[3]);
     uint32_t delaytime = atoi(argv[4]);
 
-    status = client.ScheduleServiceCheck(
-        hostname, servicedesc, delaytime, &response);
+    status = client.ScheduleServiceCheck(hostname, servicedesc, delaytime,
+                                         &response);
     std::cout << "ScheduleServiceCheck" << std::endl;
   } else if (strcmp(argv[1], "SignalProcess") == 0) {
     CommandSuccess response;
@@ -2372,23 +2301,24 @@ int main(int argc, char** argv) {
     if (argc != 6) {
       std::cout << "RemoveHostAcknowledgement require arguments : "
                    "RemoveHostAcknowledgement [mode] [hostname or id] "
-                   "[servicename or id] [delay_time]" << std::endl;
+                   "[servicename or id] [delay_time]"
+                << std::endl;
       return 1;
     } else if (strcmp(argv[2], "bynames") == 0) {
       CommandSuccess response;
       std::string hostname(argv[3]);
       std::string svcdsc(argv[4]);
       uint32_t delaytime = atoi(argv[5]);
-      status = client.DelayServiceNotificationByNames(
-          hostname, svcdsc, delaytime, &response);
+      status = client.DelayServiceNotificationByNames(hostname, svcdsc,
+                                                      delaytime, &response);
       std::cout << "DelayServiceNotification" << std::endl;
     } else if (strcmp(argv[2], "byids") == 0) {
       CommandSuccess response;
       uint32_t hostid = atoi(argv[3]);
       uint32_t serviceid = atoi(argv[4]);
       uint32_t delaytime = atoi(argv[5]);
-      status = client.DelayServiceNotificationByIds(
-          hostid, serviceid, delaytime, &response);
+      status = client.DelayServiceNotificationByIds(hostid, serviceid,
+                                                    delaytime, &response);
       std::cout << "DelayServiceNotification" << std::endl;
     }
   } else if (strcmp(argv[1], "ChangeHostObjectIntVar") == 0) {
@@ -2409,8 +2339,8 @@ int main(int argc, char** argv) {
     uint32_t intval = atoi(argv[5]);
     double dval = atof(argv[6]);
 
-    status = client.ChangeServiceObjectIntVar(
-        hostname, servicedesc, mode, intval, dval, &response);
+    status = client.ChangeServiceObjectIntVar(hostname, servicedesc, mode,
+                                              intval, dval, &response);
     std::cout << "ChangeServiceObjectIntVar" << std::endl;
   } else if (strcmp(argv[1], "ChangeContactObjectIntVar") == 0) {
     CommandSuccess response;
@@ -2419,8 +2349,8 @@ int main(int argc, char** argv) {
     uint32_t intval = atoi(argv[4]);
     double dval = atof(argv[5]);
 
-    status = client.ChangeContactObjectIntVar(
-        contactname, mode, intval, dval, &response);
+    status = client.ChangeContactObjectIntVar(contactname, mode, intval, dval,
+                                              &response);
     std::cout << "ChangeContactObjectIntVar" << std::endl;
   } else if (strcmp(argv[1], "ChangeHostObjectCustomVar") == 0) {
     CommandSuccess response;
@@ -2428,8 +2358,8 @@ int main(int argc, char** argv) {
     std::string varname(argv[3]);
     std::string varvalue(argv[4]);
 
-    status = client.ChangeHostObjectCustomVar(
-        hostname, varname, varvalue, &response);
+    status = client.ChangeHostObjectCustomVar(hostname, varname, varvalue,
+                                              &response);
     std::cout << "ChangeHostObjectCustomVar" << std::endl;
   } else if (strcmp(argv[1], "ChangeServiceObjectCustomVar") == 0) {
     CommandSuccess response;
@@ -2438,8 +2368,8 @@ int main(int argc, char** argv) {
     std::string varname(argv[4]);
     std::string varvalue(argv[5]);
 
-    status = client.ChangeServiceObjectCustomVar(
-        hostname, servicedesc, varname, varvalue, &response);
+    status = client.ChangeServiceObjectCustomVar(hostname, servicedesc, varname,
+                                                 varvalue, &response);
     std::cout << "ChangeServiceObjectCustomVar" << std::endl;
   } else if (strcmp(argv[1], "ChangeContactObjectCustomVar") == 0) {
     CommandSuccess response;
@@ -2447,8 +2377,8 @@ int main(int argc, char** argv) {
     std::string varname(argv[3]);
     std::string varvalue(argv[4]);
 
-    status = client.ChangeContactObjectCustomVar(
-        contact, varname, varvalue, &response);
+    status = client.ChangeContactObjectCustomVar(contact, varname, varvalue,
+                                                 &response);
     std::cout << "ChangeContactObjectCustomVar" << std::endl;
   } else if (strcmp(argv[1], "ChangeHostObjectCharVar") == 0) {
     CommandSuccess response;
@@ -2465,8 +2395,8 @@ int main(int argc, char** argv) {
     uint32_t mode = atoi(argv[4]);
     std::string charval(argv[5]);
 
-    status = client.ChangeServiceObjectCharVar(
-        hostname, servicedesc, mode, charval, &response);
+    status = client.ChangeServiceObjectCharVar(hostname, servicedesc, mode,
+                                               charval, &response);
     std::cout << "ChangeServiceObjectCharVar " << status << std::endl;
   } else if (strcmp(argv[1], "ChangeContactObjectCharVar") == 0) {
     CommandSuccess response;

--- a/tests/notifications/service_normal_notification.cc
+++ b/tests/notifications/service_normal_notification.cc
@@ -114,8 +114,8 @@ TEST_F(ServiceNotification, SimpleNormalServiceNotification) {
     tperiod->days[i].push_back(std::make_shared<engine::timerange>(0, 86400));
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
-      new engine::serviceescalation(
-          "test_host", "test_svc", 0, 1, 1.0, "tperiod", 7, Uuid())};
+      new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0,
+                                    "tperiod", 7, Uuid())};
   _svc->set_current_state(engine::service::state_critical);
   _svc->set_last_state(engine::service::state_critical);
   _svc->set_last_hard_state_change(43200);
@@ -124,10 +124,9 @@ TEST_F(ServiceNotification, SimpleNormalServiceNotification) {
   ASSERT_TRUE(service_escalation);
   uint64_t id{_svc->get_next_notification_id()};
   _svc->set_notification_period_ptr(tperiod.get());
-  ASSERT_EQ(
-      _svc->notify(
-          notifier::reason_normal, "", "", notifier::notification_option_none),
-      OK);
+  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
+                         notifier::notification_option_none),
+            OK);
   ASSERT_EQ(id + 1, _svc->get_next_notification_id());
 }
 
@@ -144,16 +143,15 @@ TEST_F(ServiceNotification,
     tperiod->days[i].push_back(std::make_shared<engine::timerange>(0, 86400));
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
-      new engine::serviceescalation(
-          "test_host", "test_svc", 0, 1, 1.0, "tperiod", 7, Uuid())};
+      new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0,
+                                    "tperiod", 7, Uuid())};
 
   ASSERT_TRUE(service_escalation);
   uint64_t id{_svc->get_next_notification_id()};
   _svc->set_notification_period_ptr(tperiod.get());
-  ASSERT_EQ(
-      _svc->notify(
-          notifier::reason_normal, "", "", notifier::notification_option_none),
-      OK);
+  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
+                         notifier::notification_option_none),
+            OK);
   ASSERT_EQ(id, _svc->get_next_notification_id());
 }
 
@@ -169,17 +167,16 @@ TEST_F(ServiceNotification,
     tperiod->days[i].push_back(std::make_shared<engine::timerange>(0, 86400));
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
-      new engine::serviceescalation(
-          "test_host", "test_svc", 0, 1, 1.0, "tperiod", 7, Uuid())};
+      new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0,
+                                    "tperiod", 7, Uuid())};
 
   ASSERT_TRUE(service_escalation);
   uint64_t id{_svc->get_next_notification_id()};
   _svc->set_notifications_enabled(false);
   _svc->set_notification_period_ptr(tperiod.get());
-  ASSERT_EQ(
-      _svc->notify(
-          notifier::reason_normal, "", "", notifier::notification_option_none),
-      OK);
+  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
+                         notifier::notification_option_none),
+            OK);
   ASSERT_EQ(id, _svc->get_next_notification_id());
 }
 
@@ -190,19 +187,18 @@ TEST_F(ServiceNotification, SimpleNormalServiceNotificationOutsideTimeperiod) {
 
   uint64_t id{_svc->get_next_notification_id()};
   for (int i = 0; i < 7; ++i)
-    tperiod->days[i]
-        .push_back(std::make_shared<engine::timerange>(43200, 86400));
+    tperiod->days[i].push_back(
+        std::make_shared<engine::timerange>(43200, 86400));
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
-      new engine::serviceescalation(
-          "test_host", "test_svc", 0, 1, 1.0, "", 7, Uuid())};
+      new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0, "", 7,
+                                    Uuid())};
   _svc->set_notification_period_ptr(tperiod.get());
 
   ASSERT_TRUE(service_escalation);
-  ASSERT_EQ(
-      _svc->notify(
-          notifier::reason_normal, "", "", notifier::notification_option_none),
-      OK);
+  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
+                         notifier::notification_option_none),
+            OK);
   ASSERT_EQ(id, _svc->get_next_notification_id());
 }
 
@@ -215,18 +211,16 @@ TEST_F(ServiceNotification,
 
   uint64_t id{_svc->get_next_notification_id()};
   for (int i = 0; i < 7; ++i)
-    tperiod->days[i]
-        .push_back(std::make_shared<engine::timerange>(43200, 86400));
+    tperiod->days[i].push_back(
+        std::make_shared<engine::timerange>(43200, 86400));
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
-      new engine::serviceescalation(
-          "test_host", "test_svc", 0, 1, 1.0, "", 7, Uuid())};
+      new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0, "", 7,
+                                    Uuid())};
   _svc->set_notification_period_ptr(tperiod.get());
 
   ASSERT_TRUE(service_escalation);
-  ASSERT_EQ(_svc->notify(notifier::reason_normal,
-                         "",
-                         "",
+  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
                          notifier::notification_option_forced),
             OK);
   ASSERT_EQ(id + 1, _svc->get_next_notification_id());
@@ -239,18 +233,16 @@ TEST_F(ServiceNotification, SimpleNormalServiceNotificationForcedNotification) {
 
   uint64_t id{_svc->get_next_notification_id()};
   for (int i = 0; i < 7; ++i)
-    tperiod->days[i]
-        .push_back(std::make_shared<engine::timerange>(43200, 86400));
+    tperiod->days[i].push_back(
+        std::make_shared<engine::timerange>(43200, 86400));
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
-      new engine::serviceescalation(
-          "test_host", "test_svc", 0, 1, 1.0, "", 7, Uuid())};
+      new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0, "", 7,
+                                    Uuid())};
   _svc->set_notification_period_ptr(tperiod.get());
 
   ASSERT_TRUE(service_escalation);
-  ASSERT_EQ(_svc->notify(notifier::reason_normal,
-                         "",
-                         "",
+  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
                          notifier::notification_option_forced),
             OK);
   ASSERT_EQ(id + 1, _svc->get_next_notification_id());
@@ -267,15 +259,14 @@ TEST_F(ServiceNotification, SimpleNormalServiceNotificationWithDowntime) {
     tperiod->days[i].push_back(std::make_shared<engine::timerange>(0, 86400));
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
-      new engine::serviceescalation(
-          "test_host", "test_svc", 0, 1, 1.0, "", 7, Uuid())};
+      new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0, "", 7,
+                                    Uuid())};
   _svc->set_notification_period_ptr(tperiod.get());
 
   ASSERT_TRUE(service_escalation);
-  ASSERT_EQ(
-      _svc->notify(
-          notifier::reason_normal, "", "", notifier::notification_option_none),
-      OK);
+  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
+                         notifier::notification_option_none),
+            OK);
   ASSERT_EQ(id, _svc->get_next_notification_id());
 }
 
@@ -290,15 +281,14 @@ TEST_F(ServiceNotification, SimpleNormalServiceNotificationWithFlapping) {
     tperiod->days[i].push_back(std::make_shared<engine::timerange>(0, 86400));
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
-      new engine::serviceescalation(
-          "test_host", "test_svc", 0, 1, 1.0, "", 7, Uuid())};
+      new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0, "", 7,
+                                    Uuid())};
   _svc->set_notification_period_ptr(tperiod.get());
 
   ASSERT_TRUE(service_escalation);
-  ASSERT_EQ(
-      _svc->notify(
-          notifier::reason_normal, "", "", notifier::notification_option_none),
-      OK);
+  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
+                         notifier::notification_option_none),
+            OK);
   ASSERT_EQ(id, _svc->get_next_notification_id());
 }
 
@@ -313,15 +303,14 @@ TEST_F(ServiceNotification, SimpleNormalServiceNotificationWithSoftState) {
     tperiod->days[i].push_back(std::make_shared<engine::timerange>(0, 86400));
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
-      new engine::serviceescalation(
-          "test_host", "test_svc", 0, 1, 1.0, "", 7, Uuid())};
+      new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0, "", 7,
+                                    Uuid())};
   _svc->set_notification_period_ptr(tperiod.get());
 
   ASSERT_TRUE(service_escalation);
-  ASSERT_EQ(
-      _svc->notify(
-          notifier::reason_normal, "", "", notifier::notification_option_none),
-      OK);
+  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
+                         notifier::notification_option_none),
+            OK);
   ASSERT_EQ(id, _svc->get_next_notification_id());
 }
 
@@ -336,16 +325,15 @@ TEST_F(ServiceNotification,
     tperiod->days[i].push_back(std::make_shared<engine::timerange>(0, 86400));
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
-      new engine::serviceescalation(
-          "test_host", "test_svc", 0, 1, 1.0, "", 7, Uuid())};
+      new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0, "", 7,
+                                    Uuid())};
   _svc->set_notification_period_ptr(tperiod.get());
 
   _svc->set_problem_has_been_acknowledged(true);
   ASSERT_TRUE(service_escalation);
-  ASSERT_EQ(
-      _svc->notify(
-          notifier::reason_normal, "", "", notifier::notification_option_none),
-      OK);
+  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
+                         notifier::notification_option_none),
+            OK);
   ASSERT_EQ(id, _svc->get_next_notification_id());
 }
 
@@ -360,17 +348,16 @@ TEST_F(ServiceNotification,
     tperiod->days[i].push_back(std::make_shared<engine::timerange>(0, 86400));
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
-      new engine::serviceescalation(
-          "test_host", "test_svc", 0, 1, 1.0, "", 7, Uuid())};
+      new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0, "", 7,
+                                    Uuid())};
   _svc->set_notification_period_ptr(tperiod.get());
 
   _svc->set_problem_has_been_acknowledged(true);
   ASSERT_TRUE(service_escalation);
   _svc->set_last_notification(19999);
-  ASSERT_EQ(
-      _svc->notify(
-          notifier::reason_normal, "", "", notifier::notification_option_none),
-      OK);
+  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
+                         notifier::notification_option_none),
+            OK);
   ASSERT_EQ(id, _svc->get_next_notification_id());
 }
 
@@ -385,8 +372,8 @@ TEST_F(ServiceNotification,
     tperiod->days[i].push_back(std::make_shared<engine::timerange>(0, 86400));
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
-      new engine::serviceescalation(
-          "test_host", "test_svc", 0, 1, 1.0, "", 7, Uuid())};
+      new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0, "", 7,
+                                    Uuid())};
   _svc->set_notification_period_ptr(tperiod.get());
 
   _svc->set_problem_has_been_acknowledged(true);
@@ -394,10 +381,9 @@ TEST_F(ServiceNotification,
   _svc->set_last_notification(19500);
   _svc->set_notification_number(1);
   _svc->set_notification_interval(0);
-  ASSERT_EQ(
-      _svc->notify(
-          notifier::reason_normal, "", "", notifier::notification_option_none),
-      OK);
+  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
+                         notifier::notification_option_none),
+            OK);
   ASSERT_EQ(id, _svc->get_next_notification_id());
 }
 
@@ -411,18 +397,17 @@ TEST_F(ServiceNotification, SimpleNormalServiceNotificationOnStateNotNotified) {
     tperiod->days[i].push_back(std::make_shared<engine::timerange>(0, 86400));
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
-      new engine::serviceescalation(
-          "test_host", "test_svc", 0, 1, 1.0, "", 7, Uuid())};
+      new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0, "", 7,
+                                    Uuid())};
   _svc->set_notification_period_ptr(tperiod.get());
 
   _svc->set_problem_has_been_acknowledged(false);
   ASSERT_TRUE(service_escalation);
   _svc->remove_notify_on(notifier::critical);
   _svc->set_current_state(engine::service::state_critical);
-  ASSERT_EQ(
-      _svc->notify(
-          notifier::reason_normal, "", "", notifier::notification_option_none),
-      OK);
+  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
+                         notifier::notification_option_none),
+            OK);
   ASSERT_EQ(id, _svc->get_next_notification_id());
 }
 
@@ -437,8 +422,8 @@ TEST_F(ServiceNotification,
     tperiod->days[i].push_back(std::make_shared<engine::timerange>(0, 86400));
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
-      new engine::serviceescalation(
-          "test_host", "test_svc", 0, 1, 1.0, "", 7, Uuid())};
+      new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0, "", 7,
+                                    Uuid())};
   _svc->set_notification_period_ptr(tperiod.get());
 
   _svc->set_problem_has_been_acknowledged(false);
@@ -447,10 +432,9 @@ TEST_F(ServiceNotification,
   _svc->set_last_hard_state_change(20000 - 200);
   /* It is multiplicated by config->interval_length(): we set 5 for 5*60 */
   _svc->set_first_notification_delay(5);
-  ASSERT_EQ(
-      _svc->notify(
-          notifier::reason_normal, "", "", notifier::notification_option_none),
-      OK);
+  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
+                         notifier::notification_option_none),
+            OK);
   ASSERT_EQ(id, _svc->get_next_notification_id());
 }
 
@@ -465,8 +449,8 @@ TEST_F(ServiceNotification,
     tperiod->days[i].push_back(std::make_shared<engine::timerange>(0, 86400));
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
-      new engine::serviceescalation(
-          "test_host", "test_svc", 0, 1, 1.0, "", 7, Uuid())};
+      new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0, "", 7,
+                                    Uuid())};
   _svc->set_notification_period_ptr(tperiod.get());
 
   _svc->set_problem_has_been_acknowledged(false);
@@ -474,10 +458,9 @@ TEST_F(ServiceNotification,
   _svc->set_current_state(engine::service::state_critical);
   _svc->set_last_hard_state_change(20000 - 400);
   _svc->set_first_notification_delay(5);
-  ASSERT_EQ(
-      _svc->notify(
-          notifier::reason_normal, "", "", notifier::notification_option_none),
-      OK);
+  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
+                         notifier::notification_option_none),
+            OK);
   ASSERT_EQ(id + 1, _svc->get_next_notification_id());
 }
 
@@ -493,8 +476,8 @@ TEST_F(ServiceNotification,
     tperiod->days[i].push_back(std::make_shared<engine::timerange>(0, 86400));
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
-      new engine::serviceescalation(
-          "test_host", "test_svc", 0, 1, 1.0, "tperiod", 7, Uuid())};
+      new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0,
+                                    "tperiod", 7, Uuid())};
 
   _svc->set_current_state(engine::service::state_critical);
   _svc->set_last_state(engine::service::state_critical);
@@ -505,10 +488,9 @@ TEST_F(ServiceNotification,
   /* We configure the notification interval to 2 minutes */
   _svc->set_notification_interval(2);
   _svc->set_notification_period_ptr(tperiod.get());
-  ASSERT_EQ(
-      _svc->notify(
-          notifier::reason_normal, "", "", notifier::notification_option_none),
-      OK);
+  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
+                         notifier::notification_option_none),
+            OK);
   ASSERT_EQ(id + 1, _svc->get_next_notification_id());
 
   /* Only 100 seconds since the previous notification. */
@@ -516,10 +498,9 @@ TEST_F(ServiceNotification,
   id = _svc->get_next_notification_id();
   /* Because of the notification not totally implemented, we must force the
    * notification number to be greater than 0 */
-  ASSERT_EQ(
-      _svc->notify(
-          notifier::reason_normal, "", "", notifier::notification_option_none),
-      OK);
+  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
+                         notifier::notification_option_none),
+            OK);
 
   /* No notification, because the delay is too short */
   ASSERT_EQ(id, _svc->get_next_notification_id());
@@ -564,19 +545,19 @@ TEST_F(ServiceNotification, SimpleCheck) {
   std::string out{testing::internal::GetCapturedStdout()};
   size_t step1{out.find(
       "SERVICE ALERT: test_host;test_svc;CRITICAL;HARD;3;service down")};
-  size_t step2{out.find(
-      "SERVICE NOTIFICATION: "
-      "admin;test_host;test_svc;CRITICAL;cmd;service down",
-      step1 + 1)};
-  size_t step3{out.find(
-      "SERVICE NOTIFICATION: "
-      "admin;test_host;test_svc;CRITICAL;cmd;service down",
-      step2 + 1)};
+  size_t step2{
+      out.find("SERVICE NOTIFICATION: "
+               "admin;test_host;test_svc;CRITICAL;cmd;service down",
+               step1 + 1)};
+  size_t step3{
+      out.find("SERVICE NOTIFICATION: "
+               "admin;test_host;test_svc;CRITICAL;cmd;service down",
+               step2 + 1)};
   // Sent when i == 0 on the second loop.
-  size_t step4{out.find(
-      "SERVICE NOTIFICATION: admin;test_host;test_svc;RECOVERY "
-      "(OK);cmd;service ok",
-      step2 + 1)};
+  size_t step4{
+      out.find("SERVICE NOTIFICATION: admin;test_host;test_svc;RECOVERY "
+               "(OK);cmd;service ok",
+               step2 + 1)};
   ASSERT_EQ(step3, std::string::npos);
   ASSERT_NE(step4, std::string::npos);
 }
@@ -623,19 +604,19 @@ TEST_F(ServiceNotification, CheckFirstNotificationDelay) {
   }
   std::string out{testing::internal::GetCapturedStdout()};
   size_t m1{out.find("Step 5:")};
-  size_t m2{out.find(
-      " SERVICE NOTIFICATION: "
-      "admin;test_host;test_svc;DOWN;cmd;service critical",
-      m1 + 1)};
+  size_t m2{
+      out.find(" SERVICE NOTIFICATION: "
+               "admin;test_host;test_svc;DOWN;cmd;service critical",
+               m1 + 1)};
   size_t m3{out.find("Step 35:", m2 + 1)};
-  size_t m4{out.find(
-      " SERVICE NOTIFICATION: "
-      "admin;test_host;test_svc;DOWN;cmd;service critical",
-      m3 + 1)};
-  size_t m5{out.find(
-      " SERVICE NOTIFICATION: admin;test_host;test_svc;RECOVERY "
-      "(OK);cmd;service ok",
-      m4 + 1)};
+  size_t m4{
+      out.find(" SERVICE NOTIFICATION: "
+               "admin;test_host;test_svc;DOWN;cmd;service critical",
+               m3 + 1)};
+  size_t m5{
+      out.find(" SERVICE NOTIFICATION: admin;test_host;test_svc;RECOVERY "
+               "(OK);cmd;service ok",
+               m4 + 1)};
   ASSERT_NE(m5, std::string::npos);
 }
 
@@ -684,19 +665,19 @@ TEST_F(ServiceNotification, CheckNotifIntervZero) {
   std::string out{testing::internal::GetCapturedStdout()};
   size_t step1{out.find(
       "SERVICE ALERT: test_host;test_svc;CRITICAL;HARD;3;service down")};
-  size_t step2{out.find(
-      "SERVICE NOTIFICATION: "
-      "admin;test_host;test_svc;CRITICAL;cmd;service down",
-      step1 + 1)};
-  size_t step3{out.find(
-      "SERVICE NOTIFICATION: "
-      "admin;test_host;test_svc;CRITICAL;cmd;service down",
-      step2 + 1)};
+  size_t step2{
+      out.find("SERVICE NOTIFICATION: "
+               "admin;test_host;test_svc;CRITICAL;cmd;service down",
+               step1 + 1)};
+  size_t step3{
+      out.find("SERVICE NOTIFICATION: "
+               "admin;test_host;test_svc;CRITICAL;cmd;service down",
+               step2 + 1)};
   // Sent when i == 0 on the second loop.
-  size_t step4{out.find(
-      "SERVICE NOTIFICATION: admin;test_host;test_svc;RECOVERY "
-      "(OK);cmd;service ok",
-      step2 + 1)};
+  size_t step4{
+      out.find("SERVICE NOTIFICATION: admin;test_host;test_svc;RECOVERY "
+               "(OK);cmd;service ok",
+               step2 + 1)};
   ASSERT_EQ(step3, std::string::npos);
   ASSERT_NE(step4, std::string::npos);
 }
@@ -754,21 +735,21 @@ TEST_F(ServiceNotification, NormalRecoveryTwoTimes) {
   }
 
   std::string out{testing::internal::GetCapturedStdout()};
-  size_t step1{out.find(
-      "SERVICE NOTIFICATION: "
-      "admin;test_host;test_svc;CRITICAL;cmd;service critical")};
-  size_t step2{out.find(
-      "SERVICE NOTIFICATION: admin;test_host;test_svc;RECOVERY "
-      "(OK);cmd;service ok",
-      step1 + 1)};
-  size_t step3{out.find(
-      "SERVICE NOTIFICATION: "
-      "admin;test_host;test_svc;CRITICAL;cmd;service critical",
-      step2 + 1)};
-  size_t step4{out.find(
-      "SERVICE NOTIFICATION: admin;test_host;test_svc;RECOVERY "
-      "(OK);cmd;service ok",
-      step3 + 1)};
+  size_t step1{
+      out.find("SERVICE NOTIFICATION: "
+               "admin;test_host;test_svc;CRITICAL;cmd;service critical")};
+  size_t step2{
+      out.find("SERVICE NOTIFICATION: admin;test_host;test_svc;RECOVERY "
+               "(OK);cmd;service ok",
+               step1 + 1)};
+  size_t step3{
+      out.find("SERVICE NOTIFICATION: "
+               "admin;test_host;test_svc;CRITICAL;cmd;service critical",
+               step2 + 1)};
+  size_t step4{
+      out.find("SERVICE NOTIFICATION: admin;test_host;test_svc;RECOVERY "
+               "(OK);cmd;service ok",
+               step3 + 1)};
   ASSERT_NE(step4, std::string::npos);
 }
 
@@ -841,17 +822,16 @@ TEST_F(ServiceNotification, ServiceEscalationCG) {
     std::string outNOTIFICATIONNUMBER;
     std::string outNOTIFICATIONISESCALATED;
     std::string outSERVICENOTIFICATIONNUMBER;
-    ASSERT_EQ(_svc->notify(notifier::reason_normal,
-                           "test_author",
-                           "test_comment",
-                           notifier::notification_option_forced),
-              OK);
+    ASSERT_EQ(
+        _svc->notify(notifier::reason_normal, "test_author", "test_comment",
+                     notifier::notification_option_forced),
+        OK);
     process_macros_r(mac, "$NOTIFICATIONTYPE$", outNOTIFICATIONTYPE, 0);
     process_macros_r(mac, "$NOTIFICATIONNUMBER$", outNOTIFICATIONNUMBER, 0);
-    process_macros_r(
-        mac, "$NOTIFICATIONISESCALATED$", outNOTIFICATIONISESCALATED, 0);
-    process_macros_r(
-        mac, "$SERVICENOTIFICATIONNUMBER$", outSERVICENOTIFICATIONNUMBER, 0);
+    process_macros_r(mac, "$NOTIFICATIONISESCALATED$",
+                     outNOTIFICATIONISESCALATED, 0);
+    process_macros_r(mac, "$SERVICENOTIFICATIONNUMBER$",
+                     outSERVICENOTIFICATIONNUMBER, 0);
 
     std::cout << " NOTIFICATIONTYPE: " << outNOTIFICATIONTYPE
               << " NOTIFICATIONNUMBER: " << outNOTIFICATIONNUMBER
@@ -874,41 +854,41 @@ TEST_F(ServiceNotification, ServiceEscalationCG) {
 
   std::string out{testing::internal::GetCapturedStdout()};
   size_t step1{out.find("NOW = 50900")};
-  size_t step2{out.find(
-      "SERVICE NOTIFICATION: "
-      "admin;test_host;test_svc;CRITICAL;cmd;service critical",
-      step1 + 1)};
-  size_t step3{out.find(
-      "NOTIFICATIONTYPE: PROBLEM NOTIFICATIONNUMBER: 1 "
-      "NOTIFICATIONISESCALATED: 0 SERVICENOTIFICATIONNUMBER: 1",
-      step2 + 1)};
+  size_t step2{
+      out.find("SERVICE NOTIFICATION: "
+               "admin;test_host;test_svc;CRITICAL;cmd;service critical",
+               step1 + 1)};
+  size_t step3{
+      out.find("NOTIFICATIONTYPE: PROBLEM NOTIFICATIONNUMBER: 1 "
+               "NOTIFICATIONISESCALATED: 0 SERVICENOTIFICATIONNUMBER: 1",
+               step2 + 1)};
   size_t step4{out.find("NOW = 51200", step3 + 1)};
-  size_t step5{out.find(
-      "SERVICE NOTIFICATION: "
-      "test_contact;test_host;test_svc;CRITICAL;cmd;service critical",
-      step4 + 1)};
-  size_t step6{out.find(
-      "NOTIFICATIONTYPE: PROBLEM NOTIFICATIONNUMBER: 2 "
-      "NOTIFICATIONISESCALATED: 1 SERVICENOTIFICATIONNUMBER: 2",
-      step5 + 1)};
+  size_t step5{
+      out.find("SERVICE NOTIFICATION: "
+               "test_contact;test_host;test_svc;CRITICAL;cmd;service critical",
+               step4 + 1)};
+  size_t step6{
+      out.find("NOTIFICATIONTYPE: PROBLEM NOTIFICATIONNUMBER: 2 "
+               "NOTIFICATIONISESCALATED: 1 SERVICENOTIFICATIONNUMBER: 2",
+               step5 + 1)};
   size_t step7{out.find("NOW = 51800", step6 + 1)};
-  size_t step8{out.find(
-      "SERVICE NOTIFICATION: "
-      "test_contact;test_host;test_svc;CRITICAL;cmd;service critical",
-      step7 + 1)};
-  size_t step9{out.find(
-      "NOTIFICATIONTYPE: PROBLEM NOTIFICATIONNUMBER: 3 "
-      "NOTIFICATIONISESCALATED: 1 SERVICENOTIFICATIONNUMBER: 3",
-      step8 + 1)};
+  size_t step8{
+      out.find("SERVICE NOTIFICATION: "
+               "test_contact;test_host;test_svc;CRITICAL;cmd;service critical",
+               step7 + 1)};
+  size_t step9{
+      out.find("NOTIFICATIONTYPE: PROBLEM NOTIFICATIONNUMBER: 3 "
+               "NOTIFICATIONISESCALATED: 1 SERVICENOTIFICATIONNUMBER: 3",
+               step8 + 1)};
   size_t step10{out.find("NOW = 52400", step9 + 1)};
-  size_t step11{out.find(
-      "SERVICE NOTIFICATION: "
-      "test_contact;test_host;test_svc;CRITICAL;cmd;service critical",
-      step10 + 1)};
-  size_t step12{out.find(
-      "NOTIFICATIONTYPE: PROBLEM NOTIFICATIONNUMBER: 4 "
-      "NOTIFICATIONISESCALATED: 1 SERVICENOTIFICATIONNUMBER: 4",
-      step11 + 1)};
+  size_t step11{
+      out.find("SERVICE NOTIFICATION: "
+               "test_contact;test_host;test_svc;CRITICAL;cmd;service critical",
+               step10 + 1)};
+  size_t step12{
+      out.find("NOTIFICATIONTYPE: PROBLEM NOTIFICATIONNUMBER: 4 "
+               "NOTIFICATIONISESCALATED: 1 SERVICENOTIFICATIONNUMBER: 4",
+               step11 + 1)};
   size_t step13{out.find("NOW = 53000", step12 + 1)};
   ASSERT_NE(step13, std::string::npos);
 }
@@ -944,9 +924,9 @@ TEST_F(ServiceNotification, NoServiceNotificationWhenHostDown) {
   }
 
   std::string out{testing::internal::GetCapturedStdout()};
-  size_t step{out.find(
-      "SERVICE NOTIFICATION: "
-      "admin;test_host;test_svc;CRITICAL;cmd;service down")};
+  size_t step{
+      out.find("SERVICE NOTIFICATION: "
+               "admin;test_host;test_svc;CRITICAL;cmd;service down")};
   ASSERT_EQ(step, std::string::npos);
 }
 
@@ -962,8 +942,8 @@ TEST_F(ServiceNotification, WarnCritServiceNotification) {
     tperiod->days[i].push_back(std::make_shared<engine::timerange>(0, 86400));
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
-      new engine::serviceescalation(
-          "test_host", "test_svc", 0, 1, 1.0, "tperiod", 7, Uuid())};
+      new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0,
+                                    "tperiod", 7, Uuid())};
   _svc->set_current_state(engine::service::state_critical);
   _svc->set_last_state(engine::service::state_critical);
   _svc->set_last_hard_state_change(43200);
@@ -972,20 +952,18 @@ TEST_F(ServiceNotification, WarnCritServiceNotification) {
   ASSERT_TRUE(service_escalation);
   uint64_t id{_svc->get_next_notification_id()};
   _svc->set_notification_period_ptr(tperiod.get());
-  ASSERT_EQ(
-      _svc->notify(
-          notifier::reason_normal, "", "", notifier::notification_option_none),
-      OK);
+  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
+                         notifier::notification_option_none),
+            OK);
 
   _svc->set_current_state(engine::service::state_warning);
   _svc->set_last_state(engine::service::state_warning);
   _svc->set_last_hard_state_change(43500);
   _svc->set_state_type(checkable::hard);
 
-  ASSERT_EQ(
-      _svc->notify(
-          notifier::reason_normal, "", "", notifier::notification_option_none),
-      OK);
+  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
+                         notifier::notification_option_none),
+            OK);
   ASSERT_EQ(id + 2, _svc->get_next_notification_id());
 }
 
@@ -1001,8 +979,8 @@ TEST_F(ServiceNotification, SimpleNormalVolatileServiceNotification) {
     tperiod->days[i].push_back(std::make_shared<engine::timerange>(0, 86400));
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
-      new engine::serviceescalation(
-          "test_host", "test_svc", 0, 1, 1.0, "tperiod", 7, Uuid())};
+      new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0,
+                                    "tperiod", 7, Uuid())};
   _svc->set_current_state(engine::service::state_critical);
   _svc->set_last_state(engine::service::state_critical);
   _svc->set_last_hard_state_change(43200);
@@ -1013,20 +991,18 @@ TEST_F(ServiceNotification, SimpleNormalVolatileServiceNotification) {
   ASSERT_TRUE(service_escalation);
   uint64_t id{_svc->get_next_notification_id()};
   _svc->set_notification_period_ptr(tperiod.get());
-  ASSERT_EQ(
-      _svc->notify(
-          notifier::reason_normal, "", "", notifier::notification_option_none),
-      OK);
+  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
+                         notifier::notification_option_none),
+            OK);
   ASSERT_EQ(id + 1, _svc->get_next_notification_id());
 
   /* Except if notifications disabled */
   id = _svc->get_next_notification_id();
   _svc->set_notification_period_ptr(tperiod.get());
   _svc->set_notifications_enabled(false);
-  ASSERT_EQ(
-      _svc->notify(
-          notifier::reason_normal, "", "", notifier::notification_option_none),
-      OK);
+  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
+                         notifier::notification_option_none),
+            OK);
   ASSERT_EQ(id, _svc->get_next_notification_id());
 
   /* or notifications are disabled globally */
@@ -1034,10 +1010,9 @@ TEST_F(ServiceNotification, SimpleNormalVolatileServiceNotification) {
   _svc->set_notification_period_ptr(tperiod.get());
   _svc->set_notifications_enabled(true);
   config->enable_notifications(false);
-  ASSERT_EQ(
-      _svc->notify(
-          notifier::reason_normal, "", "", notifier::notification_option_none),
-      OK);
+  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
+                         notifier::notification_option_none),
+            OK);
   ASSERT_EQ(id, _svc->get_next_notification_id());
 }
 
@@ -1053,8 +1028,8 @@ TEST_F(ServiceNotification, RecoveryNotifEvenIfServiceAcknowledged) {
     tperiod->days[i].push_back(std::make_shared<engine::timerange>(0, 86400));
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
-      new engine::serviceescalation(
-          "test_host", "test_svc", 0, 1, 1.0, "tperiod", 7, Uuid())};
+      new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0,
+                                    "tperiod", 7, Uuid())};
   _svc->set_current_state(engine::service::state_critical);
   _svc->set_last_state(engine::service::state_critical);
   _svc->set_last_hard_state_change(43200);
@@ -1062,10 +1037,9 @@ TEST_F(ServiceNotification, RecoveryNotifEvenIfServiceAcknowledged) {
 
   /* Critical notification is sent */
   uint64_t id{_svc->get_next_notification_id()};
-  ASSERT_EQ(
-      _svc->notify(
-          notifier::reason_normal, "", "", notifier::notification_option_none),
-      OK);
+  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
+                         notifier::notification_option_none),
+            OK);
   ASSERT_EQ(id + 1, _svc->get_next_notification_id());
 
   set_time(43700);
@@ -1076,9 +1050,7 @@ TEST_F(ServiceNotification, RecoveryNotifEvenIfServiceAcknowledged) {
   _svc->set_last_acknowledgement(now);
 
   id = _svc->get_next_notification_id();
-  ASSERT_EQ(_svc->notify(notifier::reason_acknowledgement,
-                         "",
-                         "",
+  ASSERT_EQ(_svc->notify(notifier::reason_acknowledgement, "", "",
                          notifier::notification_option_none),
             OK);
   ASSERT_EQ(id + 1, _svc->get_next_notification_id());
@@ -1086,10 +1058,9 @@ TEST_F(ServiceNotification, RecoveryNotifEvenIfServiceAcknowledged) {
   set_time(44000);
   /* The service is acknowledged => no more normal notification */
   id = _svc->get_next_notification_id();
-  ASSERT_EQ(
-      _svc->notify(
-          notifier::reason_normal, "", "", notifier::notification_option_none),
-      OK);
+  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
+                         notifier::notification_option_none),
+            OK);
   ASSERT_EQ(id, _svc->get_next_notification_id());
 
   set_time(44500);
@@ -1100,9 +1071,7 @@ TEST_F(ServiceNotification, RecoveryNotifEvenIfServiceAcknowledged) {
 
   /* Critical notification is sent */
   id = _svc->get_next_notification_id();
-  ASSERT_EQ(_svc->notify(notifier::reason_recovery,
-                         "",
-                         "",
+  ASSERT_EQ(_svc->notify(notifier::reason_recovery, "", "",
                          notifier::notification_option_none),
             OK);
   ASSERT_EQ(id + 1, _svc->get_next_notification_id());
@@ -1120,15 +1089,14 @@ TEST_F(ServiceNotification, SimpleVolatileServiceNotificationWithDowntime) {
     tperiod->days[i].push_back(std::make_shared<engine::timerange>(0, 86400));
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
-      new engine::serviceescalation(
-          "test_host", "test_svc", 0, 1, 1.0, "", 7, Uuid())};
+      new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0, "", 7,
+                                    Uuid())};
   _svc->set_notification_period_ptr(tperiod.get());
 
   ASSERT_TRUE(service_escalation);
-  ASSERT_EQ(
-      _svc->notify(
-          notifier::reason_normal, "", "", notifier::notification_option_none),
-      OK);
+  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
+                         notifier::notification_option_none),
+            OK);
   ASSERT_EQ(id, _svc->get_next_notification_id());
 }
 
@@ -1176,12 +1144,12 @@ TEST_F(ServiceNotification, WarningAndTwoUsers) {
   }
   std::string out{testing::internal::GetCapturedStdout()};
   std::cout << out << std::endl;
-  size_t warn_admin1{out.find(
-      "SERVICE NOTIFICATION: "
-      "admin1;test_host;test_svc;WARNING;cmd;service warn")};
+  size_t warn_admin1{
+      out.find("SERVICE NOTIFICATION: "
+               "admin1;test_host;test_svc;WARNING;cmd;service warn")};
   ASSERT_EQ(warn_admin1, std::string::npos);
-  size_t rec_admin1{out.find(
-      "SERVICE NOTIFICATION: admin1;test_host;test_svc;RECOVERY "
-      "(OK);cmd;service ok")};
+  size_t rec_admin1{
+      out.find("SERVICE NOTIFICATION: admin1;test_host;test_svc;RECOVERY "
+               "(OK);cmd;service ok")};
   ASSERT_EQ(rec_admin1, std::string::npos);
 }

--- a/tests/notifications/service_normal_notification.cc
+++ b/tests/notifications/service_normal_notification.cc
@@ -114,8 +114,8 @@ TEST_F(ServiceNotification, SimpleNormalServiceNotification) {
     tperiod->days[i].push_back(std::make_shared<engine::timerange>(0, 86400));
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
-      new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0,
-                                    "tperiod", 7, Uuid())};
+      new engine::serviceescalation(
+          "test_host", "test_svc", 0, 1, 1.0, "tperiod", 7, Uuid())};
   _svc->set_current_state(engine::service::state_critical);
   _svc->set_last_state(engine::service::state_critical);
   _svc->set_last_hard_state_change(43200);
@@ -124,9 +124,10 @@ TEST_F(ServiceNotification, SimpleNormalServiceNotification) {
   ASSERT_TRUE(service_escalation);
   uint64_t id{_svc->get_next_notification_id()};
   _svc->set_notification_period_ptr(tperiod.get());
-  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
-                         notifier::notification_option_none),
-            OK);
+  ASSERT_EQ(
+      _svc->notify(
+          notifier::reason_normal, "", "", notifier::notification_option_none),
+      OK);
   ASSERT_EQ(id + 1, _svc->get_next_notification_id());
 }
 
@@ -143,15 +144,16 @@ TEST_F(ServiceNotification,
     tperiod->days[i].push_back(std::make_shared<engine::timerange>(0, 86400));
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
-      new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0,
-                                    "tperiod", 7, Uuid())};
+      new engine::serviceescalation(
+          "test_host", "test_svc", 0, 1, 1.0, "tperiod", 7, Uuid())};
 
   ASSERT_TRUE(service_escalation);
   uint64_t id{_svc->get_next_notification_id()};
   _svc->set_notification_period_ptr(tperiod.get());
-  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
-                         notifier::notification_option_none),
-            OK);
+  ASSERT_EQ(
+      _svc->notify(
+          notifier::reason_normal, "", "", notifier::notification_option_none),
+      OK);
   ASSERT_EQ(id, _svc->get_next_notification_id());
 }
 
@@ -167,16 +169,17 @@ TEST_F(ServiceNotification,
     tperiod->days[i].push_back(std::make_shared<engine::timerange>(0, 86400));
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
-      new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0,
-                                    "tperiod", 7, Uuid())};
+      new engine::serviceescalation(
+          "test_host", "test_svc", 0, 1, 1.0, "tperiod", 7, Uuid())};
 
   ASSERT_TRUE(service_escalation);
   uint64_t id{_svc->get_next_notification_id()};
   _svc->set_notifications_enabled(false);
   _svc->set_notification_period_ptr(tperiod.get());
-  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
-                         notifier::notification_option_none),
-            OK);
+  ASSERT_EQ(
+      _svc->notify(
+          notifier::reason_normal, "", "", notifier::notification_option_none),
+      OK);
   ASSERT_EQ(id, _svc->get_next_notification_id());
 }
 
@@ -187,18 +190,19 @@ TEST_F(ServiceNotification, SimpleNormalServiceNotificationOutsideTimeperiod) {
 
   uint64_t id{_svc->get_next_notification_id()};
   for (int i = 0; i < 7; ++i)
-    tperiod->days[i].push_back(
-        std::make_shared<engine::timerange>(43200, 86400));
+    tperiod->days[i]
+        .push_back(std::make_shared<engine::timerange>(43200, 86400));
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
-      new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0, "", 7,
-                                    Uuid())};
+      new engine::serviceescalation(
+          "test_host", "test_svc", 0, 1, 1.0, "", 7, Uuid())};
   _svc->set_notification_period_ptr(tperiod.get());
 
   ASSERT_TRUE(service_escalation);
-  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
-                         notifier::notification_option_none),
-            OK);
+  ASSERT_EQ(
+      _svc->notify(
+          notifier::reason_normal, "", "", notifier::notification_option_none),
+      OK);
   ASSERT_EQ(id, _svc->get_next_notification_id());
 }
 
@@ -211,16 +215,18 @@ TEST_F(ServiceNotification,
 
   uint64_t id{_svc->get_next_notification_id()};
   for (int i = 0; i < 7; ++i)
-    tperiod->days[i].push_back(
-        std::make_shared<engine::timerange>(43200, 86400));
+    tperiod->days[i]
+        .push_back(std::make_shared<engine::timerange>(43200, 86400));
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
-      new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0, "", 7,
-                                    Uuid())};
+      new engine::serviceescalation(
+          "test_host", "test_svc", 0, 1, 1.0, "", 7, Uuid())};
   _svc->set_notification_period_ptr(tperiod.get());
 
   ASSERT_TRUE(service_escalation);
-  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
+  ASSERT_EQ(_svc->notify(notifier::reason_normal,
+                         "",
+                         "",
                          notifier::notification_option_forced),
             OK);
   ASSERT_EQ(id + 1, _svc->get_next_notification_id());
@@ -233,16 +239,18 @@ TEST_F(ServiceNotification, SimpleNormalServiceNotificationForcedNotification) {
 
   uint64_t id{_svc->get_next_notification_id()};
   for (int i = 0; i < 7; ++i)
-    tperiod->days[i].push_back(
-        std::make_shared<engine::timerange>(43200, 86400));
+    tperiod->days[i]
+        .push_back(std::make_shared<engine::timerange>(43200, 86400));
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
-      new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0, "", 7,
-                                    Uuid())};
+      new engine::serviceescalation(
+          "test_host", "test_svc", 0, 1, 1.0, "", 7, Uuid())};
   _svc->set_notification_period_ptr(tperiod.get());
 
   ASSERT_TRUE(service_escalation);
-  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
+  ASSERT_EQ(_svc->notify(notifier::reason_normal,
+                         "",
+                         "",
                          notifier::notification_option_forced),
             OK);
   ASSERT_EQ(id + 1, _svc->get_next_notification_id());
@@ -259,14 +267,15 @@ TEST_F(ServiceNotification, SimpleNormalServiceNotificationWithDowntime) {
     tperiod->days[i].push_back(std::make_shared<engine::timerange>(0, 86400));
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
-      new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0, "", 7,
-                                    Uuid())};
+      new engine::serviceescalation(
+          "test_host", "test_svc", 0, 1, 1.0, "", 7, Uuid())};
   _svc->set_notification_period_ptr(tperiod.get());
 
   ASSERT_TRUE(service_escalation);
-  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
-                         notifier::notification_option_none),
-            OK);
+  ASSERT_EQ(
+      _svc->notify(
+          notifier::reason_normal, "", "", notifier::notification_option_none),
+      OK);
   ASSERT_EQ(id, _svc->get_next_notification_id());
 }
 
@@ -281,14 +290,15 @@ TEST_F(ServiceNotification, SimpleNormalServiceNotificationWithFlapping) {
     tperiod->days[i].push_back(std::make_shared<engine::timerange>(0, 86400));
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
-      new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0, "", 7,
-                                    Uuid())};
+      new engine::serviceescalation(
+          "test_host", "test_svc", 0, 1, 1.0, "", 7, Uuid())};
   _svc->set_notification_period_ptr(tperiod.get());
 
   ASSERT_TRUE(service_escalation);
-  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
-                         notifier::notification_option_none),
-            OK);
+  ASSERT_EQ(
+      _svc->notify(
+          notifier::reason_normal, "", "", notifier::notification_option_none),
+      OK);
   ASSERT_EQ(id, _svc->get_next_notification_id());
 }
 
@@ -303,14 +313,15 @@ TEST_F(ServiceNotification, SimpleNormalServiceNotificationWithSoftState) {
     tperiod->days[i].push_back(std::make_shared<engine::timerange>(0, 86400));
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
-      new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0, "", 7,
-                                    Uuid())};
+      new engine::serviceescalation(
+          "test_host", "test_svc", 0, 1, 1.0, "", 7, Uuid())};
   _svc->set_notification_period_ptr(tperiod.get());
 
   ASSERT_TRUE(service_escalation);
-  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
-                         notifier::notification_option_none),
-            OK);
+  ASSERT_EQ(
+      _svc->notify(
+          notifier::reason_normal, "", "", notifier::notification_option_none),
+      OK);
   ASSERT_EQ(id, _svc->get_next_notification_id());
 }
 
@@ -325,15 +336,16 @@ TEST_F(ServiceNotification,
     tperiod->days[i].push_back(std::make_shared<engine::timerange>(0, 86400));
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
-      new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0, "", 7,
-                                    Uuid())};
+      new engine::serviceescalation(
+          "test_host", "test_svc", 0, 1, 1.0, "", 7, Uuid())};
   _svc->set_notification_period_ptr(tperiod.get());
 
   _svc->set_problem_has_been_acknowledged(true);
   ASSERT_TRUE(service_escalation);
-  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
-                         notifier::notification_option_none),
-            OK);
+  ASSERT_EQ(
+      _svc->notify(
+          notifier::reason_normal, "", "", notifier::notification_option_none),
+      OK);
   ASSERT_EQ(id, _svc->get_next_notification_id());
 }
 
@@ -348,16 +360,17 @@ TEST_F(ServiceNotification,
     tperiod->days[i].push_back(std::make_shared<engine::timerange>(0, 86400));
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
-      new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0, "", 7,
-                                    Uuid())};
+      new engine::serviceescalation(
+          "test_host", "test_svc", 0, 1, 1.0, "", 7, Uuid())};
   _svc->set_notification_period_ptr(tperiod.get());
 
   _svc->set_problem_has_been_acknowledged(true);
   ASSERT_TRUE(service_escalation);
   _svc->set_last_notification(19999);
-  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
-                         notifier::notification_option_none),
-            OK);
+  ASSERT_EQ(
+      _svc->notify(
+          notifier::reason_normal, "", "", notifier::notification_option_none),
+      OK);
   ASSERT_EQ(id, _svc->get_next_notification_id());
 }
 
@@ -372,8 +385,8 @@ TEST_F(ServiceNotification,
     tperiod->days[i].push_back(std::make_shared<engine::timerange>(0, 86400));
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
-      new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0, "", 7,
-                                    Uuid())};
+      new engine::serviceescalation(
+          "test_host", "test_svc", 0, 1, 1.0, "", 7, Uuid())};
   _svc->set_notification_period_ptr(tperiod.get());
 
   _svc->set_problem_has_been_acknowledged(true);
@@ -381,9 +394,10 @@ TEST_F(ServiceNotification,
   _svc->set_last_notification(19500);
   _svc->set_notification_number(1);
   _svc->set_notification_interval(0);
-  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
-                         notifier::notification_option_none),
-            OK);
+  ASSERT_EQ(
+      _svc->notify(
+          notifier::reason_normal, "", "", notifier::notification_option_none),
+      OK);
   ASSERT_EQ(id, _svc->get_next_notification_id());
 }
 
@@ -397,17 +411,18 @@ TEST_F(ServiceNotification, SimpleNormalServiceNotificationOnStateNotNotified) {
     tperiod->days[i].push_back(std::make_shared<engine::timerange>(0, 86400));
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
-      new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0, "", 7,
-                                    Uuid())};
+      new engine::serviceescalation(
+          "test_host", "test_svc", 0, 1, 1.0, "", 7, Uuid())};
   _svc->set_notification_period_ptr(tperiod.get());
 
   _svc->set_problem_has_been_acknowledged(false);
   ASSERT_TRUE(service_escalation);
   _svc->remove_notify_on(notifier::critical);
   _svc->set_current_state(engine::service::state_critical);
-  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
-                         notifier::notification_option_none),
-            OK);
+  ASSERT_EQ(
+      _svc->notify(
+          notifier::reason_normal, "", "", notifier::notification_option_none),
+      OK);
   ASSERT_EQ(id, _svc->get_next_notification_id());
 }
 
@@ -422,8 +437,8 @@ TEST_F(ServiceNotification,
     tperiod->days[i].push_back(std::make_shared<engine::timerange>(0, 86400));
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
-      new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0, "", 7,
-                                    Uuid())};
+      new engine::serviceescalation(
+          "test_host", "test_svc", 0, 1, 1.0, "", 7, Uuid())};
   _svc->set_notification_period_ptr(tperiod.get());
 
   _svc->set_problem_has_been_acknowledged(false);
@@ -432,9 +447,10 @@ TEST_F(ServiceNotification,
   _svc->set_last_hard_state_change(20000 - 200);
   /* It is multiplicated by config->interval_length(): we set 5 for 5*60 */
   _svc->set_first_notification_delay(5);
-  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
-                         notifier::notification_option_none),
-            OK);
+  ASSERT_EQ(
+      _svc->notify(
+          notifier::reason_normal, "", "", notifier::notification_option_none),
+      OK);
   ASSERT_EQ(id, _svc->get_next_notification_id());
 }
 
@@ -449,8 +465,8 @@ TEST_F(ServiceNotification,
     tperiod->days[i].push_back(std::make_shared<engine::timerange>(0, 86400));
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
-      new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0, "", 7,
-                                    Uuid())};
+      new engine::serviceescalation(
+          "test_host", "test_svc", 0, 1, 1.0, "", 7, Uuid())};
   _svc->set_notification_period_ptr(tperiod.get());
 
   _svc->set_problem_has_been_acknowledged(false);
@@ -458,9 +474,10 @@ TEST_F(ServiceNotification,
   _svc->set_current_state(engine::service::state_critical);
   _svc->set_last_hard_state_change(20000 - 400);
   _svc->set_first_notification_delay(5);
-  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
-                         notifier::notification_option_none),
-            OK);
+  ASSERT_EQ(
+      _svc->notify(
+          notifier::reason_normal, "", "", notifier::notification_option_none),
+      OK);
   ASSERT_EQ(id + 1, _svc->get_next_notification_id());
 }
 
@@ -476,8 +493,8 @@ TEST_F(ServiceNotification,
     tperiod->days[i].push_back(std::make_shared<engine::timerange>(0, 86400));
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
-      new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0,
-                                    "tperiod", 7, Uuid())};
+      new engine::serviceescalation(
+          "test_host", "test_svc", 0, 1, 1.0, "tperiod", 7, Uuid())};
 
   _svc->set_current_state(engine::service::state_critical);
   _svc->set_last_state(engine::service::state_critical);
@@ -488,9 +505,10 @@ TEST_F(ServiceNotification,
   /* We configure the notification interval to 2 minutes */
   _svc->set_notification_interval(2);
   _svc->set_notification_period_ptr(tperiod.get());
-  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
-                         notifier::notification_option_none),
-            OK);
+  ASSERT_EQ(
+      _svc->notify(
+          notifier::reason_normal, "", "", notifier::notification_option_none),
+      OK);
   ASSERT_EQ(id + 1, _svc->get_next_notification_id());
 
   /* Only 100 seconds since the previous notification. */
@@ -498,9 +516,10 @@ TEST_F(ServiceNotification,
   id = _svc->get_next_notification_id();
   /* Because of the notification not totally implemented, we must force the
    * notification number to be greater than 0 */
-  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
-                         notifier::notification_option_none),
-            OK);
+  ASSERT_EQ(
+      _svc->notify(
+          notifier::reason_normal, "", "", notifier::notification_option_none),
+      OK);
 
   /* No notification, because the delay is too short */
   ASSERT_EQ(id, _svc->get_next_notification_id());
@@ -524,7 +543,9 @@ TEST_F(ServiceNotification, SimpleCheck) {
       _svc->set_last_hard_state(_svc->get_current_state());
 
     std::time_t now{std::time(nullptr)};
-    std::string cmd{fmt::format("[{}] PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;service down", now)};
+    std::string cmd{fmt::format(
+        "[{}] PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;service down",
+        now)};
     process_external_command(cmd.c_str());
     checks::checker::instance().reap();
   }
@@ -534,26 +555,28 @@ TEST_F(ServiceNotification, SimpleCheck) {
     // When i == 1, the state_up is still here (no change) => no notification
     set_time(56500 + i * 500);
     std::time_t now{std::time(nullptr)};
-    std::string cmd{fmt::format("[{}] PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;0;service ok", now)};
+    std::string cmd{fmt::format(
+        "[{}] PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;0;service ok",
+        now)};
     process_external_command(cmd.c_str());
     checks::checker::instance().reap();
   }
   std::string out{testing::internal::GetCapturedStdout()};
   size_t step1{out.find(
       "SERVICE ALERT: test_host;test_svc;CRITICAL;HARD;3;service down")};
-  size_t step2{
-      out.find("SERVICE NOTIFICATION: "
-               "admin;test_host;test_svc;CRITICAL;cmd;service down",
-               step1 + 1)};
-  size_t step3{
-      out.find("SERVICE NOTIFICATION: "
-               "admin;test_host;test_svc;CRITICAL;cmd;service down",
-               step2 + 1)};
+  size_t step2{out.find(
+      "SERVICE NOTIFICATION: "
+      "admin;test_host;test_svc;CRITICAL;cmd;service down",
+      step1 + 1)};
+  size_t step3{out.find(
+      "SERVICE NOTIFICATION: "
+      "admin;test_host;test_svc;CRITICAL;cmd;service down",
+      step2 + 1)};
   // Sent when i == 0 on the second loop.
-  size_t step4{
-      out.find("SERVICE NOTIFICATION: admin;test_host;test_svc;RECOVERY "
-               "(OK);cmd;service ok",
-               step2 + 1)};
+  size_t step4{out.find(
+      "SERVICE NOTIFICATION: admin;test_host;test_svc;RECOVERY "
+      "(OK);cmd;service ok",
+      step2 + 1)};
   ASSERT_EQ(step3, std::string::npos);
   ASSERT_NE(step4, std::string::npos);
 }
@@ -578,8 +601,10 @@ TEST_F(ServiceNotification, CheckFirstNotificationDelay) {
     if (notifier::hard == _svc->get_state_type())
       _svc->set_last_hard_state(_svc->get_current_state());
     std::time_t now{std::time(nullptr)};
-    std::string cmd{fmt::format("[{}] PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;service "
-                   "critical", now)};
+    std::string cmd{fmt::format(
+        "[{}] PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;service "
+        "critical",
+        now)};
     process_external_command(cmd.c_str());
     checks::checker::instance().reap();
   }
@@ -590,25 +615,27 @@ TEST_F(ServiceNotification, CheckFirstNotificationDelay) {
     std::cout << "New step " << i << std::endl;
     set_time(50600 + i * 60);
     std::time_t now{std::time(nullptr)};
-    std::string cmd{fmt::format("[{}] PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;0;service ok", now)};
+    std::string cmd{fmt::format(
+        "[{}] PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;0;service ok",
+        now)};
     process_external_command(cmd.c_str());
     checks::checker::instance().reap();
   }
   std::string out{testing::internal::GetCapturedStdout()};
   size_t m1{out.find("Step 5:")};
-  size_t m2{
-      out.find(" SERVICE NOTIFICATION: "
-               "admin;test_host;test_svc;DOWN;cmd;service critical",
-               m1 + 1)};
+  size_t m2{out.find(
+      " SERVICE NOTIFICATION: "
+      "admin;test_host;test_svc;DOWN;cmd;service critical",
+      m1 + 1)};
   size_t m3{out.find("Step 35:", m2 + 1)};
-  size_t m4{
-      out.find(" SERVICE NOTIFICATION: "
-               "admin;test_host;test_svc;DOWN;cmd;service critical",
-               m3 + 1)};
-  size_t m5{
-      out.find(" SERVICE NOTIFICATION: admin;test_host;test_svc;RECOVERY "
-               "(OK);cmd;service ok",
-               m4 + 1)};
+  size_t m4{out.find(
+      " SERVICE NOTIFICATION: "
+      "admin;test_host;test_svc;DOWN;cmd;service critical",
+      m3 + 1)};
+  size_t m5{out.find(
+      " SERVICE NOTIFICATION: admin;test_host;test_svc;RECOVERY "
+      "(OK);cmd;service ok",
+      m4 + 1)};
   ASSERT_NE(m5, std::string::npos);
 }
 
@@ -657,19 +684,19 @@ TEST_F(ServiceNotification, CheckNotifIntervZero) {
   std::string out{testing::internal::GetCapturedStdout()};
   size_t step1{out.find(
       "SERVICE ALERT: test_host;test_svc;CRITICAL;HARD;3;service down")};
-  size_t step2{
-      out.find("SERVICE NOTIFICATION: "
-               "admin;test_host;test_svc;CRITICAL;cmd;service down",
-               step1 + 1)};
-  size_t step3{
-      out.find("SERVICE NOTIFICATION: "
-               "admin;test_host;test_svc;CRITICAL;cmd;service down",
-               step2 + 1)};
+  size_t step2{out.find(
+      "SERVICE NOTIFICATION: "
+      "admin;test_host;test_svc;CRITICAL;cmd;service down",
+      step1 + 1)};
+  size_t step3{out.find(
+      "SERVICE NOTIFICATION: "
+      "admin;test_host;test_svc;CRITICAL;cmd;service down",
+      step2 + 1)};
   // Sent when i == 0 on the second loop.
-  size_t step4{
-      out.find("SERVICE NOTIFICATION: admin;test_host;test_svc;RECOVERY "
-               "(OK);cmd;service ok",
-               step2 + 1)};
+  size_t step4{out.find(
+      "SERVICE NOTIFICATION: admin;test_host;test_svc;RECOVERY "
+      "(OK);cmd;service ok",
+      step2 + 1)};
   ASSERT_EQ(step3, std::string::npos);
   ASSERT_NE(step4, std::string::npos);
 }
@@ -727,21 +754,21 @@ TEST_F(ServiceNotification, NormalRecoveryTwoTimes) {
   }
 
   std::string out{testing::internal::GetCapturedStdout()};
-  size_t step1{
-      out.find("SERVICE NOTIFICATION: "
-               "admin;test_host;test_svc;CRITICAL;cmd;service critical")};
-  size_t step2{
-      out.find("SERVICE NOTIFICATION: admin;test_host;test_svc;RECOVERY "
-               "(OK);cmd;service ok",
-               step1 + 1)};
-  size_t step3{
-      out.find("SERVICE NOTIFICATION: "
-               "admin;test_host;test_svc;CRITICAL;cmd;service critical",
-               step2 + 1)};
-  size_t step4{
-      out.find("SERVICE NOTIFICATION: admin;test_host;test_svc;RECOVERY "
-               "(OK);cmd;service ok",
-               step3 + 1)};
+  size_t step1{out.find(
+      "SERVICE NOTIFICATION: "
+      "admin;test_host;test_svc;CRITICAL;cmd;service critical")};
+  size_t step2{out.find(
+      "SERVICE NOTIFICATION: admin;test_host;test_svc;RECOVERY "
+      "(OK);cmd;service ok",
+      step1 + 1)};
+  size_t step3{out.find(
+      "SERVICE NOTIFICATION: "
+      "admin;test_host;test_svc;CRITICAL;cmd;service critical",
+      step2 + 1)};
+  size_t step4{out.find(
+      "SERVICE NOTIFICATION: admin;test_host;test_svc;RECOVERY "
+      "(OK);cmd;service ok",
+      step3 + 1)};
   ASSERT_NE(step4, std::string::npos);
 }
 
@@ -814,16 +841,17 @@ TEST_F(ServiceNotification, ServiceEscalationCG) {
     std::string outNOTIFICATIONNUMBER;
     std::string outNOTIFICATIONISESCALATED;
     std::string outSERVICENOTIFICATIONNUMBER;
-    ASSERT_EQ(
-        _svc->notify(notifier::reason_normal, "test_author", "test_comment",
-                     notifier::notification_option_forced),
-        OK);
+    ASSERT_EQ(_svc->notify(notifier::reason_normal,
+                           "test_author",
+                           "test_comment",
+                           notifier::notification_option_forced),
+              OK);
     process_macros_r(mac, "$NOTIFICATIONTYPE$", outNOTIFICATIONTYPE, 0);
     process_macros_r(mac, "$NOTIFICATIONNUMBER$", outNOTIFICATIONNUMBER, 0);
-    process_macros_r(mac, "$NOTIFICATIONISESCALATED$",
-                     outNOTIFICATIONISESCALATED, 0);
-    process_macros_r(mac, "$SERVICENOTIFICATIONNUMBER$",
-                     outSERVICENOTIFICATIONNUMBER, 0);
+    process_macros_r(
+        mac, "$NOTIFICATIONISESCALATED$", outNOTIFICATIONISESCALATED, 0);
+    process_macros_r(
+        mac, "$SERVICENOTIFICATIONNUMBER$", outSERVICENOTIFICATIONNUMBER, 0);
 
     std::cout << " NOTIFICATIONTYPE: " << outNOTIFICATIONTYPE
               << " NOTIFICATIONNUMBER: " << outNOTIFICATIONNUMBER
@@ -846,63 +874,42 @@ TEST_F(ServiceNotification, ServiceEscalationCG) {
 
   std::string out{testing::internal::GetCapturedStdout()};
   size_t step1{out.find("NOW = 50900")};
-  size_t step2{
-      out.find("SERVICE NOTIFICATION: "
-               "admin;test_host;test_svc;CRITICAL;cmd;service critical",
-               step1 + 1)};
-  size_t step3{
-      out.find("NOTIFICATIONTYPE: PROBLEM NOTIFICATIONNUMBER: 1 "
-               "NOTIFICATIONISESCALATED: 0 SERVICENOTIFICATIONNUMBER: 1",
-               step2 + 1)};
+  size_t step2{out.find(
+      "SERVICE NOTIFICATION: "
+      "admin;test_host;test_svc;CRITICAL;cmd;service critical",
+      step1 + 1)};
+  size_t step3{out.find(
+      "NOTIFICATIONTYPE: PROBLEM NOTIFICATIONNUMBER: 1 "
+      "NOTIFICATIONISESCALATED: 0 SERVICENOTIFICATIONNUMBER: 1",
+      step2 + 1)};
   size_t step4{out.find("NOW = 51200", step3 + 1)};
-  size_t step5{
-      out.find("SERVICE NOTIFICATION: "
-               "test_contact;test_host;test_svc;CRITICAL;cmd;service critical",
-               step4 + 1)};
-  size_t step6{
-      out.find("NOTIFICATIONTYPE: PROBLEM NOTIFICATIONNUMBER: 2 "
-               "NOTIFICATIONISESCALATED: 1 SERVICENOTIFICATIONNUMBER: 2",
-               step5 + 1)};
+  size_t step5{out.find(
+      "SERVICE NOTIFICATION: "
+      "test_contact;test_host;test_svc;CRITICAL;cmd;service critical",
+      step4 + 1)};
+  size_t step6{out.find(
+      "NOTIFICATIONTYPE: PROBLEM NOTIFICATIONNUMBER: 2 "
+      "NOTIFICATIONISESCALATED: 1 SERVICENOTIFICATIONNUMBER: 2",
+      step5 + 1)};
   size_t step7{out.find("NOW = 51800", step6 + 1)};
-  size_t step8{
-      out.find("SERVICE NOTIFICATION: "
-               "test_contact;test_host;test_svc;CRITICAL;cmd;service critical",
-               step7 + 1)};
-  size_t step9{
-      out.find("NOTIFICATIONTYPE: PROBLEM NOTIFICATIONNUMBER: 3 "
-               "NOTIFICATIONISESCALATED: 1 SERVICENOTIFICATIONNUMBER: 3",
-               step8 + 1)};
+  size_t step8{out.find(
+      "SERVICE NOTIFICATION: "
+      "test_contact;test_host;test_svc;CRITICAL;cmd;service critical",
+      step7 + 1)};
+  size_t step9{out.find(
+      "NOTIFICATIONTYPE: PROBLEM NOTIFICATIONNUMBER: 3 "
+      "NOTIFICATIONISESCALATED: 1 SERVICENOTIFICATIONNUMBER: 3",
+      step8 + 1)};
   size_t step10{out.find("NOW = 52400", step9 + 1)};
-  size_t step11{
-      out.find("SERVICE NOTIFICATION: "
-               "test_contact;test_host;test_svc;CRITICAL;cmd;service critical",
-               step10 + 1)};
-  size_t step12{
-      out.find("NOTIFICATIONTYPE: PROBLEM NOTIFICATIONNUMBER: 4 "
-               "NOTIFICATIONISESCALATED: 1 SERVICENOTIFICATIONNUMBER: 4",
-               step11 + 1)};
+  size_t step11{out.find(
+      "SERVICE NOTIFICATION: "
+      "test_contact;test_host;test_svc;CRITICAL;cmd;service critical",
+      step10 + 1)};
+  size_t step12{out.find(
+      "NOTIFICATIONTYPE: PROBLEM NOTIFICATIONNUMBER: 4 "
+      "NOTIFICATIONISESCALATED: 1 SERVICENOTIFICATIONNUMBER: 4",
+      step11 + 1)};
   size_t step13{out.find("NOW = 53000", step12 + 1)};
-  size_t step14{
-      out.find("SERVICE NOTIFICATION: "
-               "test_contact;test_host;test_svc;CRITICAL;cmd;service critical",
-               step13 + 1)};
-  size_t step15{
-      out.find("NOTIFICATIONTYPE: PROBLEM NOTIFICATIONNUMBER: 5 "
-               "NOTIFICATIONISESCALATED: 1 SERVICENOTIFICATIONNUMBER: 5",
-               step14 + 1)};
-  size_t step16{out.find("NOW = 53600", step15 + 1)};
-  size_t step17{
-      out.find("SERVICE NOTIFICATION: "
-               "test_contact;test_host;test_svc;CRITICAL;cmd;service critical",
-               step16 + 1)};
-  size_t step18{
-      out.find("NOTIFICATIONTYPE: PROBLEM NOTIFICATIONNUMBER: 6 "
-               "NOTIFICATIONISESCALATED: 1 SERVICENOTIFICATIONNUMBER: 6",
-               step17 + 1)};
-  size_t step19{
-      out.find("SERVICE NOTIFICATION: test_contact;test_host;test_svc;RECOVERY "
-               "(OK);cmd;service ok",
-               step18 + 1)};
   ASSERT_NE(step13, std::string::npos);
 }
 
@@ -929,15 +936,17 @@ TEST_F(ServiceNotification, NoServiceNotificationWhenHostDown) {
       _svc->set_last_hard_state(_svc->get_current_state());
 
     std::time_t now{std::time(nullptr)};
-    std::string cmd{fmt::format("[{}] PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;service down", now)};
+    std::string cmd{fmt::format(
+        "[{}] PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;service down",
+        now)};
     process_external_command(cmd.c_str());
     checks::checker::instance().reap();
   }
 
   std::string out{testing::internal::GetCapturedStdout()};
-  size_t step{
-      out.find("SERVICE NOTIFICATION: "
-               "admin;test_host;test_svc;CRITICAL;cmd;service down")};
+  size_t step{out.find(
+      "SERVICE NOTIFICATION: "
+      "admin;test_host;test_svc;CRITICAL;cmd;service down")};
   ASSERT_EQ(step, std::string::npos);
 }
 
@@ -953,8 +962,8 @@ TEST_F(ServiceNotification, WarnCritServiceNotification) {
     tperiod->days[i].push_back(std::make_shared<engine::timerange>(0, 86400));
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
-      new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0,
-                                    "tperiod", 7, Uuid())};
+      new engine::serviceescalation(
+          "test_host", "test_svc", 0, 1, 1.0, "tperiod", 7, Uuid())};
   _svc->set_current_state(engine::service::state_critical);
   _svc->set_last_state(engine::service::state_critical);
   _svc->set_last_hard_state_change(43200);
@@ -963,18 +972,20 @@ TEST_F(ServiceNotification, WarnCritServiceNotification) {
   ASSERT_TRUE(service_escalation);
   uint64_t id{_svc->get_next_notification_id()};
   _svc->set_notification_period_ptr(tperiod.get());
-  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
-                         notifier::notification_option_none),
-            OK);
+  ASSERT_EQ(
+      _svc->notify(
+          notifier::reason_normal, "", "", notifier::notification_option_none),
+      OK);
 
   _svc->set_current_state(engine::service::state_warning);
   _svc->set_last_state(engine::service::state_warning);
   _svc->set_last_hard_state_change(43500);
   _svc->set_state_type(checkable::hard);
 
-  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
-                         notifier::notification_option_none),
-            OK);
+  ASSERT_EQ(
+      _svc->notify(
+          notifier::reason_normal, "", "", notifier::notification_option_none),
+      OK);
   ASSERT_EQ(id + 2, _svc->get_next_notification_id());
 }
 
@@ -990,8 +1001,8 @@ TEST_F(ServiceNotification, SimpleNormalVolatileServiceNotification) {
     tperiod->days[i].push_back(std::make_shared<engine::timerange>(0, 86400));
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
-      new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0,
-                                    "tperiod", 7, Uuid())};
+      new engine::serviceescalation(
+          "test_host", "test_svc", 0, 1, 1.0, "tperiod", 7, Uuid())};
   _svc->set_current_state(engine::service::state_critical);
   _svc->set_last_state(engine::service::state_critical);
   _svc->set_last_hard_state_change(43200);
@@ -1002,18 +1013,20 @@ TEST_F(ServiceNotification, SimpleNormalVolatileServiceNotification) {
   ASSERT_TRUE(service_escalation);
   uint64_t id{_svc->get_next_notification_id()};
   _svc->set_notification_period_ptr(tperiod.get());
-  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
-                         notifier::notification_option_none),
-            OK);
+  ASSERT_EQ(
+      _svc->notify(
+          notifier::reason_normal, "", "", notifier::notification_option_none),
+      OK);
   ASSERT_EQ(id + 1, _svc->get_next_notification_id());
 
   /* Except if notifications disabled */
   id = _svc->get_next_notification_id();
   _svc->set_notification_period_ptr(tperiod.get());
   _svc->set_notifications_enabled(false);
-  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
-                         notifier::notification_option_none),
-            OK);
+  ASSERT_EQ(
+      _svc->notify(
+          notifier::reason_normal, "", "", notifier::notification_option_none),
+      OK);
   ASSERT_EQ(id, _svc->get_next_notification_id());
 
   /* or notifications are disabled globally */
@@ -1021,9 +1034,10 @@ TEST_F(ServiceNotification, SimpleNormalVolatileServiceNotification) {
   _svc->set_notification_period_ptr(tperiod.get());
   _svc->set_notifications_enabled(true);
   config->enable_notifications(false);
-  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
-                         notifier::notification_option_none),
-            OK);
+  ASSERT_EQ(
+      _svc->notify(
+          notifier::reason_normal, "", "", notifier::notification_option_none),
+      OK);
   ASSERT_EQ(id, _svc->get_next_notification_id());
 }
 
@@ -1039,8 +1053,8 @@ TEST_F(ServiceNotification, RecoveryNotifEvenIfServiceAcknowledged) {
     tperiod->days[i].push_back(std::make_shared<engine::timerange>(0, 86400));
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
-      new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0,
-                                    "tperiod", 7, Uuid())};
+      new engine::serviceescalation(
+          "test_host", "test_svc", 0, 1, 1.0, "tperiod", 7, Uuid())};
   _svc->set_current_state(engine::service::state_critical);
   _svc->set_last_state(engine::service::state_critical);
   _svc->set_last_hard_state_change(43200);
@@ -1048,9 +1062,10 @@ TEST_F(ServiceNotification, RecoveryNotifEvenIfServiceAcknowledged) {
 
   /* Critical notification is sent */
   uint64_t id{_svc->get_next_notification_id()};
-  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
-                         notifier::notification_option_none),
-            OK);
+  ASSERT_EQ(
+      _svc->notify(
+          notifier::reason_normal, "", "", notifier::notification_option_none),
+      OK);
   ASSERT_EQ(id + 1, _svc->get_next_notification_id());
 
   set_time(43700);
@@ -1061,7 +1076,9 @@ TEST_F(ServiceNotification, RecoveryNotifEvenIfServiceAcknowledged) {
   _svc->set_last_acknowledgement(now);
 
   id = _svc->get_next_notification_id();
-  ASSERT_EQ(_svc->notify(notifier::reason_acknowledgement, "", "",
+  ASSERT_EQ(_svc->notify(notifier::reason_acknowledgement,
+                         "",
+                         "",
                          notifier::notification_option_none),
             OK);
   ASSERT_EQ(id + 1, _svc->get_next_notification_id());
@@ -1069,9 +1086,10 @@ TEST_F(ServiceNotification, RecoveryNotifEvenIfServiceAcknowledged) {
   set_time(44000);
   /* The service is acknowledged => no more normal notification */
   id = _svc->get_next_notification_id();
-  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
-                         notifier::notification_option_none),
-            OK);
+  ASSERT_EQ(
+      _svc->notify(
+          notifier::reason_normal, "", "", notifier::notification_option_none),
+      OK);
   ASSERT_EQ(id, _svc->get_next_notification_id());
 
   set_time(44500);
@@ -1082,7 +1100,9 @@ TEST_F(ServiceNotification, RecoveryNotifEvenIfServiceAcknowledged) {
 
   /* Critical notification is sent */
   id = _svc->get_next_notification_id();
-  ASSERT_EQ(_svc->notify(notifier::reason_recovery, "", "",
+  ASSERT_EQ(_svc->notify(notifier::reason_recovery,
+                         "",
+                         "",
                          notifier::notification_option_none),
             OK);
   ASSERT_EQ(id + 1, _svc->get_next_notification_id());
@@ -1100,14 +1120,15 @@ TEST_F(ServiceNotification, SimpleVolatileServiceNotificationWithDowntime) {
     tperiod->days[i].push_back(std::make_shared<engine::timerange>(0, 86400));
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
-      new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0, "", 7,
-                                    Uuid())};
+      new engine::serviceescalation(
+          "test_host", "test_svc", 0, 1, 1.0, "", 7, Uuid())};
   _svc->set_notification_period_ptr(tperiod.get());
 
   ASSERT_TRUE(service_escalation);
-  ASSERT_EQ(_svc->notify(notifier::reason_normal, "", "",
-                         notifier::notification_option_none),
-            OK);
+  ASSERT_EQ(
+      _svc->notify(
+          notifier::reason_normal, "", "", notifier::notification_option_none),
+      OK);
   ASSERT_EQ(id, _svc->get_next_notification_id());
 }
 
@@ -1155,12 +1176,12 @@ TEST_F(ServiceNotification, WarningAndTwoUsers) {
   }
   std::string out{testing::internal::GetCapturedStdout()};
   std::cout << out << std::endl;
-  size_t warn_admin1{
-      out.find("SERVICE NOTIFICATION: "
-               "admin1;test_host;test_svc;WARNING;cmd;service warn")};
+  size_t warn_admin1{out.find(
+      "SERVICE NOTIFICATION: "
+      "admin1;test_host;test_svc;WARNING;cmd;service warn")};
   ASSERT_EQ(warn_admin1, std::string::npos);
-  size_t rec_admin1{
-      out.find("SERVICE NOTIFICATION: admin1;test_host;test_svc;RECOVERY "
-               "(OK);cmd;service ok")};
+  size_t rec_admin1{out.find(
+      "SERVICE NOTIFICATION: admin1;test_host;test_svc;RECOVERY "
+      "(OK);cmd;service ok")};
   ASSERT_EQ(rec_admin1, std::string::npos);
 }


### PR DESCRIPTION
## Description

If the retention.dat file contains date in the future for last_time_... values, they are replaced by the current time which has more
sense. This avoids also to send broker too big timestamps impossible to insert in database.

There are also changes to apply fix warnings raised by clang-tidy.

REFS: MON-6916

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)
