### PR TITLE
Mon 10682 engine segfault 21.10

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -2,5 +2,10 @@
 
 go run deps.go "$*" > /tmp/deps.dot
 dot -Tpng /tmp/deps.dot -o deps.png
-eog deps.png&
-
+if [ -x /usr/bin/eog ] ; then
+  eog deps.png&
+elif [ -x /usr/bin/lximage-qt ] ; then
+  lximage-qt deps.png&
+elif [ -x /usr/bin/lximage ] ; then
+  lximage deps.png&
+fi

--- a/enginerpc/enginerpc.cc
+++ b/enginerpc/enginerpc.cc
@@ -17,7 +17,7 @@
  *
  */
 
-#include <sstream>
+#include <fmt/format.h>
 #include "com/centreon/engine/logging/logger.hh"
 #include <grpcpp/server_builder.h>
 #include "com/centreon/engine/enginerpc.hh"
@@ -25,13 +25,10 @@
 using namespace com::centreon::engine;
 
 enginerpc::enginerpc(const std::string& address, uint16_t port) {
-  engine_impl* service = new engine_impl;
-  std::ostringstream oss;
-  oss << address << ":" << port;
-  std::string server_address{oss.str()};
+  std::string server_address{fmt::format("{}:{}", address, port)};
   grpc::ServerBuilder builder;
   builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
-  builder.RegisterService(service);
+  builder.RegisterService(&_service);
   _server = builder.BuildAndStart();
 }
 

