### PR TITLE
Mon 7351 fix ext cmd 21.04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 # Changelog
+## 21.04.3
+
+### Bugs
+
+*Check*
+
+If a service check is forced, two service status are sent to broker while only
+one would be enough.
+
 ## 21.04.2
 
 ### Bugs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ link_directories(${nlohmann_json_LIB_DIRS})
 # Version.
 set(CENTREON_ENGINE_MAJOR 21)
 set(CENTREON_ENGINE_MINOR 04)
-set(CENTREON_ENGINE_PATCH 2)
+set(CENTREON_ENGINE_PATCH 3)
 if (CENTREON_ENGINE_PRERELEASE)
   set(CENTREON_ENGINE_VERSION "${CENTREON_ENGINE_MAJOR}.${CENTREON_ENGINE_MINOR}.${CENTREON_ENGINE_PATCH}-${CENTREON_ENGINE_PRERELEASE}")
 else ()
@@ -603,7 +603,7 @@ set(
 # Subdirectories with core features.
 add_subdirectory(src/broker)
 add_subdirectory(src/checks)
-add_subdirectory(conf)
+#add_subdirectory(conf)
 add_subdirectory(src/downtimes)
 add_subdirectory(src/configuration)
 add_subdirectory(src/commands)

--- a/src/service.cc
+++ b/src/service.cc
@@ -794,7 +794,7 @@ void service::check_for_expired_acknowledgement() {
             << "' on host '" << this->get_host_ptr()->get_name()
             << "' just expired";
         set_problem_has_been_acknowledged(false);
-        this->set_acknowledgement_type(ACKNOWLEDGEMENT_NONE);
+        set_acknowledgement_type(ACKNOWLEDGEMENT_NONE);
         update_status();
       }
     }
@@ -2487,12 +2487,14 @@ bool service::schedule_check(time_t check_time, int options) {
   // Save check options for retention purposes.
   set_check_options(options);
 
+  bool no_update_status_now = false;
   // Schedule a new event.
   if (!use_original_event) {
     // We're using the new event, so remove the old one.
     if (temp_event) {
       events::loop::instance().remove_event(temp_event, events::loop::low);
       temp_event = nullptr;
+      no_update_status_now = true;
     }
 
     logger(dbg_checks, most) << "Scheduling new service check event.";
@@ -2523,7 +2525,8 @@ bool service::schedule_check(time_t check_time, int options) {
   }
 
   // Update the status log.
-  update_status();
+  if (!no_update_status_now)
+    update_status();
   return true;
 }
 


### PR DESCRIPTION
## Description

External command of service check result and service status received twice :sob: 

REFS: MON-7351

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)
