### PR TITLE
[logrotate] add directive for old dir creation

### DIFF
--- a/scripts/logrotate_systemd.conf.in
+++ b/scripts/logrotate_systemd.conf.in
@@ -5,6 +5,7 @@
   delaycompress
   missingok
   olddir @LOG_ARCHIVE_DIR@
+  createolddir 755 @USER@ @GROUP@
   rotate 365
   postrotate
     systemctl reload centengine
@@ -17,6 +18,7 @@
   delaycompress
   missingok
   olddir @LOG_ARCHIVE_DIR@
+  createolddir 755 @USER@ @GROUP@
   rotate 5
   size   1G
   postrotate

--- a/scripts/logrotate_sysv.conf.in
+++ b/scripts/logrotate_sysv.conf.in
@@ -5,6 +5,7 @@
   delaycompress
   missingok
   olddir @LOG_ARCHIVE_DIR@
+  createolddir 755 @USER@ @GROUP@
   rotate 365
   postrotate
     kill -HUP `cat @PID_FILE@`
@@ -17,6 +18,7 @@
   delaycompress
   missingok
   olddir @LOG_ARCHIVE_DIR@
+  createolddir 755 @USER@ @GROUP@
   rotate 5
   size   1G
   postrotate

--- a/scripts/logrotate_upstart.conf.in
+++ b/scripts/logrotate_upstart.conf.in
@@ -5,6 +5,7 @@
   delaycompress
   missingok
   olddir @LOG_ARCHIVE_DIR@
+  createolddir 755 @USER@ @GROUP@
   rotate 365
   postrotate
     reload centengine
@@ -17,6 +18,7 @@
   delaycompress
   missingok
   olddir @LOG_ARCHIVE_DIR@
+  createolddir 755 @USER@ @GROUP@
   rotate 5
   size   1G
   postrotate


### PR DESCRIPTION
## Description

**Fixes** # (issue)
Logrotate will now create the old dir (archives) directory so that it could be OK.

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [X] 20.04.x
- [X] 20.10.x
- [X] 21.04.x
- [X] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

Launch logrotate and see it work's !

## Checklist

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).

