### PR TITLE
enh(ci): new packaging workflow

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,13 +1,17 @@
 /*
 ** Variables.
 */
-properties([buildDiscarder(logRotator(numToKeepStr: '50'))])
+properties([buildDiscarder(logRotator(numToKeepStr: '10'))])
 def serie = '21.10'
 def maintenanceBranch = "${serie}.x"
+def qaBranch = "dev-${serie}"
+
 if (env.BRANCH_NAME.startsWith('release-')) {
   env.BUILD = 'RELEASE'
 } else if ((env.BRANCH_NAME == 'master') || (env.BRANCH_NAME == maintenanceBranch)) {
   env.BUILD = 'REFERENCE'
+} else if ((env.BRANCH_NAME == 'develop') || (env.BRANCH_NAME == qaBranch)) {
+  env.BUILD = 'QA'
 } else {
   env.BUILD = 'CI'
 }
@@ -16,7 +20,7 @@ if (env.BRANCH_NAME.startsWith('release-')) {
 ** Pipeline code.
 */
 stage('Source') {
-  node {
+  node("C++") {
     sh 'setup_centreon_build.sh'
     dir('centreon-engine') {
       checkout scm
@@ -37,9 +41,9 @@ stage('Source') {
 }
 
 try {
-  stage('Unit tests') {
-    parallel 'centos7': {
-      node {
+  stage('Build // Unit Tests // RPMs Packaging') {
+    parallel 'build centos7': {
+      node("C++") {
         sh 'setup_centreon_build.sh'
         sh "./centreon-build/jobs/engine/${serie}/mon-engine-unittest.sh centos7"
         step([
@@ -55,8 +59,16 @@ try {
         }
       }
     },
-    'centos8': {
-      node {
+    'packaging centos7': {
+      node("C++") {
+        sh 'setup_centreon_build.sh'
+        sh "./centreon-build/jobs/engine/${serie}/mon-engine-package.sh centos7"
+        stash name: 'el7-rpms', includes: "output/x86_64/*.rpm"
+        archiveArtifacts artifacts: "output/x86_64/*.rpm"
+      }
+    },
+    'build centos8': {
+      node("C++") {
         sh 'setup_centreon_build.sh'
         sh "./centreon-build/jobs/engine/${serie}/mon-engine-unittest.sh centos8"
         step([
@@ -69,8 +81,16 @@ try {
         ])
       }
     },
-    'debian10': {
-      node {
+    'packaging centos8': {
+      node("C++") {
+        sh 'setup_centreon_build.sh'
+        sh "./centreon-build/jobs/engine/${serie}/mon-engine-package.sh centos8"
+        stash name: 'el8-rpms', includes: "output/x86_64/*.rpm"
+        archiveArtifacts artifacts: "output/x86_64/*.rpm"
+      }
+    },
+    'build debian10': {
+      node("C++") {
         sh 'setup_centreon_build.sh'
         sh "./centreon-build/jobs/engine/${serie}/mon-engine-unittest.sh debian10"
         step([
@@ -82,6 +102,12 @@ try {
           tools: [[$class: 'GoogleTestType', pattern: 'ut.xml']]
         ])
       }
+    },
+    'packaging debian10': {
+      node("C++") {
+        sh 'setup_centreon_build.sh'
+        sh "./centreon-build/jobs/engine/${serie}/mon-engine-package.sh debian10"
+      }
     }
     if ((currentBuild.result ?: 'SUCCESS') != 'SUCCESS') {
       error('Unit tests stage failure.');
@@ -90,8 +116,7 @@ try {
 
   // sonarQube step to get qualityGate result
   stage('Quality gate') {
-    node {
-      sleep 20
+    node("C++") {
       def qualityGate = waitForQualityGate()
       if (qualityGate.status != 'OK') {
         currentBuild.result = 'FAIL'
@@ -102,41 +127,9 @@ try {
     }
   }
 
-  stage('Package') {
-    parallel 'centos7': {
-      node {
-        sh 'setup_centreon_build.sh'
-        sh "./centreon-build/jobs/engine/${serie}/mon-engine-package.sh centos7"
-      }
-    },
-    'centos8': {
-      node {
-        sh 'setup_centreon_build.sh'
-        sh "./centreon-build/jobs/engine/${serie}/mon-engine-package.sh centos8"
-      }
-    },
-    'debian10': {
-      node {
-        sh 'setup_centreon_build.sh'
-        sh "./centreon-build/jobs/engine/${serie}/mon-engine-package.sh debian10"
-      }
-/*
-    },
-    'debian10-armhf': {
-      node {
-        sh 'setup_centreon_build.sh'
-        sh "./centreon-build/jobs/engine/${serie}/mon-engine-package.sh debian10-armhf"
-      }
-*/
-    }
-    if ((currentBuild.result ?: 'SUCCESS') != 'SUCCESS') {
-      error('Package stage failure.');
-    }
-  }
-
-  if ((env.BUILD == 'RELEASE') || (env.BUILD == 'REFERENCE')) {
+  if ((env.BUILD == 'RELEASE') || (env.BUILD == 'QA')) {
     stage('Delivery') {
-      node {
+      node("C++") {
         sh 'setup_centreon_build.sh'
         sh "./centreon-build/jobs/engine/${serie}/mon-engine-delivery.sh"
       }
@@ -144,10 +137,9 @@ try {
         error('Delivery stage failure.');
       }
     }
-
-    if (env.BUILD == 'REFERENCE') {
+  }
+  if (env.BUILD == 'REFERENCE') {
       build job: "centreon-web/${env.BRANCH_NAME}", wait: false
-    }
   }
 }
 finally {


### PR DESCRIPTION
## Description

Because of : 

- the new branch workflow
- the new packaging and rpm pushing workflow
- the necessity to give an easy access to rpm for the QA

Here's an enhancement that : 

- specify "QA" branches that are develop and dev-xx.yy.zz to manage the rpm pushing location 
- //lise build tests and packaging for all distributions
- push rpm directly on yum.centreon.com
It means that RPM created from develop and dev-xx.yy.zz branches are pushed directly to the unstable repo of yum.centreon.com and RPM created from release branches are pushed directly to the testing repo. 
No more RPM pushing for reference branches (for now) and PR- / CI branches

It speeds up the pipeline and the feedback loop for devs also.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

Launch a job of each type of branches and check that everything is green on jenkins and that the packages are available on yum.centreon.com.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

