### PR TITLE
fix(flapping) don't flap if host/parents not up

### DIFF
--- a/src/host.cc
+++ b/src/host.cc
@@ -1902,14 +1902,17 @@ void host::check_for_flapping(bool update,
 
   update_history = update;
 
+  /* don't update history if parents are not up */
+  if (update_history) {
+    if (get_current_state() == host::state_unreachable)
+      update_history = false;
+  }
+
   /* should we update state history for this state? */
   if (update_history) {
     if (get_current_state() == host::state_up && !get_flap_detection_on(up))
       update_history = false;
     if (get_current_state() == host::state_down && !get_flap_detection_on(down))
-      update_history = false;
-    if (get_current_state() == host::state_unreachable &&
-        !get_flap_detection_on(host::unreachable))
       update_history = false;
   }
 

--- a/src/service.cc
+++ b/src/service.cc
@@ -1927,6 +1927,13 @@ void service::check_for_flapping(bool update,
 
   update_history = update;
 
+  /* don't update history if host is not up */
+  if (update_history) {
+    host* hst{get_host_ptr()};
+    if (hst->get_current_state() != host::state_up)
+      update_history = false;
+  }
+
   /* should we update state history for this state? */
   if (update_history) {
     if (_current_state == service::state_ok && !get_flap_detection_on(ok))


### PR DESCRIPTION
Hi,

## Description

As described in #192, flapping should not be computed when related host (for a service) or parents (for a host) are not up.
It makes more sense, and flapping is only reliable to compute when the related host / parents are up.
This also leads to less unneeded / unwanted notifications.
Fixes #192.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

Enable flapping detection, make a host or service to flap while its related host or parent is down, and be sure it is not flagged as flapping.

Many thanks 👍