### PR TITLE
fix(loop): sleep_until replaced by sleep_for because of gc 4.8.5

### DIFF
--- a/src/events/loop.cc
+++ b/src/events/loop.cc
@@ -399,7 +399,7 @@ void loop::_dispatching() {
       }
 
       auto t1 = std::chrono::system_clock::now();
-      auto t2 = t1 + std::chrono::nanoseconds(static_cast<uint64_t>(
+      auto delay = std::chrono::nanoseconds(static_cast<uint64_t>(
                          1000000000 * config->sleep_time()));
       command_manager::instance().execute();
 
@@ -418,7 +418,12 @@ void loop::_dispatching() {
       broker_timed_event(NEBTYPE_TIMEDEVENT_SLEEP, NEBFLAG_NONE, NEBATTR_NONE,
                          &_sleep_event, nullptr);
 
-      std::this_thread::sleep_until(t2);
+      auto t2 = std::chrono::system_clock::now();
+      auto laps = t2 - t1;
+      if (laps < delay) {
+        delay -= laps;
+        std::this_thread::sleep_for(delay);
+      }
     }
     configuration::applier::state::instance().unlock();
   }


### PR DESCRIPTION
## Description

Here is a fix because of gcc-4.8.5 (the one in centos7). Engine can wait forever in several cases.

REFS: MON-7215

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)
