### PR TITLE
fix(ci): delete rpm after stashing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,6 +65,7 @@ try {
         sh "./centreon-build/jobs/engine/${serie}/mon-engine-package.sh centos7"
         stash name: 'el7-rpms', includes: "output/x86_64/*.rpm"
         archiveArtifacts artifacts: "output/x86_64/*.rpm"
+        sh 'rm -rf output'
       }
     },
     'build centos8': {
@@ -87,6 +88,7 @@ try {
         sh "./centreon-build/jobs/engine/${serie}/mon-engine-package.sh centos8"
         stash name: 'el8-rpms', includes: "output/x86_64/*.rpm"
         archiveArtifacts artifacts: "output/x86_64/*.rpm"
+        sh 'rm -rf output'
       }
     },
     'build debian10': {


### PR DESCRIPTION
## Description

Fixes the double rpm delivery in the yum repository

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

Launch develop pipeline and check if there is twice the same rpm in the unstable engine repo


## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

