### PR TITLE
fix(ci): sonar qg timeout management

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,14 +92,10 @@ try {
   // sonarQube step to get qualityGate result
   stage('Quality gate') {
     node {
-        timeout(time: 10, unit: 'MINUTES') {
-              sleep 120
-              def qualityGate = waitForQualityGate()
-              if (qualityGate.status != 'OK') {
-                currentBuild.result = 'FAIL'
-              }
-          }
-        }
+      sleep 120
+      def qualityGate = waitForQualityGate()
+      if (qualityGate.status != 'OK') {
+        currentBuild.result = 'FAIL'
       }
       if ((currentBuild.result ?: 'SUCCESS') != 'SUCCESS') {
         error('Quality gate failure: ${qualityGate.status}.');

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,25 +92,8 @@ try {
   // sonarQube step to get qualityGate result
   stage('Quality gate') {
     node {
-      def reportFilePath = "target/sonar/report-task.txt"
-      def reportTaskFileExists = fileExists "${reportFilePath}"
-      if (reportTaskFileExists) {
-        echo "Found report task file"
-        def taskProps = readProperties file: "${reportFilePath}"
-        echo "taskId[${taskProps['ceTaskId']}]"
         timeout(time: 10, unit: 'MINUTES') {
-          while (true) {
-            sleep 5
-            def taskStatusResult    =
-              sh(returnStdout: true, script: "curl -s -X GET -u ${authString} \'${sonarProps['sonar.host.url']}/api/ce/task?id=${taskProps['ceTaskId']}\'")
-              echo "taskStatusResult[${taskStatusResult}]"
-              def taskStatus  = new JsonSlurper().parseText(taskStatusResult).task.status
-              echo "taskStatus[${taskStatus}]"
-              // Status can be SUCCESS, ERROR, PENDING, or IN_PROGRESS. The last two indicate it's
-              // not done yet.
-              if (taskStatus != "IN_PROGRESS" && taskStatus != "PENDING") {
-                  break;
-              }
+              sleep 120
               def qualityGate = waitForQualityGate()
               if (qualityGate.status != 'OK') {
                 currentBuild.result = 'FAIL'


### PR DESCRIPTION
## Description

sleep 2 minutes in order to wait for the quality gate status

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

