### PR TITLE
fix(flapping) consider soft state in history

### DIFF
--- a/src/service.cc
+++ b/src/service.cc
@@ -1911,12 +1911,6 @@ void service::check_for_flapping(bool update,
       << "Checking service '" << _description << "' on host '" << _hostname
       << "' for flapping...";
 
-  /* if this is a soft service state and not a soft recovery, don't record this
-   * in the history */
-  /* only hard states and soft recoveries get recorded for flap detection */
-  if (get_state_type() == soft && _current_state != service::state_ok)
-    return;
-
   /* what threshold values should we use (global or service-specific)? */
   low_threshold = (get_low_flap_threshold() <= 0.0)
                       ? config->low_service_flap_threshold()


### PR DESCRIPTION
Hi,

## Description

Services flapping algorithm only considers hard states to compute the flapping percentage.
This however leads to undetected situations.
Think about a URL check, which every time switches from OK to non-OK to OK state.
This service then flaps, certainly due to some issue with the remote web server, but the flapping algorithm will never classify the service as such.
Let's then consider soft states to compute the flapping percentage, as it's already done for hosts, let's then get consistent !
https://github.com/centreon/centreon-engine/blob/43b0a23047cbcbe5838bab36b530d6808db65971/src/host.cc#L1728

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

Enable services flapping detection, and make a service to flap every time from OK to non-OK to OK state.
Service must be flagged as flapping after some state changes.

Many thanks 👍