### PR TITLE
fix(flapping) start flapping on !OK state

### DIFF
--- a/src/host.cc
+++ b/src/host.cc
@@ -1998,7 +1998,9 @@ void host::check_for_flapping(bool update,
     is_flapping = false;
   /* else we're above the upper bound, so we are flapping */
   else if (curved_percent_change >= high_threshold)
-    is_flapping = true;
+    /* start flapping on !OK states which makes more sense */
+    if ((get_current_state() != host::state_up) || get_is_flapping())
+      is_flapping = true;
 
   logger(dbg_flapping, more)
       << "Host " << (is_flapping ? "is" : "is not") << " flapping ("

--- a/src/service.cc
+++ b/src/service.cc
@@ -2009,7 +2009,9 @@ void service::check_for_flapping(bool update,
     is_flapping = false;
   /* else we're above the upper bound, so we are flapping */
   else if (curved_percent_change >= high_threshold)
-    is_flapping = true;
+    /* start flapping on !OK states which makes more sense */
+    if ((_current_state != service::state_ok) || get_is_flapping())
+      is_flapping = true;
 
   logger(dbg_flapping, more)
       << com::centreon::logging::setprecision(2) << "Service "


### PR DESCRIPTION
Hi,

## Description

it's possible for flapping algorithm to flag hosts and services as starting to flap when they switch from a non-OK to OK state.
Which, from a user point of view, is rather strange, as a FLAPPINGSTART notification will be sent, with a OK state.
Would make more sense to receive a FLAPPINGSTART notification with a non-OK state.
Let's then make a host or service starting to flap only when it switches to a non-OK state.
This gives it a very last chance not to be flagged as flapping, avoiding as such unneeded notifications.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

Enable flapping detection, make a host or service to flap, and be sure it is flagged as flapping only when it switches to a non-OK state.

Many thanks 👍