### PR TITLE
Mon 10682 minimal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Bugs
 
+*external commands*
+
+the new C++ standard is not compatible with pthread\_cancel(). This last one is
+removed.
+
 *gRPC*
 
 Reflection module has been removed because of an issue in the compilation.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -608,7 +608,7 @@ set(
 # Subdirectories with core features.
 add_subdirectory(src/broker)
 add_subdirectory(src/checks)
-add_subdirectory(conf)
+#add_subdirectory(conf)
 add_subdirectory(src/downtimes)
 add_subdirectory(src/configuration)
 add_subdirectory(src/commands)
@@ -631,6 +631,7 @@ target_link_libraries(cce_core ${nlohmann_json_LIBS}
   ${PTHREAD_LIBRARIES}
   ${SOCKET_LIBRARIES}
   ${CLIB_LIBRARIES}
+  ${fmt_LIBRARIES}
 )
 
 # centengine target.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -608,7 +608,7 @@ set(
 # Subdirectories with core features.
 add_subdirectory(src/broker)
 add_subdirectory(src/checks)
-#add_subdirectory(conf)
+add_subdirectory(conf)
 add_subdirectory(src/downtimes)
 add_subdirectory(src/configuration)
 add_subdirectory(src/commands)

--- a/deps.sh
+++ b/deps.sh
@@ -2,5 +2,5 @@
 
 go run deps.go "$*" > /tmp/deps.dot
 dot -Tpng /tmp/deps.dot -o deps.png
-eog deps.png&
+lximage-qt deps.png&
 

--- a/enginerpc/enginerpc.cc
+++ b/enginerpc/enginerpc.cc
@@ -17,7 +17,7 @@
  *
  */
 
-#include <sstream>
+#include <fmt/format.h>
 #include "com/centreon/engine/logging/logger.hh"
 #include <grpcpp/server_builder.h>
 #include "enginerpc.hh"
@@ -25,13 +25,10 @@
 using namespace com::centreon::engine;
 
 enginerpc::enginerpc(const std::string& address, uint16_t port) {
-  engine_impl* service = new engine_impl;
-  std::ostringstream oss;
-  oss << address << ":" << port;
-  std::string server_address{oss.str()};
+  std::string server_address{fmt::format("{}:{}", address, port)};
   grpc::ServerBuilder builder;
   builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
-  builder.RegisterService(service);
+  builder.RegisterService(&_service);
   _server = builder.BuildAndStart();
 }
 

--- a/enginerpc/enginerpc.hh
+++ b/enginerpc/enginerpc.hh
@@ -9,6 +9,7 @@
 
 CCE_BEGIN()
 class enginerpc final {
+  engine_impl _service;
   std::unique_ptr<grpc::Server> _server;
  public:
   enginerpc(const std::string& address, uint16_t port);

--- a/inc/com/centreon/engine/globals.hh
+++ b/inc/com/centreon/engine/globals.hh
@@ -82,7 +82,6 @@ extern time_t program_start;
 extern time_t event_start;
 
 extern circular_buffer external_command_buffer;
-extern pthread_t worker_threads[];
 
 extern check_stats check_statistics[];
 

--- a/modules/external_commands/inc/com/centreon/engine/modules/external_commands/utils.hh
+++ b/modules/external_commands/inc/com/centreon/engine/modules/external_commands/utils.hh
@@ -33,7 +33,7 @@ int close_command_file();  // closes and deletes the external command file
 int init_command_file_worker_thread(void);
 int shutdown_command_file_worker_thread(void);
 void cleanup_command_file_worker_thread(void* arg);
-void* command_file_worker_thread(void* arg);
+void command_file_worker_thread();
 int submit_external_command(char const* cmd, int* buffer_items);
 
 #ifdef __cplusplus

--- a/src/globals.cc
+++ b/src/globals.cc
@@ -68,7 +68,6 @@ int test_scheduling(false);
 int verify_circular_paths(true);
 int verify_config(false);
 nebcallback* neb_callback_list[NEBCALLBACK_NUMITEMS];
-pthread_t worker_threads[TOTAL_WORKER_THREADS];
 sched_info scheduling_info;
 time_t event_start((time_t)-1);
 time_t last_command_check((time_t)-1);


### PR DESCRIPTION
## Description

No more pthread in engine. Just std::threads... The goal is to remove pthread_cancel() calls, not compatible with c++14.

REFS: MON-10682

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