--- a/inc/com/centreon/engine/common.hh
+++ b/inc/com/centreon/engine/common.hh
@@ -325,7 +325,4 @@ enum ret_val {
 #define HOST_STATECHANGE 0
 #define SERVICE_STATECHANGE 1
 
-/* Thread stuff. */
-#define TOTAL_WORKER_THREADS 1
-
 #endif /* !CCE_COMMON_HH */

--- a/inc/com/centreon/engine/enginerpc.hh
+++ b/inc/com/centreon/engine/enginerpc.hh
@@ -1,15 +1,17 @@
 #ifndef CCE_ENGINERPC_ENGINERPC_HH
 #define CCE_ENGINERPC_ENGINERPC_HH
 
-#include <string>
-#include <memory>
 #include <grpcpp/server.h>
+#include <memory>
+#include <string>
 #include "com/centreon/engine/namespace.hh"
 #include "engine_impl.hh"
 
 CCE_BEGIN()
 class enginerpc final {
+  engine_impl _service;
   std::unique_ptr<grpc::Server> _server;
+
  public:
   enginerpc(const std::string& address, uint16_t port);
   enginerpc() = delete;

--- a/inc/com/centreon/engine/globals.hh
+++ b/inc/com/centreon/engine/globals.hh
@@ -86,7 +86,6 @@ extern time_t program_start;
 extern time_t event_start;
 
 extern circular_buffer external_command_buffer;
-extern pthread_t worker_threads[];
 
 extern check_stats check_statistics[];
 

--- a/modules/external_commands/inc/com/centreon/engine/modules/external_commands/utils.hh
+++ b/modules/external_commands/inc/com/centreon/engine/modules/external_commands/utils.hh
@@ -32,8 +32,6 @@ int close_command_file();  // closes and deletes the external command file
                            // (FIFO)
 int init_command_file_worker_thread(void);
 int shutdown_command_file_worker_thread(void);
-void cleanup_command_file_worker_thread(void* arg);
-void* command_file_worker_thread(void* arg);
 int submit_external_command(char const* cmd, int* buffer_items);
 
 #ifdef __cplusplus

--- a/modules/external_commands/src/utils.cc
+++ b/modules/external_commands/src/utils.cc
@@ -1,5 +1,6 @@
 /*
 ** Copyright 2011-2013 Merethis
+** Copyright 2020-2021 Centreon
 **
 ** This file is part of Centreon Engine.
 **
@@ -20,15 +21,14 @@
 #include "com/centreon/engine/modules/external_commands/utils.hh"
 #include <fcntl.h>
 #include <poll.h>
-#include <pthread.h>
 #include <sys/stat.h>
-#include <sys/types.h>
 #include <unistd.h>
+#include <atomic>
 #include <cerrno>
 #include <csignal>
 #include <cstdio>
-#include <cstring>
-#include <sstream>
+#include <memory>
+#include <thread>
 #include "com/centreon/engine/common.hh"
 #include "com/centreon/engine/globals.hh"
 #include "com/centreon/engine/logging/logger.hh"
@@ -42,6 +42,9 @@ using namespace com::centreon::engine::logging;
 static int command_file_fd = -1;
 static int command_file_created = false;
 static FILE* command_file_fp = NULL;
+
+static std::unique_ptr<std::thread> worker;
+static std::atomic_bool should_exit{false};
 
 /* creates external command file as a named pipe (FIFO) and opens it for reading
  * (non-blocked mode) */
@@ -64,7 +67,7 @@ int open_command_file(void) {
         (st.st_mode & S_IFIFO))) {
     /* create the external command file as a named pipe (FIFO) */
     if (mkfifo(config->command_file().c_str(),
-                         S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP) != 0) {
+               S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP) != 0) {
       logger(log_runtime_error, basic)
           << "Error: Could not create external command file '"
           << config->command_file() << "' as named pipe: (" << errno << ") -> "
@@ -158,81 +161,10 @@ int close_command_file(void) {
   return OK;
 }
 
-/* initializes command file worker thread */
-int init_command_file_worker_thread(void) {
-  int result = 0;
-  sigset_t newmask;
-
-  /* initialize circular buffer */
-  external_command_buffer.head = 0;
-  external_command_buffer.tail = 0;
-  external_command_buffer.items = 0;
-  external_command_buffer.high = 0;
-  external_command_buffer.overflow = 0L;
-  external_command_buffer.buffer =
-      new void*[config->external_command_buffer_slots()];
-  if (external_command_buffer.buffer == NULL)
-    return ERROR;
-
-  /* initialize mutex (only on cold startup) */
-  if (sigrestart == false)
-    pthread_mutex_init(&external_command_buffer.buffer_lock, NULL);
-
-  /* new thread should block all signals */
-  sigfillset(&newmask);
-  pthread_sigmask(SIG_BLOCK, &newmask, NULL);
-
-  /* create worker thread */
-  result = pthread_create(&worker_threads[COMMAND_WORKER_THREAD], NULL,
-                          command_file_worker_thread, NULL);
-
-  /* main thread should unblock all signals */
-  pthread_sigmask(SIG_UNBLOCK, &newmask, NULL);
-
-  if (result)
-    return ERROR;
-
-  return OK;
-}
-
-/* shutdown command file worker thread */
-int shutdown_command_file_worker_thread(void) {
-  int result = 0;
-
-  /*
-   * calling pthread_cancel(0) will cause segfaults with some
-   * thread libraries. It's possible that will happen if the
-   * user has a number of config files larger than the max
-   * open file descriptor limit (ulimit -n) and some retarded
-   * eventbroker module leaks filedescriptors, since we'll then
-   * enter the cleanup() routine from main() before we've
-   * spawned any threads.
-   */
-  if (worker_threads[COMMAND_WORKER_THREAD]) {
-    /* tell the worker thread to exit */
-    result = pthread_cancel(worker_threads[COMMAND_WORKER_THREAD]);
-
-    /* wait for the worker thread to exit */
-    if (result == 0)
-      pthread_join(worker_threads[COMMAND_WORKER_THREAD], NULL);
-    /* we're being called from a fork()'ed child process - can't cancel thread,
-     * so just cleanup memory */
-    else {
-      cleanup_command_file_worker_thread(NULL);
-    }
-  }
-
-  return OK;
-}
-
 /* clean up resources used by command file worker thread */
-void cleanup_command_file_worker_thread(void* arg) {
-  int x = 0;
-
-  (void)arg;
-
+static void cleanup_command_file_worker_thread() {
   /* release memory allocated to circular buffer */
-  for (x = external_command_buffer.tail; x != external_command_buffer.head;
+  for (int x = external_command_buffer.tail; x != external_command_buffer.head;
        x = (x + 1) % config->external_command_buffer_slots()) {
     delete[]((char**)external_command_buffer.buffer)[x];
     ((char**)external_command_buffer.buffer)[x] = NULL;
@@ -242,24 +174,14 @@ void cleanup_command_file_worker_thread(void* arg) {
 }
 
 /* worker thread - artificially increases buffer of named pipe */
-void* command_file_worker_thread(void* arg) {
+static void command_file_worker_thread() {
   char input_buffer[MAX_EXTERNAL_COMMAND_LENGTH];
   struct pollfd pfd;
   int pollval;
   struct timeval tv;
   int buffer_items = 0;
 
-  (void)arg;
-
-  /* specify cleanup routine */
-  pthread_cleanup_push(cleanup_command_file_worker_thread, NULL);
-
-  /* set cancellation info */
-  pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
-  pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL);
-
-  while (1) {
-    /* should we shutdown? */
+  while (!should_exit) {
     pthread_testcancel();
 
     /* wait for data to arrive */
@@ -311,9 +233,6 @@ void* command_file_worker_thread(void* arg) {
       continue;
     }
 
-    /* should we shutdown? */
-    pthread_testcancel();
-
     /* get number of items in the buffer */
     pthread_mutex_lock(&external_command_buffer.buffer_lock);
     buffer_items = external_command_buffer.items;
@@ -338,7 +257,8 @@ void* command_file_worker_thread(void* arg) {
       clearerr(command_file_fp);
 
       /* read and process the next command in the file */
-      while (fgets(input_buffer, (int)(sizeof(input_buffer) - 1),
+      while (!should_exit &&
+             fgets(input_buffer, (int)(sizeof(input_buffer) - 1),
                    command_file_fp) != nullptr) {
         // Check if command is thread-safe (for immediate execution).
         if (modules::external_commands::gl_processor.is_thread_safe(
@@ -347,33 +267,61 @@ void* command_file_worker_thread(void* arg) {
         // Submit the external command for processing
         // (retry if buffer is full).
         else {
-          while (submit_external_command(input_buffer, &buffer_items) ==
+          while (!should_exit &&
+                 submit_external_command(input_buffer, &buffer_items) ==
                      ERROR &&
                  buffer_items == config->external_command_buffer_slots()) {
             // Wait a bit.
             tv.tv_sec = 0;
             tv.tv_usec = 250000;
             select(0, nullptr, nullptr, nullptr, &tv);
-
-            // Should we shutdown?
-            pthread_testcancel();
           }
 
           // Bail if the circular buffer is full.
           if (buffer_items == config->external_command_buffer_slots())
             break;
-
-          // Should we shutdown?
-          pthread_testcancel();
         }
       }
     }
   }
 
-  /* removes cleanup handler - this should never be reached */
-  pthread_cleanup_pop(0);
+  cleanup_command_file_worker_thread();
+}
 
-  return nullptr;
+/* initializes command file worker thread */
+int init_command_file_worker_thread(void) {
+  /* initialize circular buffer */
+  external_command_buffer.head = 0;
+  external_command_buffer.tail = 0;
+  external_command_buffer.items = 0;
+  external_command_buffer.high = 0;
+  external_command_buffer.overflow = 0L;
+  external_command_buffer.buffer =
+      new void*[config->external_command_buffer_slots()];
+  if (external_command_buffer.buffer == NULL)
+    return ERROR;
+
+  /* initialize mutex (only on cold startup) */
+  if (!sigrestart)
+    pthread_mutex_init(&external_command_buffer.buffer_lock, NULL);
+
+  /* create worker thread */
+  worker = std::make_unique<std::thread>(&command_file_worker_thread);
+
+  return OK;
+}
+
+/* shutdown command file worker thread */
+int shutdown_command_file_worker_thread(void) {
+  if (!should_exit) {
+    /* tell the worker thread to exit */
+    should_exit = true;
+
+    /* wait for the worker thread to exit */
+    worker->join();
+  }
+
+  return OK;
 }
 
 /* submits an external command for processing */

--- a/src/globals.cc
+++ b/src/globals.cc
@@ -22,8 +22,6 @@
 
 #include "com/centreon/engine/globals.hh"
 
-#include <map>
-
 #include "com/centreon/engine/logging/logger.hh"
 #include "nagios.h"
 
@@ -70,7 +68,6 @@ int test_scheduling(false);
 int verify_circular_paths(true);
 int verify_config(false);
 nebcallback* neb_callback_list[NEBCALLBACK_NUMITEMS];
-pthread_t worker_threads[TOTAL_WORKER_THREADS];
 sched_info scheduling_info;
 time_t event_start((time_t)-1);
 time_t last_command_check((time_t)-1);

--- a/tests/enginerpc/enginerpc.cc
+++ b/tests/enginerpc/enginerpc.cc
@@ -1671,7 +1671,7 @@ TEST_F(EngineRpc, ChangeHostObjectCustomVar) {
   std::mutex mutex;
   bool continuerunning = false;
 
-  ASSERT_EQ(_host->custom_variables.size(), 0);
+  ASSERT_EQ(_host->custom_variables.size(), 0u);
   call_command_manager(th, &condvar, &mutex, &continuerunning);
   auto output = execute(
       "ChangeHostObjectCustomVar"
@@ -1686,7 +1686,7 @@ TEST_F(EngineRpc, ChangeHostObjectCustomVar) {
   ASSERT_EQ(_host->custom_variables.size(), 1u);
   ASSERT_EQ(_host->custom_variables["TEST_VAR"].get_value(), "test_val");
   _host->custom_variables.clear();
-  ASSERT_EQ(_host->custom_variables.size(), 0);
+  ASSERT_EQ(_host->custom_variables.size(), 0u);
   erpc.shutdown();
 }
 
@@ -1698,7 +1698,7 @@ TEST_F(EngineRpc, ChangeServiceObjectCustomVar) {
   bool continuerunning = false;
 
   _svc->custom_variables.clear();
-  ASSERT_EQ(_svc->custom_variables.size(), 0);
+  ASSERT_EQ(_svc->custom_variables.size(), 0u);
   call_command_manager(th, &condvar, &mutex, &continuerunning);
   auto output = execute(
       "ChangeServiceObjectCustomVar"
@@ -1713,7 +1713,7 @@ TEST_F(EngineRpc, ChangeServiceObjectCustomVar) {
   ASSERT_EQ(_svc->custom_variables.size(), 1u);
   ASSERT_EQ(_svc->custom_variables["TEST_VAR"].get_value(), "test_val");
   _svc->custom_variables.clear();
-  ASSERT_EQ(_svc->custom_variables.size(), 0);
+  ASSERT_EQ(_svc->custom_variables.size(), 0u);
   erpc.shutdown();
 }
 
@@ -1723,7 +1723,7 @@ TEST_F(EngineRpc, ChangeContactObjectCustomVar) {
   std::condition_variable condvar;
   std::mutex mutex;
   bool continuerunning = false;
-  ASSERT_EQ(_contact->get_custom_variables().size(), 0);
+  ASSERT_EQ(_contact->get_custom_variables().size(), 0u);
 
   call_command_manager(th, &condvar, &mutex, &continuerunning);
   auto output = execute(

--- a/tests/enginerpc/enginerpc.cc
+++ b/tests/enginerpc/enginerpc.cc
@@ -48,14 +48,11 @@
 #include "com/centreon/engine/version.hh"
 #include "helper.hh"
 
-
-
 using namespace com::centreon;
 using namespace com::centreon::engine;
 using namespace com::centreon::engine::downtimes;
 using namespace com::centreon::engine::configuration;
 using namespace com::centreon::engine::configuration::applier;
-
 
 class EngineRpc : public TestEngine {
  public:
@@ -234,7 +231,7 @@ TEST_F(EngineRpc, GetVersion) {
   enginerpc erpc("0.0.0.0", 40001);
   auto output = execute("GetVersion");
   ASSERT_EQ(output.front(), oss.str());
-  if (output.size() == 2) {
+  if (output.size() == 2u) {
     oss.str("");
     oss << "minor: " << CENTREON_ENGINE_VERSION_MINOR;
     ASSERT_EQ(output.back(), oss.str());
@@ -318,8 +315,6 @@ TEST_F(EngineRpc, GetWrongHost) {
   erpc.shutdown();
 }
 
-
-
 TEST_F(EngineRpc, GetService) {
   enginerpc erpc("0.0.0.0", 40001);
   std::unique_ptr<std::thread> th;
@@ -391,7 +386,6 @@ TEST_F(EngineRpc, GetWrongService) {
   ASSERT_EQ(vectests, result_names);
   erpc.shutdown();
 }
-
 
 TEST_F(EngineRpc, GetContact) {
   enginerpc erpc("0.0.0.0", 40001);
@@ -704,9 +698,10 @@ TEST_F(EngineRpc, DeleteWrongComment) {
   std::condition_variable condvar;
   std::mutex mutex;
   bool continuerunning = false;
-  std::vector<std::string> vectests = {"DeleteComment failed.", 
-                                       "DeleteComment 0",
-                                      };
+  std::vector<std::string> vectests{
+      "DeleteComment failed.",
+      "DeleteComment 0",
+  };
   call_command_manager(th, &condvar, &mutex, &continuerunning);
 
   auto output = execute("DeleteComment 999");
@@ -724,7 +719,6 @@ TEST_F(EngineRpc, DeleteWrongComment) {
   ASSERT_EQ(comment::comments.size(), 0u);
   erpc.shutdown();
 }
-
 
 TEST_F(EngineRpc, DeleteAllHostComments) {
   enginerpc erpc("0.0.0.0", 40001);
@@ -1482,9 +1476,9 @@ TEST_F(EngineRpc, ChangeHostObjectIntVar) {
   call_command_manager(th, &condvar, &mutex, &continuerunning);
 
   auto output = execute("ChangeHostObjectIntVar test_host 0 1 1.0");
-  ASSERT_EQ(_host->get_check_interval(), 1);
+  ASSERT_EQ(_host->get_check_interval(), 1u);
   output = execute("ChangeHostObjectIntVar test_host 1 1 2.0");
-  ASSERT_EQ(_host->get_retry_interval(), 2);
+  ASSERT_EQ(_host->get_retry_interval(), 2u);
   output = execute("ChangeHostObjectIntVar test_host 2 1 1.0");
   ASSERT_EQ(_host->get_max_attempts(), 1);
   {
@@ -1508,11 +1502,11 @@ TEST_F(EngineRpc, ChangeServiceObjectIntVar) {
   auto output = execute(
       "ChangeServiceObjectIntVar"
       " test_host test_svc 0 1 1.0");
-  ASSERT_EQ(_svc->get_check_interval(), 1);
+  ASSERT_EQ(_svc->get_check_interval(), 1u);
   output = execute(
       "ChangeServiceObjectIntVar"
       " test_host test_svc 1 1 2.0");
-  ASSERT_EQ(_svc->get_retry_interval(), 2);
+  ASSERT_EQ(_svc->get_retry_interval(), 2u);
   output = execute(
       "ChangeServiceObjectIntVar"
       " test_host test_svc 2 1 1.0");
@@ -1539,15 +1533,15 @@ TEST_F(EngineRpc, ChangeContactObjectIntVar) {
   auto output = execute(
       "ChangeContactObjectIntVar"
       " admin 0 1 1.0");
-  ASSERT_EQ(_contact->get_modified_attributes(), 1);
+  ASSERT_EQ(_contact->get_modified_attributes(), 1u);
   output = execute(
       "ChangeContactObjectIntVar"
       " admin 1 2 1.0");
-  ASSERT_EQ(_contact->get_modified_host_attributes(), 2);
+  ASSERT_EQ(_contact->get_modified_host_attributes(), 2u);
   output = execute(
       "ChangeContactObjectIntVar"
       " admin 2 3 1.0");
-  ASSERT_EQ(_contact->get_modified_service_attributes(), 3);
+  ASSERT_EQ(_contact->get_modified_service_attributes(), 3u);
   {
     std::lock_guard<std::mutex> lock(mutex);
     continuerunning = true;
@@ -1752,7 +1746,7 @@ TEST_F(EngineRpc, ChangeContactObjectCustomVar) {
 TEST_F(EngineRpc, ProcessServiceCheckResult) {
   enginerpc erpc("0.0.0.0", 40001);
   auto output = execute("ProcessServiceCheckResult test_host test_svc 0");
-  ASSERT_EQ(output.size(), 1);
+  ASSERT_EQ(output.size(), 1u);
   ASSERT_EQ(output.front(), "ProcessServiceCheckResult: 0");
   erpc.shutdown();
 }
@@ -1760,7 +1754,7 @@ TEST_F(EngineRpc, ProcessServiceCheckResult) {
 TEST_F(EngineRpc, ProcessServiceCheckResultBadHost) {
   enginerpc erpc("0.0.0.0", 40001);
   auto output = execute("ProcessServiceCheckResult \"\" test_svc 0");
-  ASSERT_EQ(output.size(), 2);
+  ASSERT_EQ(output.size(), 2u);
   ASSERT_EQ(output.front(), "ProcessServiceCheckResult failed.");
   erpc.shutdown();
 }
@@ -1768,7 +1762,7 @@ TEST_F(EngineRpc, ProcessServiceCheckResultBadHost) {
 TEST_F(EngineRpc, ProcessServiceCheckResultBadService) {
   enginerpc erpc("0.0.0.0", 40001);
   auto output = execute("ProcessServiceCheckResult test_host \"\" 0");
-  ASSERT_EQ(output.size(), 2);
+  ASSERT_EQ(output.size(), 2u);
   ASSERT_EQ(output.front(), "ProcessServiceCheckResult failed.");
   erpc.shutdown();
 }
@@ -1776,7 +1770,7 @@ TEST_F(EngineRpc, ProcessServiceCheckResultBadService) {
 TEST_F(EngineRpc, ProcessHostCheckResult) {
   enginerpc erpc("0.0.0.0", 40001);
   auto output = execute("ProcessHostCheckResult test_host 0");
-  ASSERT_EQ(output.size(), 1);
+  ASSERT_EQ(output.size(), 1u);
   ASSERT_EQ(output.front(), "ProcessHostCheckResult: 0");
   erpc.shutdown();
 }
@@ -1784,7 +1778,7 @@ TEST_F(EngineRpc, ProcessHostCheckResult) {
 TEST_F(EngineRpc, ProcessHostCheckResultBadHost) {
   enginerpc erpc("0.0.0.0", 40001);
   auto output = execute("ProcessHostCheckResult '' 0");
-  ASSERT_EQ(output.size(), 2);
+  ASSERT_EQ(output.size(), 2u);
   ASSERT_EQ(output.front(), "ProcessHostCheckResult failed.");
   erpc.shutdown();
 }
@@ -1802,7 +1796,7 @@ TEST_F(EngineRpc, NewThresholdsFile) {
       "21,\n \"fit\": 60.5\n }\n]}]");
   enginerpc erpc("0.0.0.0", 40001);
   auto output = execute("NewThresholdsFile /tmp/thresholds_file.json");
-  ASSERT_EQ(output.size(), 1);
+  ASSERT_EQ(output.size(), 1u);
   ASSERT_EQ(output.front(), "NewThresholdsFile: 0");
   command_manager::instance().execute();
   ASSERT_EQ(_ad->get_thresholds_file(), "/tmp/thresholds_file.json");


### PR DESCRIPTION
## Description

The segfault during centengine stop is fixed.

REFS: MON-10682

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

